### PR TITLE
TST use torch.testing.assert_close

### DIFF
--- a/torchdr/tests/test_utils.py
+++ b/torchdr/tests/test_utils.py
@@ -1,6 +1,8 @@
-from torchdr.utils.root_finding import binary_search, false_position
 import torch
 import pytest
+
+from torch.testing import assert_close
+from torchdr.utils.root_finding import binary_search, false_position
 
 lst_types = [torch.double, torch.float]
 
@@ -17,13 +19,13 @@ def test_binary_search(dtype):
 
     m = binary_search(f, 1, begin=begin, end=end,
                       max_iter=1000, tol=1e-9, verbose=False)
-    assert torch.allclose(m, torch.tensor([1.0], dtype=dtype), atol=1e-5)
+    assert_close(m, torch.tensor([1.0], dtype=dtype))
 
     # test 2D
     begin = torch.tensor([-0.5, -0.5], dtype=dtype)
     end = torch.tensor([2.0, 2.0], dtype=dtype)
     m = binary_search(f, 2, begin=begin, end=end, max_iter=1000, tol=1e-9, verbose=True)
-    assert torch.allclose(m, torch.tensor([1.0, 1.0], dtype=dtype), atol=1e-5)
+    assert_close(m, torch.tensor([1.0, 1.0], dtype=dtype))
 
 
 @pytest.mark.parametrize("dtype", lst_types)
@@ -39,7 +41,7 @@ def test_false_position(dtype):
     m = false_position(
         f, 1, begin=begin, end=end, max_iter=1000, tol=1e-9, verbose=False
     )
-    assert torch.allclose(m, torch.tensor([1.0], dtype=dtype), atol=1e-5)
+    assert_close(m, torch.tensor([1.0], dtype=dtype))
 
     # test 2D
     begin = torch.tensor([-0.5, -0.5], dtype=dtype)
@@ -47,4 +49,4 @@ def test_false_position(dtype):
     m = false_position(
         f, 2, begin=begin, end=end, max_iter=1000, tol=1e-9, verbose=True
     )
-    assert torch.allclose(m, torch.tensor([1.0, 1.0], dtype=dtype), atol=1e-5)
+    assert_close(m, torch.tensor([1.0, 1.0], dtype=dtype))


### PR DESCRIPTION
It gives way more actionable feedback when failing, see:
```python
In [7]: a, b = torch.Tensor([1, 2]), torch.Tensor([1, 2.1])

In [8]: assert torch.allclose(a, b)
---------------------------------------------------------------------------
AssertionError                            Traceback (most recent call last)
Cell In [8], line 1
----> 1 assert torch.allclose(a, b)

AssertionError: 

In [9]: torch.testing.assert_close(a, b)
---------------------------------------------------------------------------
AssertionError                            Traceback (most recent call last)
Cell In [9], line 1
----> 1 torch.testing.assert_close(a, b)

File ~/mambaforge/lib/python3.10/site-packages/torch/testing/_comparison.py:1520, in assert_close(actual, expected, allow_subclasses, rtol, atol, equal_nan, check_device, check_dtype, check_layout, check_stride, msg)
   1498 error_metas = not_close_error_metas(
   1499     actual,
   1500     expected,
   (...)
   1515     msg=msg,
   1516 )
   1518 if error_metas:
   1519     # TODO: compose all metas into one AssertionError
-> 1520     raise error_metas[0].to_error(msg)

AssertionError: Tensor-likes are not close!

Mismatched elements: 1 / 2 (50.0%)
Greatest absolute difference: 0.09999990463256836 at index (1,) (up to 1e-05 allowed)
Greatest relative difference: 0.04761900380253792 at index (1,) (up to 1.3e-06 allowed)
```