### PR TITLE
[BugFix] balance repulsive term in NE methods with BCE loss 

### DIFF
--- a/torchdr/tests/test_neighbor_embedding.py
+++ b/torchdr/tests/test_neighbor_embedding.py
@@ -41,7 +41,7 @@ def toy_dataset(n=300, dtype="float32"):
         (SNEkhorn, SEA_params | {"unrolling": False}),
         (TSNEkhorn, SEA_params | {"unrolling": True}),
         (TSNEkhorn, SEA_params | {"unrolling": False}),
-        (LargeVis, {"coeff_repulsion": 1e-3}),
+        (LargeVis, {}),
         (InfoTSNE, {}),
     ],
 )


### PR DESCRIPTION
When using BCE loss (like in LargeVis or UMAP), the repulsive term of the loss needs to be rescaled.