### PR TITLE
[Feature] Make pykeops optional dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
             name: Get Python running
             command: |
               python -m pip install --user --upgrade --progress-bar off pip
-              python -m pip install --user -e .
+              python -m pip install --user -e .[all]
               python -m pip install --user .[doc]
           # python -m pip install --user --upgrade --progress-bar off ipython "https://api.github.com/repos/sphinx-gallery/sphinx-gallery/zipball/master" memory_profiler
         - save_cache:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -88,3 +88,9 @@ jobs:
     # Run Tests
     - name: Run Tests without torch
       run: pytest torchdr/ --verbose --cov=torchdr torchdr/ --cov-report term
+    # Codecov
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v4.0.1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        slug: TorchDR/TorchDR

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -54,3 +54,37 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         slug: TorchDR/TorchDR
+
+  Test-minimal:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+
+    # Install torchdr
+    - name: Checking Out Repository
+      uses: actions/checkout@v2
+    # Cache 'torchdr' datasets
+    - name: Create/Restore torchdr Data Cache
+      id: cache-torchdr_datasets
+      uses: actions/cache@v2
+      with:
+        path: ~/torchdr_datasets
+        key: ${{ runner.os }}-v3
+    # Install Python & Packages
+    - uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+    - run: which python
+    - name: Install dependencies
+      run: |
+        python -m pip install --user --upgrade --progress-bar off pip
+    - name: Install 'torchdr' package
+      run: |
+        python -m pip install --user -e .[test]
+    # Run Tests
+    - name: Run Tests without torch
+      run: pytest torchdr/ --verbose --cov=torchdr torchdr/ --cov-report term

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -42,11 +42,9 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --user --upgrade --progress-bar off pip
-        python -m pip install --user -r requirements.txt
-        python -m pip install --user --upgrade pytest pytest-cov codecov 
     - name: Install 'torchdr' package
       run: |
-        python -m pip install --user -e .
+        python -m pip install --user -e .[all]
     # Run Tests
     - name: Run Tests without torch
       run: pytest torchdr/ --verbose --cov=torchdr torchdr/ --cov-report term

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -44,7 +44,7 @@ jobs:
         python -m pip install --user --upgrade --progress-bar off pip
     - name: Install 'torchdr' package
       run: |
-        python -m pip install --user -e .[all]
+        python -m pip install --user -e .[all,test]
     # Run Tests
     - name: Run Tests without torch
       run: pytest torchdr/ --verbose --cov=torchdr torchdr/ --cov-report term

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,8 @@ test = [
     "flake8",
     "coverage",
     "numpydoc",
+    "pytest-cov",
+    "codecov"
 ]
 
 keops = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,13 +9,14 @@ license = {text = "BSD (3-Clause)"}
 readme = {file = "README.md", content-type = "text/markdown"}
 dependencies = [
     "numpy>=1.20",
-    "matplotlib",
     "scikit-learn",
     "torch",
-    "pykeops",
     "tqdm",
 ]
 dynamic = ["version"]
+
+[tool.setuptools]
+packages = ["torchdr"]
 
 
 [tool.setuptools.dynamic]
@@ -29,10 +30,19 @@ test = [
     "numpydoc",
 ]
 
+keops = [
+    "pykeops",
+]
+
+all =  [
+    "pykeops",
+]
+
 doc = [
     "sphinx",
     "sphinx_gallery",
     "sphinx_rtd_theme",
+    "matplotlib",
     "numpydoc",
     "memory_profiler",
     "myst-parser",

--- a/torchdr/affinity/base.py
+++ b/torchdr/affinity/base.py
@@ -10,7 +10,7 @@ Base classes for affinity matrices
 from abc import ABC, abstractmethod
 
 import torch
-try : # try to import LazyTensor from KeOps for type hinting
+try :  # try to import LazyTensor from KeOps for type hinting
     from keops.torch import LazyTensor
 except ImportError:
     LazyTensor = type(None)

--- a/torchdr/affinity/base.py
+++ b/torchdr/affinity/base.py
@@ -10,10 +10,7 @@ Base classes for affinity matrices
 from abc import ABC, abstractmethod
 
 import torch
-try :  # try to import LazyTensor from KeOps for type hinting
-    from keops.torch import LazyTensor
-except ImportError:
-    LazyTensor = type(None)
+from ..utils import LazyTensor, pykeops
 
 import numpy as np
 from torchdr.utils import (
@@ -52,6 +49,13 @@ class Affinity(ABC):
         keops: bool = False,
         verbose: bool = True,
     ):
+
+        if keops and not pykeops:
+            raise ValueError(
+                "[TorchDR] ERROR : pykeops is not installed. Please install it to use "
+                "`keops=true`."
+            )
+
         self.log = {}
         self.metric = metric
         self.zero_diag = zero_diag

--- a/torchdr/affinity/base.py
+++ b/torchdr/affinity/base.py
@@ -10,7 +10,11 @@ Base classes for affinity matrices
 from abc import ABC, abstractmethod
 
 import torch
-import pykeops
+try : # try to import LazyTensor from KeOps for type hinting
+    from keops.torch import LazyTensor
+except ImportError:
+    LazyTensor = type(None)
+
 import numpy as np
 from torchdr.utils import (
     symmetric_pairwise_distances,
@@ -227,7 +231,7 @@ class TransformableAffinity(Affinity):
         )
 
     @abstractmethod
-    def _affinity_formula(self, C: torch.Tensor | pykeops.torch.LazyTensor):
+    def _affinity_formula(self, C: torch.Tensor | LazyTensor):
         r"""
         Computes the affinity matrix from the pairwise distance matrix.
         This method must be overridden by subclasses.
@@ -412,7 +416,7 @@ class TransformableLogAffinity(LogAffinity):
         )
 
     @abstractmethod
-    def _log_affinity_formula(self, C: torch.Tensor | pykeops.torch.LazyTensor):
+    def _log_affinity_formula(self, C: torch.Tensor | LazyTensor):
         r"""
         Computes the log affinity matrix from the pairwise distances.
         This method must be overridden by subclasses.

--- a/torchdr/affinity/simple.py
+++ b/torchdr/affinity/simple.py
@@ -8,7 +8,7 @@ Common simple affinities
 # License: BSD 3-Clause License
 
 import torch
-try : # try to import LazyTensor from KeOps for type hinting
+try :  # try to import LazyTensor from KeOps for type hinting
     from keops.torch import LazyTensor
 except ImportError:
     LazyTensor = type(None)

--- a/torchdr/affinity/simple.py
+++ b/torchdr/affinity/simple.py
@@ -8,10 +8,7 @@ Common simple affinities
 # License: BSD 3-Clause License
 
 import torch
-try :  # try to import LazyTensor from KeOps for type hinting
-    from keops.torch import LazyTensor
-except ImportError:
-    LazyTensor = type(None)
+from ..utils import LazyTensorType
 import numpy as np
 
 from torchdr.utils import to_torch
@@ -64,7 +61,7 @@ class GaussianAffinity(TransformableLogAffinity):
         )
         self.sigma = sigma
 
-    def _log_affinity_formula(self, C: torch.Tensor | LazyTensor):
+    def _log_affinity_formula(self, C: torch.Tensor | LazyTensorType):
         return -C / self.sigma
 
 
@@ -111,7 +108,7 @@ class StudentAffinity(TransformableLogAffinity):
         )
         self.degrees_of_freedom = degrees_of_freedom
 
-    def _log_affinity_formula(self, C: torch.Tensor | LazyTensor):
+    def _log_affinity_formula(self, C: torch.Tensor | LazyTensorType):
         return (
             -0.5
             * (self.degrees_of_freedom + 1)

--- a/torchdr/affinity/simple.py
+++ b/torchdr/affinity/simple.py
@@ -8,7 +8,10 @@ Common simple affinities
 # License: BSD 3-Clause License
 
 import torch
-import pykeops
+try : # try to import LazyTensor from KeOps for type hinting
+    from keops.torch import LazyTensor
+except ImportError:
+    LazyTensor = type(None)
 import numpy as np
 
 from torchdr.utils import to_torch
@@ -61,7 +64,7 @@ class GaussianAffinity(TransformableLogAffinity):
         )
         self.sigma = sigma
 
-    def _log_affinity_formula(self, C: torch.Tensor | pykeops.torch.LazyTensor):
+    def _log_affinity_formula(self, C: torch.Tensor | LazyTensor):
         return -C / self.sigma
 
 
@@ -108,7 +111,7 @@ class StudentAffinity(TransformableLogAffinity):
         )
         self.degrees_of_freedom = degrees_of_freedom
 
-    def _log_affinity_formula(self, C: torch.Tensor | pykeops.torch.LazyTensor):
+    def _log_affinity_formula(self, C: torch.Tensor | LazyTensor):
         return (
             -0.5
             * (self.degrees_of_freedom + 1)

--- a/torchdr/affinity/umap.py
+++ b/torchdr/affinity/umap.py
@@ -8,7 +8,11 @@ Affinity matrices used in UMAP.
 # License: BSD 3-Clause License
 
 import torch
-import pykeops
+try : # try to import LazyTensor from KeOps for type hinting
+    from keops.torch import LazyTensor
+except ImportError:
+    LazyTensor = type(None)
+import numpy as np
 import math
 import numpy as np
 from scipy.optimize import curve_fit
@@ -196,5 +200,5 @@ class UMAPAffinityOut(TransformableAffinity):
             self._a = a
             self._b = b
 
-    def _affinity_formula(self, C: torch.Tensor | pykeops.torch.LazyTensor):
+    def _affinity_formula(self, C: torch.Tensor | LazyTensor):
         return 1 / (1 + self._a * C**self._b)

--- a/torchdr/affinity/umap.py
+++ b/torchdr/affinity/umap.py
@@ -12,7 +12,6 @@ try :  # try to import LazyTensor from KeOps for type hinting
     from keops.torch import LazyTensor
 except ImportError:
     LazyTensor = type(None)
-import numpy as np
 import math
 import numpy as np
 from scipy.optimize import curve_fit

--- a/torchdr/affinity/umap.py
+++ b/torchdr/affinity/umap.py
@@ -8,7 +8,7 @@ Affinity matrices used in UMAP.
 # License: BSD 3-Clause License
 
 import torch
-try : # try to import LazyTensor from KeOps for type hinting
+try :  # try to import LazyTensor from KeOps for type hinting
     from keops.torch import LazyTensor
 except ImportError:
     LazyTensor = type(None)

--- a/torchdr/affinity/umap.py
+++ b/torchdr/affinity/umap.py
@@ -8,10 +8,7 @@ Affinity matrices used in UMAP.
 # License: BSD 3-Clause License
 
 import torch
-try :  # try to import LazyTensor from KeOps for type hinting
-    from keops.torch import LazyTensor
-except ImportError:
-    LazyTensor = type(None)
+from ..utils import LazyTensorType
 import math
 import numpy as np
 from scipy.optimize import curve_fit
@@ -199,5 +196,5 @@ class UMAPAffinityOut(TransformableAffinity):
             self._a = a
             self._b = b
 
-    def _affinity_formula(self, C: torch.Tensor | LazyTensor):
+    def _affinity_formula(self, C: torch.Tensor | LazyTensorType):
         return 1 / (1 + self._a * C**self._b)

--- a/torchdr/affinity/unnormalized.py
+++ b/torchdr/affinity/unnormalized.py
@@ -9,7 +9,6 @@ Common simple affinities
 
 import torch
 from ..utils import LazyTensorType
-import numpy as np
 
 from torchdr.affinity.base import (
     TransformableAffinity,

--- a/torchdr/base.py
+++ b/torchdr/base.py
@@ -10,7 +10,7 @@ Base classes for DR methods
 from abc import ABC, abstractmethod
 from sklearn.base import BaseEstimator, TransformerMixin
 
-from torchdr.utils import to_torch
+from torchdr.utils import to_torch, pykeops
 
 
 class DRModule(TransformerMixin, BaseEstimator, ABC):
@@ -27,6 +27,13 @@ class DRModule(TransformerMixin, BaseEstimator, ABC):
         verbose: bool = True,
         random_state: float = 0,
     ):
+
+        if keops and not pykeops:
+            raise ValueError(
+                "[TorchDR] ERROR : pykeops is not installed. Please install it to use "
+                "`keops=true`."
+            )
+
         self.n_components = n_components
         self.device = device
         self.keops = keops

--- a/torchdr/tests/test_affinity.py
+++ b/torchdr/tests/test_affinity.py
@@ -17,11 +17,9 @@ from torchdr.utils import pykeops
 # define lists for keops testing
 if pykeops:
     lst_keops = [False, True]
-    lst_keops2 = [True, False]
 else:
     pykeops = False
-    lst_keops = [False, False]
-    lst_keops2 = [False]
+    lst_keops = [False]
 
 
 from torchdr.utils import (
@@ -79,7 +77,8 @@ def test_scalar_product_affinity(dtype):
         check_symmetry(P)
 
     # --- check consistency between torch and keops ---
-    check_similarity_torch_keops(list_P[0], list_P[1], K=10)
+    if len(lst_keops) > 1:
+        check_similarity_torch_keops(list_P[0], list_P[1], K=10)
 
 
 @pytest.mark.parametrize("dtype", lst_types)
@@ -108,7 +107,8 @@ def test_normalized_gibbs_affinity(dtype, metric, dim):
             check_total_sum(P, 1)
 
     # --- check consistency between torch and keops ---
-    check_similarity_torch_keops(list_P[0], list_P[1], K=10)
+    if len(lst_keops) > 1:
+        check_similarity_torch_keops(list_P[0], list_P[1], K=10)
 
 
 @pytest.mark.parametrize("dtype", lst_types)
@@ -129,7 +129,8 @@ def test_gibbs_affinity(dtype, metric):
         check_nonnegativity(P)
 
     # --- check consistency between torch and keops ---
-    check_similarity_torch_keops(list_P[0], list_P[1], K=10)
+    if len(lst_keops) > 1:
+        check_similarity_torch_keops(list_P[0], list_P[1], K=10)
 
 
 @pytest.mark.parametrize("dtype", lst_types)
@@ -157,7 +158,8 @@ def test_self_tuning_gibbs_affinity(dtype, metric, dim):
             check_total_sum(P, 1)
 
     # --- check consistency between torch and keops ---
-    check_similarity_torch_keops(list_P[0], list_P[1], K=10)
+    if len(lst_keops) > 1:
+        check_similarity_torch_keops(list_P[0], list_P[1], K=10)
 
 
 @pytest.mark.parametrize("dtype", lst_types)
@@ -178,14 +180,15 @@ def test_student_affinity(dtype, metric):
         check_nonnegativity(P)
 
     # --- check consistency between torch and keops ---
-    check_similarity_torch_keops(list_P[0], list_P[1], K=10)
+    if len(lst_keops) > 1:
+        check_similarity_torch_keops(list_P[0], list_P[1], K=10)
 
 
 @pytest.mark.parametrize("dtype", lst_types)
 @pytest.mark.parametrize("metric", LIST_METRICS_TEST)
-@pytest.mark.parametrize("keops", lst_keops2)
 @pytest.mark.parametrize("sparsity", [False])
-def test_entropic_affinity(dtype, metric, keops, sparsity):
+@pytest.mark.parametrize("keops", lst_keops)
+def test_entropic_affinity(dtype, metric, sparsity, keops):
     n = 300
     X = toy_dataset(n, dtype)
     perp = 30
@@ -228,7 +231,7 @@ def test_entropic_affinity(dtype, metric, keops, sparsity):
 @pytest.mark.parametrize("dtype", lst_types)
 @pytest.mark.parametrize("metric", LIST_METRICS_TEST)
 @pytest.mark.parametrize("optimizer", ["Adam", "LBFGS"])
-@pytest.mark.parametrize("keops", lst_keops2)
+@pytest.mark.parametrize("keops", lst_keops)
 def test_sym_entropic_affinity(dtype, metric, optimizer, keops):
     n = 300
     X = toy_dataset(n, dtype)
@@ -265,7 +268,7 @@ def test_sym_entropic_affinity(dtype, metric, optimizer, keops):
 
 @pytest.mark.parametrize("dtype", lst_types)
 @pytest.mark.parametrize("metric", LIST_METRICS_TEST)
-@pytest.mark.parametrize("keops", lst_keops2)
+@pytest.mark.parametrize("keops", lst_keops)
 def test_doubly_stochastic_entropic(dtype, metric, keops):
     n = 300
     X = toy_dataset(n, dtype)
@@ -293,7 +296,7 @@ def test_doubly_stochastic_entropic(dtype, metric, keops):
 
 @pytest.mark.parametrize("dtype", lst_types)
 @pytest.mark.parametrize("metric", LIST_METRICS_TEST)
-@pytest.mark.parametrize("keops", lst_keops2)
+@pytest.mark.parametrize("keops", lst_keops)
 def test_doubly_stochastic_quadratic(dtype, metric, keops):
     n = 300
     X = toy_dataset(n, dtype)
@@ -321,9 +324,9 @@ def test_doubly_stochastic_quadratic(dtype, metric, keops):
 
 @pytest.mark.parametrize("dtype", lst_types)
 @pytest.mark.parametrize("metric", LIST_METRICS_TEST)
-@pytest.mark.parametrize("keops", lst_keops2)
 @pytest.mark.parametrize("sparsity", [False])
-def test_umap_data_affinity(dtype, metric, keops, sparsity):
+@pytest.mark.parametrize("keops", lst_keops)
+def test_umap_data_affinity(dtype, metric, sparsity, keops):
     n = 300
     X = toy_dataset(n, dtype)
     n_neighbors = 30
@@ -348,7 +351,7 @@ def test_umap_data_affinity(dtype, metric, keops, sparsity):
 
 @pytest.mark.parametrize("dtype", lst_types)
 @pytest.mark.parametrize("metric", LIST_METRICS_TEST)
-@pytest.mark.parametrize("keops", lst_keops2)
+@pytest.mark.parametrize("keops", lst_keops)
 @pytest.mark.parametrize("a, b", [(1, 2), (None, None)])
 def test_umap_embedding_affinity(dtype, metric, keops, a, b):
     n = 300
@@ -376,7 +379,7 @@ def test_umap_embedding_affinity(dtype, metric, keops, a, b):
     "Affinity",
     [ScalarProductAffinity, GaussianAffinity, StudentAffinity, UMAPAffinityOut],
 )
-@pytest.mark.parametrize("keops", lst_keops2)
+@pytest.mark.parametrize("keops", lst_keops)
 def test_affinity_transform(Affinity, keops, dtype):
     n = 50
     X = toy_dataset(n, dtype)

--- a/torchdr/tests/test_affinity.py
+++ b/torchdr/tests/test_affinity.py
@@ -15,7 +15,7 @@ from sklearn.datasets import make_moons
 
 try:
     import pykeops
-    lst_keops = [True, False]
+    lst_keops = [False, True]
     lst_keops2 = [True, False]
 except ImportError:
     pykeops = False

--- a/torchdr/tests/test_affinity.py
+++ b/torchdr/tests/test_affinity.py
@@ -35,7 +35,6 @@ from torchdr.utils import (
     entropy,
 )
 from torchdr.affinity import (
-    Affinity,
     ScalarProductAffinity,
     GaussianAffinity,
     NormalizedGaussianAffinity,
@@ -64,7 +63,7 @@ def toy_dataset(n=300, dtype="float32"):
 @pytest.mark.skipif(pykeops, reason="pykeops is available")
 def test_keops_not_installed():
     with pytest.raises(ValueError, match="KeOps is not available"):
-        Affinity(keops=True)
+        ScalarProductAffinity(keops=True)
 
 
 @pytest.mark.parametrize("dtype", lst_types)

--- a/torchdr/tests/test_affinity.py
+++ b/torchdr/tests/test_affinity.py
@@ -35,6 +35,7 @@ from torchdr.utils import (
     entropy,
 )
 from torchdr.affinity import (
+    Affinity,
     ScalarProductAffinity,
     GaussianAffinity,
     NormalizedGaussianAffinity,
@@ -58,6 +59,12 @@ DEVICE = "cpu"
 def toy_dataset(n=300, dtype="float32"):
     X, _ = make_moons(n_samples=n, noise=0.05, random_state=0)
     return X.astype(dtype)
+
+
+@pytest.mark.skipif(pykeops, reason="pykeops is available")
+def test_keops_not_installed():
+    with pytest.raises(ValueError, match="KeOps is not available"):
+        Affinity(keops=True)
 
 
 @pytest.mark.parametrize("dtype", lst_types)

--- a/torchdr/tests/test_affinity.py
+++ b/torchdr/tests/test_affinity.py
@@ -62,7 +62,7 @@ def toy_dataset(n=300, dtype="float32"):
 
 @pytest.mark.skipif(pykeops, reason="pykeops is available")
 def test_keops_not_installed():
-    with pytest.raises(ValueError, match="KeOps is not available"):
+    with pytest.raises(ValueError, match="pykeops is not installed"):
         ScalarProductAffinity(keops=True)
 
 

--- a/torchdr/tests/test_affinity.py
+++ b/torchdr/tests/test_affinity.py
@@ -12,12 +12,13 @@ import torch
 import numpy as np
 import math
 from sklearn.datasets import make_moons
+from torchdr.utils import pykeops
 
-try:
-    import pykeops
+# define lists for keops testing
+if pykeops:
     lst_keops = [False, True]
     lst_keops2 = [True, False]
-except ImportError:
+else:
     pykeops = False
     lst_keops = [False, False]
     lst_keops2 = [False]

--- a/torchdr/tests/test_affinity.py
+++ b/torchdr/tests/test_affinity.py
@@ -13,6 +13,16 @@ import numpy as np
 import math
 from sklearn.datasets import make_moons
 
+try:
+    import pykeops
+    lst_keops = [True, False]
+    lst_keops2 = [True, False]
+except ImportError:
+    pykeops = False
+    lst_keops = [False, False]
+    lst_keops2 = [False]
+
+
 from torchdr.utils import (
     check_similarity_torch_keops,
     check_symmetry,
@@ -57,7 +67,7 @@ def test_scalar_product_affinity(dtype):
     X = toy_dataset(n, dtype)
 
     list_P = []
-    for keops in [False, True]:
+    for keops in lst_keops:
         affinity = ScalarProductAffinity(device=DEVICE, keops=keops)
         P = affinity.fit_transform(X)
         list_P.append(P)
@@ -80,7 +90,7 @@ def test_normalized_gibbs_affinity(dtype, metric, dim):
     one = torch.ones(n, dtype=getattr(torch, dtype), device=DEVICE)
 
     list_P = []
-    for keops in [False, True]:
+    for keops in lst_keops:
         affinity = NormalizedGaussianAffinity(
             device=DEVICE, keops=keops, metric=metric, normalization_dim=dim
         )
@@ -107,7 +117,7 @@ def test_gibbs_affinity(dtype, metric):
     X = toy_dataset(n, dtype)
 
     list_P = []
-    for keops in [False, True]:
+    for keops in lst_keops:
         affinity = GaussianAffinity(device=DEVICE, keops=keops, metric=metric)
         P = affinity.fit_transform(X)
         list_P.append(P)
@@ -130,7 +140,7 @@ def test_self_tuning_gibbs_affinity(dtype, metric, dim):
     one = torch.ones(n, dtype=getattr(torch, dtype), device=DEVICE)
 
     list_P = []
-    for keops in [False, True]:
+    for keops in lst_keops:
         affinity = SelfTuningAffinity(
             device=DEVICE, keops=keops, metric=metric, normalization_dim=dim
         )
@@ -156,7 +166,7 @@ def test_student_affinity(dtype, metric):
     X = toy_dataset(n, dtype)
 
     list_P = []
-    for keops in [False, True]:
+    for keops in lst_keops:
         affinity = StudentAffinity(device=DEVICE, keops=keops, metric=metric)
         P = affinity.fit_transform(X)
         list_P.append(P)
@@ -172,7 +182,7 @@ def test_student_affinity(dtype, metric):
 
 @pytest.mark.parametrize("dtype", lst_types)
 @pytest.mark.parametrize("metric", LIST_METRICS_TEST)
-@pytest.mark.parametrize("keops", [True, False])
+@pytest.mark.parametrize("keops", lst_keops2)
 @pytest.mark.parametrize("sparsity", [False])
 def test_entropic_affinity(dtype, metric, keops, sparsity):
     n = 300
@@ -217,7 +227,7 @@ def test_entropic_affinity(dtype, metric, keops, sparsity):
 @pytest.mark.parametrize("dtype", lst_types)
 @pytest.mark.parametrize("metric", LIST_METRICS_TEST)
 @pytest.mark.parametrize("optimizer", ["Adam", "LBFGS"])
-@pytest.mark.parametrize("keops", [True, False])
+@pytest.mark.parametrize("keops", lst_keops2)
 def test_sym_entropic_affinity(dtype, metric, optimizer, keops):
     n = 300
     X = toy_dataset(n, dtype)
@@ -254,7 +264,7 @@ def test_sym_entropic_affinity(dtype, metric, optimizer, keops):
 
 @pytest.mark.parametrize("dtype", lst_types)
 @pytest.mark.parametrize("metric", LIST_METRICS_TEST)
-@pytest.mark.parametrize("keops", [True, False])
+@pytest.mark.parametrize("keops", lst_keops2)
 def test_doubly_stochastic_entropic(dtype, metric, keops):
     n = 300
     X = toy_dataset(n, dtype)
@@ -282,7 +292,7 @@ def test_doubly_stochastic_entropic(dtype, metric, keops):
 
 @pytest.mark.parametrize("dtype", lst_types)
 @pytest.mark.parametrize("metric", LIST_METRICS_TEST)
-@pytest.mark.parametrize("keops", [True, False])
+@pytest.mark.parametrize("keops", lst_keops2)
 def test_doubly_stochastic_quadratic(dtype, metric, keops):
     n = 300
     X = toy_dataset(n, dtype)
@@ -310,7 +320,7 @@ def test_doubly_stochastic_quadratic(dtype, metric, keops):
 
 @pytest.mark.parametrize("dtype", lst_types)
 @pytest.mark.parametrize("metric", LIST_METRICS_TEST)
-@pytest.mark.parametrize("keops", [True, False])
+@pytest.mark.parametrize("keops", lst_keops2)
 @pytest.mark.parametrize("sparsity", [False])
 def test_umap_data_affinity(dtype, metric, keops, sparsity):
     n = 300
@@ -337,7 +347,7 @@ def test_umap_data_affinity(dtype, metric, keops, sparsity):
 
 @pytest.mark.parametrize("dtype", lst_types)
 @pytest.mark.parametrize("metric", LIST_METRICS_TEST)
-@pytest.mark.parametrize("keops", [True, False])
+@pytest.mark.parametrize("keops", lst_keops2)
 @pytest.mark.parametrize("a, b", [(1, 2), (None, None)])
 def test_umap_embedding_affinity(dtype, metric, keops, a, b):
     n = 300
@@ -365,7 +375,7 @@ def test_umap_embedding_affinity(dtype, metric, keops, a, b):
     "Affinity",
     [ScalarProductAffinity, GaussianAffinity, StudentAffinity, UMAPAffinityOut],
 )
-@pytest.mark.parametrize("keops", [True, False])
+@pytest.mark.parametrize("keops", lst_keops2)
 def test_affinity_transform(Affinity, keops, dtype):
     n = 50
     X = toy_dataset(n, dtype)

--- a/torchdr/tests/test_estimators.py
+++ b/torchdr/tests/test_estimators.py
@@ -18,7 +18,6 @@ from torchdr.neighbor_embedding import (
     TSNEkhorn,
     LargeVis,
 )
-from torchdr.base import DRModule
 from torchdr.utils import pykeops
 from sklearn.utils.estimator_checks import check_estimator
 
@@ -28,7 +27,7 @@ DEVICE = "cpu"
 @pytest.mark.skipif(pykeops, reason="pykeops is available")
 def test_keops_not_installed():
     with pytest.raises(ValueError, match="KeOps is not available"):
-        DRModule(keops=True)
+        SNE(keops=True)
 
 
 @pytest.mark.parametrize(

--- a/torchdr/tests/test_estimators.py
+++ b/torchdr/tests/test_estimators.py
@@ -26,7 +26,7 @@ DEVICE = "cpu"
 
 @pytest.mark.skipif(pykeops, reason="pykeops is available")
 def test_keops_not_installed():
-    with pytest.raises(ValueError, match="KeOps is not available"):
+    with pytest.raises(ValueError, match="pykeops is not installed"):
         SNE(keops=True)
 
 

--- a/torchdr/tests/test_estimators.py
+++ b/torchdr/tests/test_estimators.py
@@ -18,9 +18,17 @@ from torchdr.neighbor_embedding import (
     TSNEkhorn,
     LargeVis,
 )
+from torchdr.base import DRModule
+from torchdr.utils import pykeops
 from sklearn.utils.estimator_checks import check_estimator
 
 DEVICE = "cpu"
+
+
+@pytest.mark.skipif(pykeops, reason="pykeops is available")
+def test_keops_not_installed():
+    with pytest.raises(ValueError, match="KeOps is not available"):
+        DRModule(keops=True)
 
 
 @pytest.mark.parametrize(

--- a/torchdr/tests/test_neighbor_embedding.py
+++ b/torchdr/tests/test_neighbor_embedding.py
@@ -20,13 +20,11 @@ from torchdr.neighbor_embedding import (
     InfoTSNE,
     UMAP,
 )
-from torchdr.utils import check_shape
+from torchdr.utils import check_shape, pykeops
 
-try:
-    import pykeops
+if pykeops:
     lst_keops = [True, False]
-except ImportError:
-    pykeops = False
+else:
     lst_keops = [False]
 
 

--- a/torchdr/tests/test_neighbor_embedding.py
+++ b/torchdr/tests/test_neighbor_embedding.py
@@ -22,6 +22,13 @@ from torchdr.neighbor_embedding import (
 )
 from torchdr.utils import check_shape
 
+try:
+    import pykeops
+    lst_keops = [True, False]
+except ImportError:
+    pykeops = False
+    lst_keops = [False]
+
 
 lst_types = ["float32", "float64"]
 SEA_params = {"lr_affinity_in": 1e-1, "max_iter_affinity_in": 1000}
@@ -52,7 +59,7 @@ def test_NE(DRModel, kwargs, dtype):
     n = 300
     X, y = toy_dataset(n, dtype)
 
-    for keops in [False, True]:
+    for keops in lst_keops:
         model = DRModel(
             n_components=2,
             keops=keops,

--- a/torchdr/tests/test_utils.py
+++ b/torchdr/tests/test_utils.py
@@ -25,7 +25,7 @@ from torchdr.utils import (
     check_symmetry,
     check_shape,
     check_similarity,
-    pykeops
+    pykeops,
 )
 
 lst_types = [torch.double, torch.float]

--- a/torchdr/tests/test_utils.py
+++ b/torchdr/tests/test_utils.py
@@ -99,6 +99,7 @@ def test_pairwise_distances(dtype, metric):
     C = pairwise_distances(x, y, metric=metric, keops=False)
     check_shape(C, (n, m))
 
+
 @pytest.mark.skipif(not pykeops, reason="pykeops is not available")
 @pytest.mark.parametrize("dtype", lst_types)
 @pytest.mark.parametrize("metric", LIST_METRICS)
@@ -131,6 +132,7 @@ def test_symmetric_pairwise_distances(dtype, metric):
     # --- check consistency with pairwise_distances ---
     C_ = pairwise_distances(x, metric=metric, keops=False)
     check_similarity(C, C_)
+
 
 @pytest.mark.skipif(not pykeops, reason="pykeops is not available")
 @pytest.mark.parametrize("dtype", lst_types)

--- a/torchdr/tests/test_utils.py
+++ b/torchdr/tests/test_utils.py
@@ -11,10 +11,6 @@ import torch
 import pytest
 
 from torch.testing import assert_close
-try:
-    import pykeops
-except ImportError:
-    pykeops = False
 
 
 from torchdr.utils import (
@@ -29,6 +25,7 @@ from torchdr.utils import (
     check_symmetry,
     check_shape,
     check_similarity,
+    pykeops
 )
 
 lst_types = [torch.double, torch.float]

--- a/torchdr/utils/__init__.py
+++ b/torchdr/utils/__init__.py
@@ -9,6 +9,13 @@ from .optim import binary_search, false_position, OPTIMIZERS
 
 from .losses import cross_entropy_loss, square_loss
 
+from .keops import (
+    pykeops,
+    LazyTensor,
+    LazyTensorType,
+    is_lazy_tensor,
+)
+
 from .wrappers import (
     wrap_vectors,
     to_torch,
@@ -51,12 +58,15 @@ from .utils import (
     sum_matrix_vector,
     sum_red,
     logsumexp_red,
-    batch_transpose,
-    is_lazy_tensor,
+    batch_transpose
 )
 
 
 __all__ = [
+    "LazyTensor",
+    "LazyTensorType",
+    "is_lazy_tensor",
+    "pykeops",
     "binary_search",
     "false_position",
     "OPTIMIZERS",
@@ -95,5 +105,4 @@ __all__ = [
     "torch_to_backend",
     "handle_backend",
     "batch_transpose",
-    "is_lazy_tensor",
 ]

--- a/torchdr/utils/__init__.py
+++ b/torchdr/utils/__init__.py
@@ -52,6 +52,7 @@ from .utils import (
     sum_red,
     logsumexp_red,
     batch_transpose,
+    is_lazy_tensor,
 )
 
 
@@ -94,4 +95,5 @@ __all__ = [
     "torch_to_backend",
     "handle_backend",
     "batch_transpose",
+    "is_lazy_tensor",
 ]

--- a/torchdr/utils/geometry.py
+++ b/torchdr/utils/geometry.py
@@ -50,6 +50,9 @@ def pairwise_distances(
     if Y is None:
         Y = X
 
+    if keops and (LazyTensor is None):  # pykeops no installed
+        raise ValueError("pykeops is not installed. Please install it to use `keops=true`.")
+
     if keops:  # recommended for large datasets
         C = _pairwise_distances_keops(X, Y, metric)
     else:
@@ -82,6 +85,9 @@ def symmetric_pairwise_distances(
     C : torch.Tensor or pykeops.torch.LazyTensor (if keops is True) of shape (n_samples, n_samples) or (n_batch, n_samples_batch, n_samples_batch)
         Pairwise distances matrix.
     """  # noqa E501
+
+    if keops and (LazyTensor is None):  # pykeops no installed
+        raise ValueError("pykeops is not installed. Please install it to use `keops=true`.")
 
     if keops:  # recommended for large datasets
         C = _pairwise_distances_keops(X, metric=metric)

--- a/torchdr/utils/geometry.py
+++ b/torchdr/utils/geometry.py
@@ -48,7 +48,8 @@ def pairwise_distances(
 
     if keops and not pykeops:  # pykeops no installed
         raise ValueError(
-            "pykeops is not installed. Please install it to use `keops=true`.")
+            "pykeops is not installed. Please install it to use `keops=true`."
+        )
 
     if keops:  # recommended for large datasets
         C = _pairwise_distances_keops(X, Y, metric)
@@ -85,7 +86,8 @@ def symmetric_pairwise_distances(
 
     if keops and not pykeops:  # pykeops no installed
         raise ValueError(
-            "pykeops is not installed. Please install it to use `keops=true`.")
+            "pykeops is not installed. Please install it to use `keops=true`."
+        )
 
     if keops:  # recommended for large datasets
         C = _pairwise_distances_keops(X, metric=metric)

--- a/torchdr/utils/geometry.py
+++ b/torchdr/utils/geometry.py
@@ -51,7 +51,8 @@ def pairwise_distances(
         Y = X
 
     if keops and (LazyTensor is None):  # pykeops no installed
-        raise ValueError("pykeops is not installed. Please install it to use `keops=true`.")
+        raise ValueError(
+            "pykeops is not installed. Please install it to use `keops=true`.")
 
     if keops:  # recommended for large datasets
         C = _pairwise_distances_keops(X, Y, metric)
@@ -87,7 +88,8 @@ def symmetric_pairwise_distances(
     """  # noqa E501
 
     if keops and (LazyTensor is None):  # pykeops no installed
-        raise ValueError("pykeops is not installed. Please install it to use `keops=true`.")
+        raise ValueError(
+            "pykeops is not installed. Please install it to use `keops=true`.")
 
     if keops:  # recommended for large datasets
         C = _pairwise_distances_keops(X, metric=metric)

--- a/torchdr/utils/geometry.py
+++ b/torchdr/utils/geometry.py
@@ -8,7 +8,11 @@ Ground metrics and distances
 # License: BSD 3-Clause License
 
 import torch
-from pykeops.torch import LazyTensor
+
+try:
+    from pykeops.torch import LazyTensor
+except ImportError:
+    LazyTensor = None
 
 from torchdr.utils.utils import identity_matrix
 

--- a/torchdr/utils/geometry.py
+++ b/torchdr/utils/geometry.py
@@ -8,11 +8,7 @@ Ground metrics and distances
 # License: BSD 3-Clause License
 
 import torch
-
-try:
-    from pykeops.torch import LazyTensor
-except ImportError:
-    LazyTensor = None
+from .keops import LazyTensor, pykeops
 
 from torchdr.utils.utils import identity_matrix
 
@@ -50,7 +46,7 @@ def pairwise_distances(
     if Y is None:
         Y = X
 
-    if keops and (LazyTensor is None):  # pykeops no installed
+    if keops and not pykeops:  # pykeops no installed
         raise ValueError(
             "pykeops is not installed. Please install it to use `keops=true`.")
 
@@ -87,7 +83,7 @@ def symmetric_pairwise_distances(
         Pairwise distances matrix.
     """  # noqa E501
 
-    if keops and (LazyTensor is None):  # pykeops no installed
+    if keops and not pykeops:  # pykeops no installed
         raise ValueError(
             "pykeops is not installed. Please install it to use `keops=true`.")
 

--- a/torchdr/utils/keops.py
+++ b/torchdr/utils/keops.py
@@ -10,10 +10,12 @@ Robust handling of pykeops as optional dependency
 try:
     import pykeops
     from pykeops.torch import LazyTensor
+
     LazyTensorType = LazyTensor
-except ImportError:
-    pykeops = False  # pykeops is not installed
-    LazyTensor = None  # pykeops is not installed
+
+except ImportError:  # pykeops is not installed
+    pykeops = False
+    LazyTensor = None
     LazyTensorType = type(None)
 
 

--- a/torchdr/utils/keops.py
+++ b/torchdr/utils/keops.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+"""
+Robust handling of pykeops as optional dependency
+"""
+
+# Author: Rémi Flamary <remi.flamary@polytechnique.edu>
+#
+# License: BSD 3-Clause License
+
+try:
+    import pykeops
+    from pykeops.torch import LazyTensor
+    LazyTensorType = LazyTensor
+except ImportError:
+    pykeops = False  # pykeops is not installed
+    LazyTensor = None  # pykeops is not installed
+    LazyTensorType = type(None)
+
+
+def is_lazy_tensor(arg):
+    r"""
+    Returns True if the input is a KeOps lazy tensor.
+    """
+    if not pykeops:
+        return False
+    return isinstance(arg, LazyTensor)

--- a/torchdr/utils/utils.py
+++ b/torchdr/utils/utils.py
@@ -8,20 +8,8 @@ Useful functions for defining objectives and constraints
 # License: BSD 3-Clause License
 
 import torch
-try:
-    from pykeops.torch import LazyTensor
-except ImportError:
-    LazyTensor = None
+from .keops import LazyTensor, is_lazy_tensor
 from .wrappers import wrap_vectors
-
-
-def is_lazy_tensor(arg):
-    r"""
-    Returns True if the input is a KeOps lazy tensor.
-    """
-    if LazyTensor is None:
-        return False
-    return isinstance(arg, LazyTensor)
 
 
 def entropy(P, log=True, dim=1):

--- a/torchdr/utils/utils.py
+++ b/torchdr/utils/utils.py
@@ -14,6 +14,7 @@ except ImportError:
     LazyTensor = None
 from .wrappers import wrap_vectors
 
+
 def is_lazy_tensor(arg):
     r"""
     Returns True if the input is a KeOps lazy tensor.

--- a/torchdr/utils/utils.py
+++ b/torchdr/utils/utils.py
@@ -8,9 +8,19 @@ Useful functions for defining objectives and constraints
 # License: BSD 3-Clause License
 
 import torch
-from pykeops.torch import LazyTensor
+try:
+    from pykeops.torch import LazyTensor
+except ImportError:
+    LazyTensor = None
+from .wrappers import wrap_vectors
 
-from torchdr.utils.wrappers import wrap_vectors
+def is_lazy_tensor(arg):
+    r"""
+    Returns True if the input is a KeOps lazy tensor.
+    """
+    if LazyTensor is None:
+        return False
+    return isinstance(arg, LazyTensor)
 
 
 def entropy(P, log=True, dim=1):
@@ -38,7 +48,7 @@ def kmin(A, k=1, dim=0):
     if k >= A.shape[dim]:
         return A, torch.arange(A.shape[dim]).int()
 
-    if isinstance(A, LazyTensor):
+    if is_lazy_tensor(A):
         dim_red = lambda P: (
             P.T if dim == 0 else P
         )  # reduces the same axis as torch.topk
@@ -64,7 +74,7 @@ def kmax(A, k=1, dim=0):
     if k >= A.shape[dim]:
         return A, torch.arange(A.shape[dim]).int()
 
-    if isinstance(A, LazyTensor):
+    if is_lazy_tensor(A):
         dim_red = lambda P: (
             P.T if dim == 0 else P
         )  # reduces the same axis as torch.topk
@@ -110,7 +120,7 @@ def sum_red(P, dim):
     if isinstance(P, torch.Tensor):
         return P.sum(dim, keepdim=True)
 
-    elif isinstance(P, LazyTensor):
+    elif is_lazy_tensor(P):
         if dim == (0, 1):
             return P.sum(1).sum(0)  # shape (1)
         elif dim == 1:
@@ -149,7 +159,7 @@ def logsumexp_red(log_P, dim):
     if isinstance(log_P, torch.Tensor):
         return log_P.logsumexp(dim, keepdim=True)
 
-    elif isinstance(log_P, LazyTensor):
+    elif is_lazy_tensor(log_P):
         if dim == (0, 1):
             return log_P.logsumexp(1).logsumexp(0)  # shape (1)
         elif dim == 1:
@@ -223,7 +233,7 @@ def batch_transpose(arg):
     Transposes a tensor or lazy tensor that can have a batch dimension.
     The batch dimension is the first, thus only the last two axis are transposed.
     """
-    if isinstance(arg, LazyTensor):
+    if is_lazy_tensor(arg):
         return arg.T
     elif isinstance(arg, torch.Tensor):
         return arg.transpose(-2, -1)

--- a/torchdr/utils/validation.py
+++ b/torchdr/utils/validation.py
@@ -9,7 +9,7 @@ Useful functions for testing, compatible with KeOps
 
 import torch
 from torch.testing import assert_close
-try: 
+try:
     import pykeops
 except ImportError:
     pykeops = False
@@ -48,9 +48,13 @@ def check_similarity_torch_keops(P, P_keops, K=None, test_indices=True, tol=1e-5
     if pykeops:
         assert is_lazy_tensor(P_keops), "P_keops is not a LazyTensor."
     else:
-        assert_close(P, P_keops, atol=tol, rtol=tol, msg="Torch and Keops matrices are different.")
+        assert_close(
+            P,
+            P_keops,
+            atol=tol,
+            rtol=tol,
+            msg="Torch and Keops matrices are different.")
         return
-
 
     # retrieve largest P_keops values and arguments
     Largest_keops_values, Largest_keops_arg = (-P_keops).Kmin_argKmin(K=K, dim=1)

--- a/torchdr/utils/validation.py
+++ b/torchdr/utils/validation.py
@@ -9,12 +9,8 @@ Useful functions for testing, compatible with KeOps
 
 import torch
 from torch.testing import assert_close
-try:
-    import pykeops
-except ImportError:
-    pykeops = False
-
-from torchdr.utils.utils import entropy, is_lazy_tensor
+from .keops import pykeops, is_lazy_tensor
+from .utils import entropy
 
 
 def check_NaNs(input, msg=None):

--- a/torchdr/utils/validation.py
+++ b/torchdr/utils/validation.py
@@ -9,9 +9,8 @@ Useful functions for testing, compatible with KeOps
 
 import torch
 from torch.testing import assert_close
-from pykeops.torch import LazyTensor
 
-from torchdr.utils.utils import entropy
+from torchdr.utils.utils import entropy, is_lazy_tensor
 
 
 def check_NaNs(input, msg=None):
@@ -33,7 +32,7 @@ def check_similarity_torch_keops(P, P_keops, K=None, test_indices=True, tol=1e-5
     Checks that a torch.Tensor and a LazyTensor are equal on their largest entries.
     """
     assert isinstance(P, torch.Tensor), "P is not a torch.Tensor."
-    assert isinstance(P_keops, LazyTensor), "P_keops is not a LazyTensor."
+    assert is_lazy_tensor(P_keops), "P_keops is not a LazyTensor."
     assert P.shape == P_keops.shape, "P and P_keops do not have the same shape."
 
     n = P.shape[0]
@@ -181,7 +180,7 @@ def check_type(P, keops):
     Checks if a tensor is a torch.Tensor or a LazyTensor (if keops is True).
     """
     if keops:
-        assert isinstance(P, LazyTensor), "Input is not a LazyTensor."
+        assert is_lazy_tensor(P), "Input is not a LazyTensor."
     else:
         assert isinstance(P, torch.Tensor), "Input is not a torch.Tensor."
 

--- a/torchdr/utils/wrappers.py
+++ b/torchdr/utils/wrappers.py
@@ -10,6 +10,7 @@ Useful wrappers for dealing with backends and devices
 import functools
 import torch
 import numpy as np
+from .keops import LazyTensor, is_lazy_tensor
 from sklearn.utils.validation import check_array
 
 

--- a/torchdr/utils/wrappers.py
+++ b/torchdr/utils/wrappers.py
@@ -10,17 +10,7 @@ Useful wrappers for dealing with backends and devices
 import functools
 import torch
 import numpy as np
-from .keops import LazyTensor
 from sklearn.utils.validation import check_array
-
-
-def is_lazy_tensor(arg):
-    r"""
-    Returns True if the input is a KeOps lazy tensor.
-    """
-    if LazyTensor is None:
-        return False
-    return isinstance(arg, LazyTensor)
 
 
 def output_contiguous(func):

--- a/torchdr/utils/wrappers.py
+++ b/torchdr/utils/wrappers.py
@@ -16,6 +16,7 @@ except ImportError:
     LazyTensor = None
 from sklearn.utils.validation import check_array
 
+
 def is_lazy_tensor(arg):
     r"""
     Returns True if the input is a KeOps lazy tensor.

--- a/torchdr/utils/wrappers.py
+++ b/torchdr/utils/wrappers.py
@@ -10,10 +10,7 @@ Useful wrappers for dealing with backends and devices
 import functools
 import torch
 import numpy as np
-try:
-    from pykeops.torch import LazyTensor
-except ImportError:
-    LazyTensor = None
+from .keops import LazyTensor
 from sklearn.utils.validation import check_array
 
 


### PR DESCRIPTION
TODO:

- [x]  try/catch imports of pykeops
- [x] test if array is Lazytesor with need to import pykeops
- [x] Test import of torchdr on env with pykeops
- [x] Update all tests to skip por reun wiell even in pykeops not installed
- [x] Add GH action with tests on minimal install
- [x] Update pyprojet.toml to cleanup dependencies (pykeops/matplotlib)
- [x] create sub_module in torchdr.utils with all keops stuf to avoid all te tests? 
- [x] Create tests that check raising of error when pykeops not installed an keops required
