### PR TITLE
[Feature] Switching to keops automatically (if installed) when out of memory encountered

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1,4 +1,5 @@
 
+- Functionality to switch to keops backend if it is installed and an out-of-memory error is raised `PR #130 <https://github.com/TorchDR/TorchDR/pull/130>`_.
 - Code of conduct `PR #127 <https://github.com/TorchDR/TorchDR/pull/127>`_.
 - Pull request template `PR #125 <https://github.com/TorchDR/TorchDR/pull/125>`_.
 

--- a/torchdr/affinity/base.py
+++ b/torchdr/affinity/base.py
@@ -17,6 +17,7 @@ from torchdr.utils import (
     to_torch,
     LazyTensorType,
     pykeops,
+    handle_keops,
 )
 
 
@@ -97,6 +98,7 @@ class Affinity(ABC):
             "[TorchDR] ERROR : `_compute_affinity` method is not implemented."
         )
 
+    @handle_keops
     def _distance_matrix(self, X: torch.Tensor):
         r"""Compute the pairwise distance matrix from the input data.
 
@@ -118,7 +120,7 @@ class Affinity(ABC):
         return symmetric_pairwise_distances(
             X=X,
             metric=self.metric,
-            keops=self.keops,
+            keops=self.keops_,
             add_diag=self.add_diag,
         )
 
@@ -412,6 +414,7 @@ class UnnormalizedAffinity(Affinity):
             "[TorchDR] ERROR : `_affinity_formula` method is not implemented."
         )
 
+    @handle_keops
     def _distance_matrix(
         self,
         X: torch.Tensor | np.ndarray,
@@ -455,11 +458,11 @@ class UnnormalizedAffinity(Affinity):
             )
 
         elif Y is not None:
-            return pairwise_distances(X, Y, metric=self.metric, keops=self.keops)
+            return pairwise_distances(X, Y, metric=self.metric, keops=self.keops_)
 
         else:
             return symmetric_pairwise_distances(
-                X, metric=self.metric, keops=self.keops, add_diag=self.add_diag
+                X, metric=self.metric, keops=self.keops_, add_diag=self.add_diag
             )
 
 

--- a/torchdr/utils/__init__.py
+++ b/torchdr/utils/__init__.py
@@ -20,6 +20,7 @@ from .wrappers import (
     torch_to_backend,
     handle_backend,
     sum_output,
+    handle_keops,
 )
 
 from .geometry import (
@@ -104,4 +105,5 @@ __all__ = [
     "torch_to_backend",
     "handle_backend",
     "batch_transpose",
+    "handle_keops",
 ]

--- a/torchdr/utils/wrappers.py
+++ b/torchdr/utils/wrappers.py
@@ -170,7 +170,7 @@ def handle_backend(func):
 
 
 def handle_keops(func):
-    """Sets the keops_ attribute to True if an OutOfMemoryError is encountered.
+    """Set the keops_ attribute to True if an OutOfMemoryError is encountered.
 
     If keops is set to True, keops_ is also set to True and nothing is done.
     Otherwise, the function is called and if an OutOfMemoryError is encountered,
@@ -179,7 +179,6 @@ def handle_keops(func):
 
     @functools.wraps(func)
     def wrapper(self, *args, **kwargs):
-
         # if indices are provided, we do not use KeOps
         if kwargs.get("indices", None) is not None:
             return func(self, *args, **kwargs)
@@ -192,7 +191,8 @@ def handle_keops(func):
 
                 except torch.cuda.OutOfMemoryError:
                     print(
-                        f"[TorchDR] Out of memory encountered, setting keops to True for {self.__class__.__name__} object."
+                        "[TorchDR] Out of memory encountered, setting keops to True "
+                        f"for {self.__class__.__name__} object."
                     )
                     if not pykeops:
                         raise ValueError(

--- a/torchdr/utils/wrappers.py
+++ b/torchdr/utils/wrappers.py
@@ -170,7 +170,7 @@ def handle_backend(func):
 
 
 def handle_keops(func):
-    """Set the keops_ attribute to True if an OutOfMemoryError is encountered.
+    """Sets the keops_ attribute to True if an OutOfMemoryError is encountered.
 
     If keops is set to True, keops_ is also set to True and nothing is done.
     Otherwise, the function is called and if an OutOfMemoryError is encountered,
@@ -179,6 +179,11 @@ def handle_keops(func):
 
     @functools.wraps(func)
     def wrapper(self, *args, **kwargs):
+
+        # if indices are provided, we do not use KeOps
+        if kwargs.get("indices", None) is not None:
+            return func(self, *args, **kwargs)
+
         if not hasattr(self, "keops_"):
             self.keops_ = self.keops
             if not self.keops_:
@@ -186,7 +191,9 @@ def handle_keops(func):
                     return func(self, *args, **kwargs)
 
                 except torch.cuda.OutOfMemoryError:
-                    print("[TorchDR] Out of memory encountered, setting keops to True.")
+                    print(
+                        f"[TorchDR] Out of memory encountered, setting keops to True for {self.__class__.__name__} object."
+                    )
                     if not pykeops:
                         raise ValueError(
                             "[TorchDR] pykeops is not installed. Please install it by "

--- a/torchdr/utils/wrappers.py
+++ b/torchdr/utils/wrappers.py
@@ -196,8 +196,9 @@ def handle_keops(func):
                     )
                     if not pykeops:
                         raise ValueError(
-                            "[TorchDR] pykeops is not installed. Please install it by "
-                            "running `pip install pykeops` to use `keops=True`."
+                            "[TorchDR] ERROR : pykeops is not installed. "
+                            "To use `keops=True`, please run `pip install pykeops` "
+                            "or `pip install torchdr[all]`. "
                         )
                     self.keops_ = True
 

--- a/torchdr/utils/wrappers.py
+++ b/torchdr/utils/wrappers.py
@@ -170,7 +170,7 @@ def handle_backend(func):
 
 
 def handle_keops(func):
-    """Sets the keops_ attribute to True if an OutOfMemoryError is encountered.
+    """Set the keops_ attribute to True if an OutOfMemoryError is encountered.
 
     If keops is set to True, keops_ is also set to True and nothing is done.
     Otherwise, the function is called and if an OutOfMemoryError is encountered,

--- a/torchdr/utils/wrappers.py
+++ b/torchdr/utils/wrappers.py
@@ -170,6 +170,14 @@ def handle_backend(func):
 
 
 def handle_keops(func):
+    """Sets the keops_ attribute to True if an OutOfMemoryError is encountered.
+
+    If keops is set to True, keops_ is also set to True and nothing is done.
+    Otherwise, the function is called and if an OutOfMemoryError is encountered,
+    keops_ is set to True and the function is called again.
+    """
+
+    @functools.wraps(func)
     def wrapper(self, *args, **kwargs):
         if not hasattr(self, "keops_"):
             self.keops_ = self.keops

--- a/torchdr/utils/wrappers.py
+++ b/torchdr/utils/wrappers.py
@@ -8,8 +8,8 @@
 import functools
 import torch
 import numpy as np
-from .keops import LazyTensor, is_lazy_tensor
 from sklearn.utils.validation import check_array
+from .keops import LazyTensor, is_lazy_tensor, pykeops
 
 
 def output_contiguous(func):
@@ -165,5 +165,27 @@ def handle_backend(func):
         )
         output = func(self, X_, *args, **kwargs).detach()
         return torch_to_backend(output, backend=input_backend, device=input_device)
+
+    return wrapper
+
+
+def handle_keops(func):
+    def wrapper(self, *args, **kwargs):
+        if not hasattr(self, "keops_"):
+            self.keops_ = self.keops
+            if not self.keops_:
+                try:
+                    return func(self, *args, **kwargs)
+
+                except torch.cuda.OutOfMemoryError:
+                    print("[TorchDR] Out of memory encountered, setting keops to True.")
+                    if not pykeops:
+                        raise ValueError(
+                            "[TorchDR] pykeops is not installed. Please install it by "
+                            "running `pip install pykeops` to use `keops=True`."
+                        )
+                    self.keops_ = True
+
+        return func(self, *args, **kwargs)
 
     return wrapper


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Switch to keops if out of memory is raised and the user has already installed keops.


## Motivation and context / Related issue
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

Adresses issue #116 , provides better error message for user. Solves #128 .

## How has this been tested (if it applies)
<!--- Please describe here how your modifications have been tested. -->

Added some tests but did not manage to test the CUDA out of memory condition. The decorator structure makes it difficult to test.

## PR checklist
<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**How to Contribute**](https://torchdr.github.io/torchdr.contributing.html) document.
- [x] The documentation is up-to-date with the changes I made (check build artifacts).
- [x] All tests passed, and additional code has been **covered with new tests**.
- [x] I have added the PR and Issue fix to the [**RELEASES.rst**](RELEASES.rst) file.

<!--- In any case, don't hesitate to join and ask questions if you need on slack (https://pot-toolbox.slack.com/), gitter (https://gitter.im/PythonOT/community), or the mailing list (https://mail.python.org/mm3/mailman3/lists/pot.python.org/). -->