### PR TITLE
[Feature] kmeans & neighborhood preservation eval scores

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,8 @@ test = [
     "numpydoc",
     "pytest-cov",
     "codecov",
-    "matplotlib"
+    "matplotlib",
+    "torchmetrics"
 ]
 
 keops = [
@@ -83,6 +84,7 @@ dev = [
     "codecov",
     "pykeops",
     "pre-commit",
+    "torchmetrics",
 ]
 
 doc = [

--- a/torchdr/eval/__init__.py
+++ b/torchdr/eval/__init__.py
@@ -1,0 +1,13 @@
+"""Evaluation methods for dimensionality reduction."""
+
+from .silhouette import silhouette_samples, silhouette_score, admissible_LIST_METRICS
+from .kmeans import kmeans_ari
+from .neighborhood_preservation import neighborhood_preservation
+
+__all__ = [
+    "silhouette_samples",
+    "silhouette_score",
+    "admissible_LIST_METRICS",
+    "kmeans_ari",
+    "neighborhood_preservation",
+]

--- a/torchdr/eval/kmeans.py
+++ b/torchdr/eval/kmeans.py
@@ -1,0 +1,177 @@
+"""K-means clustering evaluation for dimensionality reduction."""
+
+# Author: Hugues Van Assel <vanasselhugues@gmail.com>
+#
+# License: BSD 3-Clause License
+
+import warnings
+import numpy as np
+import torch
+from typing import Union, Optional
+
+from torchdr.utils import to_torch
+from torchdr.utils.faiss import faiss
+
+try:
+    from torchmetrics.clustering import AdjustedRandScore
+except ImportError:
+    AdjustedRandScore = None
+
+
+def kmeans_ari(
+    X: Union[torch.Tensor, np.ndarray],
+    labels: Union[torch.Tensor, np.ndarray],
+    n_clusters: Optional[int] = None,
+    niter: int = 20,
+    nredo: int = 1,
+    device: Optional[str] = None,
+    random_state: Optional[int] = None,
+    verbose: bool = False,
+):
+    r"""Perform K-means clustering and compute Adjusted Rand Index.
+
+    This function clusters the input data using FAISS K-means and computes
+    the Adjusted Rand Index (ARI) between the predicted clusters and true labels.
+    The ARI measures the similarity between two clusterings, adjusted for chance.
+
+    Parameters
+    ----------
+    X : torch.Tensor or np.ndarray of shape (n_samples, n_features)
+        Input data to cluster.
+    labels : torch.Tensor or np.ndarray of shape (n_samples,)
+        True labels for computing ARI.
+    n_clusters : int, optional
+        Number of clusters. If None, uses the number of unique labels.
+    niter : int, default=20
+        Maximum number of K-means iterations.
+    nredo : int, default=1
+        Number of times to run K-means with different initializations,
+        keeping the best result (lowest objective).
+    device : str, optional
+        Device to use for ARI computation. If None, uses the input device.
+    random_state : int, optional
+        Random seed for reproducibility.
+    verbose : bool, default=False
+        Whether to print progress information.
+
+    Returns
+    -------
+    ari_score : float or torch.Tensor
+        Adjusted Rand Index between predicted clusters and true labels.
+        Values range from -1 to 1, where 1 indicates perfect agreement,
+        0 indicates random labeling, and negative values indicate
+        systematic disagreement. Returns numpy float if inputs are numpy,
+        torch.Tensor if inputs are torch.
+    predicted_labels : np.ndarray or torch.Tensor of shape (n_samples,)
+        Cluster assignments from K-means. Returns same type as input X.
+
+    Raises
+    ------
+    ImportError
+        If FAISS or torchmetrics is not installed.
+    ValueError
+        If n_clusters is less than 1 or greater than n_samples.
+
+    Examples
+    --------
+    >>> import torch
+    >>> from torchdr.eval.kmeans import kmeans_ari
+    >>>
+    >>> # Generate sample data
+    >>> X = torch.randn(1000, 50)
+    >>> true_labels = torch.randint(0, 5, (1000,))
+    >>>
+    >>> # Compute ARI score
+    >>> ari_score, pred_labels = kmeans_ari(X, true_labels)
+    >>> print(f"ARI Score: {ari_score:.3f}")
+
+    Notes
+    -----
+    The Adjusted Rand Index is a measure of clustering quality that:
+    - Accounts for chance agreement between clusterings
+    - Is symmetric (swapping predicted and true labels gives same result)
+    - Has expected value of 0 for random clusterings
+    - Has maximum value of 1 for identical clusterings
+
+    FAISS K-means uses Lloyd's algorithm with optional multiple runs.
+    GPU acceleration is automatically used if FAISS-GPU is installed and X is on GPU.
+    """
+    if faiss is False:
+        raise ImportError(
+            "[TorchDR] FAISS is required for kmeans_ari but not installed. "
+            "Install it with: conda install -c pytorch -c nvidia faiss-gpu"
+        )
+
+    if AdjustedRandScore is None:
+        raise ImportError(
+            "[TorchDR] torchmetrics is required for kmeans_ari but not installed. "
+            "Install it with: pip install torchmetrics"
+        )
+
+    input_is_numpy = not isinstance(X, torch.Tensor) or not isinstance(
+        labels, torch.Tensor
+    )
+
+    X = to_torch(X)
+    labels = to_torch(labels).squeeze()
+
+    if device is None:
+        device = X.device
+    else:
+        device = torch.device(device)
+
+    X_np = X.detach().cpu().numpy().astype(np.float32)
+    labels_np = labels.detach().cpu().numpy()
+
+    n_samples, d = X_np.shape
+
+    if n_clusters is None:
+        n_clusters = len(np.unique(labels_np))
+
+    if n_clusters < 1:
+        raise ValueError(f"n_clusters must be at least 1, got {n_clusters}")
+    if n_clusters > n_samples:
+        raise ValueError(
+            f"n_clusters ({n_clusters}) cannot be greater than n_samples ({n_samples})"
+        )
+
+    if random_state is not None:
+        np.random.seed(random_state)
+
+    use_gpu = (device.type == "cuda") and hasattr(faiss, "StandardGpuResources")
+
+    kmeans = faiss.Kmeans(
+        d,
+        n_clusters,
+        niter=niter,
+        nredo=nredo,
+        verbose=verbose,
+        gpu=use_gpu,
+        seed=random_state if random_state is not None else np.random.randint(2**31),
+    )
+
+    if device.type == "cuda" and not use_gpu:
+        warnings.warn(
+            "[TorchDR] WARNING: GPU device specified but faiss-gpu not installed. "
+            "Using CPU for K-means. For GPU support, install faiss-gpu.",
+            stacklevel=2,
+        )
+
+    kmeans.train(X_np)
+
+    _, predicted_labels_np = kmeans.index.search(X_np, 1)
+    predicted_labels_np = predicted_labels_np.ravel()
+
+    predicted_labels_torch = torch.from_numpy(predicted_labels_np).long().to(device)
+    labels_torch = labels.long().to(device)
+
+    ari_metric = AdjustedRandScore().to(device)
+    ari_score = ari_metric(predicted_labels_torch, labels_torch)
+
+    if input_is_numpy:
+        ari_score = ari_score.detach().cpu().numpy().item()
+        predicted_labels = predicted_labels_np
+    else:
+        predicted_labels = predicted_labels_torch
+
+    return ari_score, predicted_labels

--- a/torchdr/eval/neighborhood_preservation.py
+++ b/torchdr/eval/neighborhood_preservation.py
@@ -1,0 +1,137 @@
+"""K-ary neighborhood preservation metric for dimensionality reduction evaluation."""
+
+# Author: Hugues Van Assel <vanasselhugues@gmail.com>
+#
+# License: BSD 3-Clause License
+
+import numpy as np
+import torch
+from typing import Union, Optional
+
+from torchdr.utils import to_torch
+from torchdr.distance import pairwise_distances, FaissConfig
+
+
+def neighborhood_preservation(
+    X: Union[torch.Tensor, np.ndarray],
+    Z: Union[torch.Tensor, np.ndarray],
+    K: int,
+    metric: str = "euclidean",
+    backend: Optional[Union[str, FaissConfig]] = None,
+    device: Optional[str] = None,
+):
+    r"""Compute K-ary neighborhood preservation between input data and embeddings.
+
+    This metric measures how well local neighborhood structure is preserved
+    when reducing from high-dimensional input data (X) to low-dimensional embeddings (Z).
+
+    Parameters
+    ----------
+    X : torch.Tensor or np.ndarray of shape (n_samples, n_features)
+        Original high-dimensional data.
+    Z : torch.Tensor or np.ndarray of shape (n_samples, n_features_reduced)
+        Reduced low-dimensional embeddings.
+    K : int
+        Neighborhood size (number of nearest neighbors to consider).
+    metric : str, default='euclidean'
+        Distance metric to use for computing nearest neighbors.
+        Options: 'euclidean', 'sqeuclidean', 'manhattan', 'angular'.
+    backend : {'keops', 'faiss', None} or FaissConfig, optional
+        Backend to use for k-NN computation:
+        - 'keops': Memory-efficient symbolic computations
+        - 'faiss': Fast approximate nearest neighbors (recommended for large datasets)
+        - None: Standard PyTorch operations
+        - FaissConfig object: FAISS with custom configuration
+    device : str, optional
+        Device to use for computation. If None, uses input device.
+
+    Returns
+    -------
+    score : float or torch.Tensor
+        Average proportion of preserved neighbors across all points.
+        Value between 0 and 1, where 1 indicates perfect preservation.
+        Returns numpy float if inputs are numpy, torch.Tensor otherwise.
+
+    Examples
+    --------
+    >>> import torch
+    >>> from torchdr.eval.neighborhood_preservation import neighborhood_preservation
+    >>>
+    >>> # Generate example data
+    >>> X = torch.randn(100, 50)  # High-dimensional data
+    >>> Z = torch.randn(100, 2)   # Low-dimensional embedding
+    >>>
+    >>> # Compute preservation score
+    >>> score = neighborhood_preservation(X, Z, K=10)
+    >>> print(f"Neighborhood preservation: {score:.3f}")
+
+    Notes
+    -----
+    The metric computes the Jaccard similarity (intersection over union) between
+    the K-nearest neighbor sets in the original and reduced spaces for each point,
+    then averages across all points.
+
+    For large datasets, using backend='faiss' is recommended for efficiency.
+    The metric excludes self-neighbors (i.e., the point itself).
+    """
+    if K < 1:
+        raise ValueError(f"K must be at least 1, got {K}")
+
+    input_is_numpy = not isinstance(X, torch.Tensor) or not isinstance(Z, torch.Tensor)
+
+    X = to_torch(X)
+    Z = to_torch(Z)
+
+    if X.shape[0] != Z.shape[0]:
+        raise ValueError(
+            f"X and Z must have same number of samples, got {X.shape[0]} and {Z.shape[0]}"
+        )
+
+    n_samples = X.shape[0]
+
+    if K >= n_samples:
+        raise ValueError(f"K ({K}) must be less than number of samples ({n_samples})")
+
+    if device is None:
+        device = X.device
+    else:
+        device = torch.device(device)
+
+    X = X.to(device)
+    Z = Z.to(device)
+
+    _, neighbors_X = pairwise_distances(
+        X,
+        metric=metric,
+        backend=backend,
+        k=K,
+        exclude_diag=True,
+        return_indices=True,
+        device=device,
+    )
+
+    _, neighbors_Z = pairwise_distances(
+        Z,
+        metric=metric,
+        backend=backend,
+        k=K,
+        exclude_diag=True,
+        return_indices=True,
+        device=device,
+    )
+
+    # Vectorized computation using broadcasting to check neighborhood overlap
+    neighbors_X_expanded = neighbors_X.unsqueeze(2)  # (n_samples, K, 1)
+    neighbors_Z_expanded = neighbors_Z.unsqueeze(1)  # (n_samples, 1, K)
+
+    matches = (neighbors_X_expanded == neighbors_Z_expanded).any(
+        dim=2
+    )  # (n_samples, K)
+    overlaps = matches.float().sum(dim=1) / K
+
+    score = overlaps.mean()
+
+    if input_is_numpy:
+        score = score.detach().cpu().numpy().item()
+
+    return score

--- a/torchdr/tests/test_eval_comprehensive.py
+++ b/torchdr/tests/test_eval_comprehensive.py
@@ -1,0 +1,549 @@
+"""
+Comprehensive tests for the eval module.
+"""
+
+# Author: Hugues Van Assel <vanasselhugues@gmail.com>
+#         Cédric Vincent-Cuaz <cedvincentcuaz@gmail.com>
+#
+# License: BSD 3-Clause License
+
+import warnings
+import numpy as np
+import pytest
+import torch
+from sklearn.metrics import silhouette_score as sk_silhouette_score
+from torch.testing import assert_close
+
+from torchdr.eval import (
+    admissible_LIST_METRICS,
+    silhouette_samples,
+    silhouette_score,
+    kmeans_ari,
+    neighborhood_preservation,
+)
+from torchdr.tests.utils import toy_dataset, iris_dataset
+from torchdr.utils import pykeops
+from torchdr.utils.faiss import faiss
+from torchdr.distance import pairwise_distances, FaissConfig
+
+
+# Test configuration
+lst_types = ["float32", "float64"]
+if pykeops:
+    lst_backend = ["keops", None]
+else:
+    lst_backend = [None]
+
+# Add faiss backend if available
+if faiss:
+    lst_backend.append("faiss")
+
+DEVICE = "cpu"
+if torch.cuda.is_available():
+    CUDA_DEVICE = "cuda"
+else:
+    CUDA_DEVICE = None
+
+
+# ============================================================================
+# SILHOUETTE TESTS (keeping existing tests)
+# ============================================================================
+
+
+@pytest.mark.parametrize("dtype", lst_types)
+@pytest.mark.parametrize("backend", lst_backend)
+@pytest.mark.parametrize("metric", ["euclidean", "manhattan", "whatever"])
+def test_silhouette_score_euclidean(dtype, backend, metric):
+    """Test silhouette score with various metrics and backends."""
+    n = 10
+    Id = torch.eye(n, device=DEVICE, dtype=getattr(torch, dtype))
+    y_I = torch.arange(n, device=DEVICE)
+    ones = torch.ones(n, device=DEVICE, dtype=getattr(torch, dtype))
+    zeros = torch.zeros(n, device=DEVICE, dtype=getattr(torch, dtype))
+
+    y_I2 = []
+    for i in range(n // 2):
+        y_I2 += [i] * 2
+    y_I2 = torch.tensor(y_I2, device=DEVICE)
+
+    if metric in admissible_LIST_METRICS:
+        # Test edge cases with isolated samples
+        with warnings.catch_warnings(record=True) as w:
+            coeffs = silhouette_samples(Id, y_I, None, metric, None, backend, True)
+            assert issubclass(w[-1].category, UserWarning)
+
+        assert_close(coeffs, ones)
+        weighted_coeffs = silhouette_samples(
+            Id, y_I, ones / n, metric, DEVICE, backend, False
+        )
+        assert_close(coeffs, weighted_coeffs)
+        score = silhouette_score(Id, y_I, None, metric, DEVICE, backend)
+        assert_close(coeffs.mean(), score)
+        sampled_score = silhouette_score(Id, y_I, None, metric, DEVICE, backend, n)
+        assert_close(score, sampled_score)
+
+        # Test with equidistant samples
+        coeffs_2 = silhouette_samples(Id, y_I2, ones / n, metric, None, backend)
+        assert_close(coeffs_2, zeros)
+
+        weighted_coeffs_2 = silhouette_samples(
+            Id, y_I2, None, metric, DEVICE, backend, False
+        )
+        assert_close(coeffs_2, weighted_coeffs_2)
+
+        score_2 = silhouette_score(Id, y_I2, None, metric, DEVICE, backend)
+        assert_close(coeffs_2.mean(), score_2)
+
+    else:
+        with pytest.raises(ValueError):
+            _ = silhouette_samples(Id, y_I, None, metric, None, backend, True)
+
+
+@pytest.mark.parametrize("dtype", lst_types)
+@pytest.mark.parametrize("backend", lst_backend)
+def test_silhouette_score_precomputed(dtype, backend):
+    """Test silhouette score with precomputed distances."""
+    n = 10
+    Id = torch.eye(n, device=DEVICE, dtype=getattr(torch, dtype))
+    CI = pairwise_distances(Id, Id, "euclidean")
+    ones = torch.ones(n, device=DEVICE, dtype=getattr(torch, dtype))
+
+    y_I2 = []
+    for i in range(n // 2):
+        y_I2 += [i] * 2
+    y_I2 = torch.tensor(y_I2, device=DEVICE)
+
+    # Test with precomputed distances
+    coeffs_pre = silhouette_samples(CI, y_I2, None, "precomputed", None, backend, True)
+    coeffs = silhouette_samples(Id, y_I2, None, "euclidean", None, backend, True)
+
+    assert_close(coeffs_pre, coeffs)
+    weighted_coeffs_pre = silhouette_samples(
+        CI, y_I2, ones / n, "precomputed", DEVICE, backend, False
+    )
+    assert_close(coeffs_pre, weighted_coeffs_pre)
+    score_pre = silhouette_score(CI, y_I2, None, "precomputed", DEVICE, backend)
+    assert_close(coeffs_pre.mean(), score_pre)
+    sampled_score_pre = silhouette_score(
+        CI, y_I2, None, "precomputed", DEVICE, backend, n
+    )
+    assert_close(score_pre, sampled_score_pre)
+
+    # Test error cases
+    with pytest.raises(ValueError):
+        _ = silhouette_samples(
+            CI[:, :-2], y_I2, None, "precomputed", None, backend, True
+        )
+
+    with pytest.raises(ValueError):
+        _ = silhouette_score(CI[:, :-2], y_I2, None, "precomputed", None, backend, n)
+
+
+@pytest.mark.parametrize("dtype", lst_types)
+@pytest.mark.parametrize("backend", lst_backend)
+@pytest.mark.parametrize("metric", ["euclidean", "manhattan"])
+def test_consistency_sklearn(dtype, backend, metric):
+    """Test consistency with sklearn's silhouette score."""
+    n = 100
+    X, y = toy_dataset(n, dtype)
+
+    score_torchdr = silhouette_score(X, y, None, metric, DEVICE, backend)
+    score_sklearn = sk_silhouette_score(X, y, metric=metric)
+    assert (score_torchdr - score_sklearn) ** 2 < 1e-5, (
+        "Silhouette scores from torchdr and sklearn should be close."
+    )
+
+    # Generate noisy labels
+    y_noise = y.copy()
+    y_noise[: n // 2] = np.random.permutation(y_noise[: n // 2])
+
+    score_torchdr_noise = silhouette_score(X, y_noise, None, metric, DEVICE, backend)
+    score_sklearn_noise = sk_silhouette_score(X, y_noise, metric=metric)
+    assert (score_torchdr_noise - score_sklearn_noise) ** 2 < 1e-5, (
+        "Silhouette scores from torchdr and sklearn should be close on noised labels."
+    )
+
+
+@pytest.mark.parametrize("backend", lst_backend)
+def test_silhouette_with_faiss_config(backend):
+    """Test silhouette with FaissConfig object."""
+    if backend == "faiss" and faiss:
+        X, y = toy_dataset(100, "float32")
+
+        # Test with FaissConfig
+        config = FaissConfig(use_float16=False)
+        score_with_config = silhouette_score(X, y, backend=config)
+        score_with_string = silhouette_score(X, y, backend="faiss")
+
+        # Results should be similar (may have small differences due to implementation)
+        assert abs(score_with_config - score_with_string) < 0.01
+
+
+# ============================================================================
+# K-MEANS ARI TESTS
+# ============================================================================
+
+
+@pytest.mark.skipif(not faiss, reason="FAISS not installed")
+@pytest.mark.parametrize("dtype", lst_types)
+def test_kmeans_ari_basic(dtype):
+    """Test basic kmeans_ari functionality."""
+    try:
+        import torchmetrics  # noqa: F401
+    except ImportError:
+        pytest.skip("torchmetrics not installed")
+
+    X, y = toy_dataset(100, dtype)
+
+    # Test with numpy arrays
+    ari_score, pred_labels = kmeans_ari(X, y)
+    assert isinstance(ari_score, float)
+    assert isinstance(pred_labels, np.ndarray)
+    assert -1 <= ari_score <= 1
+    assert pred_labels.shape == (100,)
+
+    # Test with torch tensors
+    X_torch = torch.from_numpy(X)
+    y_torch = torch.from_numpy(y)
+    ari_score_torch, pred_labels_torch = kmeans_ari(X_torch, y_torch)
+    assert isinstance(ari_score_torch, torch.Tensor)
+    assert isinstance(pred_labels_torch, torch.Tensor)
+    assert -1 <= ari_score_torch <= 1
+    assert pred_labels_torch.shape == (100,)
+
+
+@pytest.mark.skipif(not faiss, reason="FAISS not installed")
+def test_kmeans_ari_n_clusters():
+    """Test kmeans_ari with different n_clusters settings."""
+    try:
+        import torchmetrics  # noqa: F401
+    except ImportError:
+        pytest.skip("torchmetrics not installed")
+
+    X, y = iris_dataset("float32")
+
+    # Test with automatic n_clusters (should use number of unique labels)
+    ari_auto, _ = kmeans_ari(X, y)
+
+    # Test with explicit n_clusters
+    ari_explicit, _ = kmeans_ari(X, y, n_clusters=3)
+
+    # Test with different n_clusters
+    ari_diff, pred_labels = kmeans_ari(X, y, n_clusters=4)
+    assert len(np.unique(pred_labels)) <= 4
+
+    # Test error cases
+    with pytest.raises(ValueError):
+        kmeans_ari(X, y, n_clusters=0)
+
+    with pytest.raises(ValueError):
+        kmeans_ari(X, y, n_clusters=len(X) + 1)
+
+
+@pytest.mark.skipif(not faiss, reason="FAISS not installed")
+def test_kmeans_ari_reproducibility():
+    """Test kmeans_ari reproducibility with random_state."""
+    try:
+        import torchmetrics  # noqa: F401
+    except ImportError:
+        pytest.skip("torchmetrics not installed")
+
+    X, y = toy_dataset(100, "float32")
+
+    # Test reproducibility
+    ari1, labels1 = kmeans_ari(X, y, random_state=42)
+    ari2, labels2 = kmeans_ari(X, y, random_state=42)
+
+    assert ari1 == ari2
+    assert np.array_equal(labels1, labels2)
+
+    # Test different random states give different results
+    ari3, labels3 = kmeans_ari(X, y, random_state=123)
+    # ARI might be similar but labels should differ
+    assert not np.array_equal(labels1, labels3)
+
+
+@pytest.mark.skipif(not faiss, reason="FAISS not installed")
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_kmeans_ari_gpu():
+    """Test kmeans_ari with GPU device."""
+    try:
+        import torchmetrics  # noqa: F401
+    except ImportError:
+        pytest.skip("torchmetrics not installed")
+
+    X, y = toy_dataset(100, "float32")
+    X_cuda = torch.from_numpy(X).cuda()
+    y_cuda = torch.from_numpy(y).cuda()
+
+    # Test with GPU tensors
+    ari_gpu, pred_labels_gpu = kmeans_ari(X_cuda, y_cuda, device="cuda")
+
+    assert isinstance(ari_gpu, torch.Tensor)
+    assert isinstance(pred_labels_gpu, torch.Tensor)
+    assert pred_labels_gpu.device.type == "cuda"
+
+
+@pytest.mark.skipif(not faiss, reason="FAISS not installed")
+def test_kmeans_ari_perfect_clustering():
+    """Test kmeans_ari with perfect clustering."""
+    try:
+        import torchmetrics  # noqa: F401
+    except ImportError:
+        pytest.skip("torchmetrics not installed")
+
+    # Create well-separated clusters
+    np.random.seed(42)
+    X1 = np.random.randn(50, 2) + np.array([0, 0])
+    X2 = np.random.randn(50, 2) + np.array([10, 10])
+    X3 = np.random.randn(50, 2) + np.array([-10, 10])
+    X = np.vstack([X1, X2, X3]).astype("float32")
+    y = np.array([0] * 50 + [1] * 50 + [2] * 50)
+
+    ari_score, pred_labels = kmeans_ari(X, y, n_clusters=3, nredo=5)
+
+    # With well-separated clusters, ARI should be high
+    assert ari_score > 0.8
+
+
+# ============================================================================
+# NEIGHBORHOOD PRESERVATION TESTS
+# ============================================================================
+
+
+@pytest.mark.parametrize("dtype", lst_types)
+@pytest.mark.parametrize("backend", lst_backend)
+def test_neighborhood_preservation_basic(dtype, backend):
+    """Test basic neighborhood preservation functionality."""
+    n = 50
+    d_high = 10
+    d_low = 2
+    K = 5
+
+    # Create random data
+    X = torch.randn(n, d_high, dtype=getattr(torch, dtype))
+    Z = torch.randn(n, d_low, dtype=getattr(torch, dtype))
+
+    score = neighborhood_preservation(X, Z, K, backend=backend)
+
+    assert 0 <= score <= 1
+    assert isinstance(score, float) or isinstance(score, torch.Tensor)
+
+
+@pytest.mark.parametrize("backend", lst_backend)
+def test_neighborhood_preservation_perfect(backend):
+    """Test neighborhood preservation with identical embeddings."""
+    n = 30
+    d = 5
+    K = 5
+
+    # When X and Z are identical, preservation should be perfect
+    X = torch.randn(n, d)
+    Z = X.clone()
+
+    score = neighborhood_preservation(X, Z, K, backend=backend)
+    assert_close(score, torch.tensor(1.0))
+
+
+@pytest.mark.parametrize("backend", lst_backend)
+def test_neighborhood_preservation_random(backend):
+    """Test neighborhood preservation with random embeddings."""
+    n = 50
+    d_high = 10
+    d_low = 2
+    K = 10
+
+    # Random embeddings should have low preservation
+    torch.manual_seed(42)
+    X = torch.randn(n, d_high)
+    Z = torch.randn(n, d_low)
+
+    score = neighborhood_preservation(X, Z, K, backend=backend)
+
+    # Random embeddings should have low but non-zero preservation
+    assert 0 < score < 0.5
+
+
+def test_neighborhood_preservation_numpy():
+    """Test neighborhood preservation with numpy arrays."""
+    n = 30
+    d_high = 10
+    d_low = 2
+    K = 5
+
+    # Test with numpy arrays
+    X_np = np.random.randn(n, d_high).astype("float32")
+    Z_np = np.random.randn(n, d_low).astype("float32")
+
+    score = neighborhood_preservation(X_np, Z_np, K)
+
+    assert isinstance(score, float)
+    assert 0 <= score <= 1
+
+
+def test_neighborhood_preservation_errors():
+    """Test neighborhood preservation error handling."""
+    X = torch.randn(50, 10)
+    Z = torch.randn(30, 2)  # Different number of samples
+
+    # Different number of samples
+    with pytest.raises(ValueError):
+        neighborhood_preservation(X, Z, K=5)
+
+    # K too large
+    X2 = torch.randn(10, 5)
+    Z2 = torch.randn(10, 2)
+    with pytest.raises(ValueError):
+        neighborhood_preservation(X2, Z2, K=10)
+
+    # K < 1
+    with pytest.raises(ValueError):
+        neighborhood_preservation(X2, Z2, K=0)
+
+
+@pytest.mark.parametrize("K", [1, 5, 10, 20])
+def test_neighborhood_preservation_different_k(K):
+    """Test neighborhood preservation with different K values."""
+    n = 50
+    X = torch.randn(n, 10)
+    Z = torch.randn(n, 2)
+
+    score = neighborhood_preservation(X, Z, K)
+    assert 0 <= score <= 1
+
+
+@pytest.mark.parametrize("metric", ["euclidean", "manhattan", "sqeuclidean"])
+def test_neighborhood_preservation_metrics(metric):
+    """Test neighborhood preservation with different metrics."""
+    X = torch.randn(30, 10)
+    Z = torch.randn(30, 2)
+
+    score = neighborhood_preservation(X, Z, K=5, metric=metric)
+    assert 0 <= score <= 1
+
+
+def test_neighborhood_preservation_with_faiss_config():
+    """Test neighborhood preservation with FaissConfig."""
+    if faiss:
+        X = torch.randn(100, 50)
+        Z = torch.randn(100, 2)
+
+        config = FaissConfig(use_float16=False)
+        score = neighborhood_preservation(X, Z, K=10, backend=config)
+        assert 0 <= score <= 1
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_neighborhood_preservation_gpu():
+    """Test neighborhood preservation on GPU."""
+    X = torch.randn(50, 10).cuda()
+    Z = torch.randn(50, 2).cuda()
+
+    score = neighborhood_preservation(X, Z, K=5, device="cuda")
+    assert 0 <= score <= 1
+
+
+def test_neighborhood_preservation_dimensionality_reduction():
+    """Test neighborhood preservation with actual DR scenario."""
+    from sklearn.decomposition import PCA
+
+    # Generate data with structure
+    X, _ = toy_dataset(100, "float32")
+
+    # Reduce dimensionality with PCA
+    pca = PCA(n_components=2)
+    Z = pca.fit_transform(X)
+
+    # PCA should preserve some neighborhood structure
+    score = neighborhood_preservation(X, Z, K=10)
+
+    # PCA preserves global structure, so should have reasonable preservation
+    assert score > 0.3
+
+
+# ============================================================================
+# INTEGRATION TESTS
+# ============================================================================
+
+
+@pytest.mark.parametrize("backend", lst_backend)
+def test_eval_functions_consistency(backend):
+    """Test that all eval functions work with same data and backends."""
+    X, y = toy_dataset(50, "float32")
+
+    # All functions should work with the same data
+    sil_score = silhouette_score(X, y, backend=backend)
+    assert -1 <= sil_score <= 1
+
+    if faiss:
+        try:
+            import torchmetrics  # noqa: F401
+
+            ari_score, _ = kmeans_ari(X, y)
+            assert -1 <= ari_score <= 1
+        except ImportError:
+            pass
+
+    # Create a simple embedding for neighborhood preservation
+    Z = X[:, :2]  # Use first 2 dimensions as embedding
+    np_score = neighborhood_preservation(X, Z, K=5, backend=backend)
+    assert 0 <= np_score <= 1
+
+
+def test_eval_functions_type_preservation():
+    """Test that eval functions preserve input types."""
+    X_np, y_np = toy_dataset(50, "float32")
+    X_torch = torch.from_numpy(X_np)
+    y_torch = torch.from_numpy(y_np)
+
+    # Test silhouette
+    sil_np = silhouette_score(X_np, y_np)
+    assert isinstance(sil_np, (float, np.floating))
+
+    sil_torch = silhouette_score(X_torch, y_torch)
+    assert isinstance(sil_torch, torch.Tensor)
+
+    # Test neighborhood preservation
+    Z_np = X_np[:, :2]
+    Z_torch = X_torch[:, :2]
+
+    np_score_np = neighborhood_preservation(X_np, Z_np, K=5)
+    assert isinstance(np_score_np, (float, np.floating))
+
+    np_score_torch = neighborhood_preservation(X_torch, Z_torch, K=5)
+    assert isinstance(np_score_torch, torch.Tensor)
+
+
+# ============================================================================
+# BENCHMARKING TESTS (optional, for performance)
+# ============================================================================
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("n_samples", [100, 500, 1000])
+@pytest.mark.parametrize("backend", lst_backend)
+def test_eval_performance(n_samples, backend):
+    """Benchmark eval functions with different data sizes."""
+    import time
+
+    X = np.random.randn(n_samples, 50).astype("float32")
+    y = np.random.randint(0, 10, n_samples)
+    Z = np.random.randn(n_samples, 2).astype("float32")
+
+    # Time silhouette score
+    start = time.time()
+    _ = silhouette_score(X, y, backend=backend)
+    sil_time = time.time() - start
+
+    # Time neighborhood preservation
+    start = time.time()
+    _ = neighborhood_preservation(X, Z, K=10, backend=backend)
+    np_time = time.time() - start
+
+    print(f"\nBackend: {backend}, N={n_samples}")
+    print(f"Silhouette time: {sil_time:.3f}s")
+    print(f"Neighborhood preservation time: {np_time:.3f}s")
+
+    # Just ensure they complete without error
+    assert sil_time < 60  # Should complete within 60 seconds
+    assert np_time < 60


### PR DESCRIPTION
- Create torchdr/eval/ module for evaluation metrics
- Move silhouette score functions from eval.py to eval/silhouette.py
- Add kmeans_ari function for K-means clustering with Adjusted Rand Index
- Add neighborhood_preservation function for k-NN preservation metric
- Update all functions to support FaissConfig backend parameter
- Add comprehensive test suite in test_eval_comprehensive.py
- Add torchmetrics to optional dependencies for ARI computation

This reorganization improves code organization and adds new evaluation metrics for assessing dimensionality reduction quality.

## Description

<!--- What types of changes does your code introduce? -->

<!--- Please link to an existing issue here if one exists. -->


## Checklist

<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**How to Contribute**](https://torchdr.github.io/torchdr.contributing.html) document.
- [ ] The documentation is up-to-date with the changes I made (check build artifacts).
- [ ] All tests passed, and additional code has been **covered with new tests**.
- [ ] I have added the PR to the [**RELEASES.rst**](RELEASES.rst) file.
