### PR TITLE
[Feature] Fix memory leak in AffinityMatcher by freeing input data after initialization

### DIFF
--- a/torchdr/affinity_matcher.py
+++ b/torchdr/affinity_matcher.py
@@ -260,9 +260,11 @@ class AffinityMatcher(DRModule):
         self._configure_scheduler()
 
         # Free input data - no longer needed after initialization
-        del X
-        if torch.cuda.is_available():
-            torch.cuda.empty_cache()
+        # (except when precomputed, where X is the affinity matrix itself)
+        if self.affinity_in != "precomputed":
+            del X
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
 
         grad_norm = float("nan")
         for step in range(self.max_iter):


### PR DESCRIPTION
## Summary
Fixes a significant memory leak in `AffinityMatcher` where the input tensor `X` was retained in GPU memory throughout the entire optimization loop, even though it's only needed during initialization.

## Problem
- Input tensor `X` was never deleted after affinity computation and embedding initialization
- For large datasets, this caused significant GPU memory waste
- In multi-GPU setups, the issue was amplified across all devices
- Led to OOM errors when training on datasets larger than 90M samples

## Solution
- Explicitly delete `X` after `_configure_scheduler()`
- Clear CUDA cache to immediately free GPU memory
- This is safe because `X` is not used during the optimization loop

## Impact
**Memory savings:**
- Single dataset example (95M samples × 10 features): **3.56 GB per GPU**
- Multi-GPU setup (8 GPUs): **28.5 GB total savings**

**Results:**
- ✅ Successfully tested with 90M samples on 8 B200 GPUs (previously OOM)
- ✅ Enables fitting larger datasets without memory errors
- ✅ No impact on accuracy or convergence

## Testing
- Tested with UMAP on Tahoe-100M dataset (95.6M cells)
- Multi-GPU distributed training with 8 GPUs
- Confirmed memory reduction via `nvidia-smi` monitoring

## Checklist
- [x] Code follows project style guidelines (passed pre-commit hooks)
- [x] Tested on large-scale multi-GPU setup
- [x] No breaking changes to API
- [x] Memory leak confirmed fixed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> After initializing and configuring training, delete `X` (when not `precomputed`) and clear CUDA cache to free GPU memory during optimization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 490b4bce348d364e7b42c70199c04ab86b98ab14. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->