### PR TITLE
[Fix] Update codecov action from v4.0.1 to v5

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -45,7 +45,7 @@ jobs:
         run: pytest torchdr/ --verbose --cov=torchdr torchdr/ --cov-report term
       # Codecov
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4.0.1
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: TorchDR/TorchDR
@@ -84,7 +84,7 @@ jobs:
         run: pytest torchdr/ --verbose --cov=torchdr torchdr/ --cov-report term
       # Codecov
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4.0.1
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: TorchDR/TorchDR
@@ -121,7 +121,7 @@ jobs:
       - name: Run Tests
         run: pytest torchdr/tests/test_utils.py --verbose --cov=torchdr torchdr/ --cov-report term
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4.0.1
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: TorchDR/TorchDR


### PR DESCRIPTION
## Summary
- Updates codecov/codecov-action from v4.0.1 to v5 in all three test jobs

## Problem
The codecov action v4.0.1 was failing with the following errors:
- `write EPIPE` error during GPG signature verification
- `SyntaxError: Unexpected token '<', "<!DOCTYPE "... is not valid JSON` when fetching version info

## Solution
Upgrade to v5 which resolves these API compatibility issues.

## Test plan
- [ ] Verify CI tests pass successfully
- [ ] Verify codecov reports are uploaded correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Upgrade Codecov upload action to v5 across all jobs in `.github/workflows/testing.yml`.
> 
> - **CI / GitHub Actions** (`.github/workflows/testing.yml`):
>   - Update `codecov/codecov-action` from `v4.0.1` to `v5` in:
>     - `Test`
>     - `Test-minimal`
>     - `Test-faiss`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 707531a45f2f5657ec889f24d135bf0268fa2cc1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->