### PR TITLE
[Feature] Add automatic releases via GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Release
+
+on:
+  push:
+    tags:
+      # Publish on version tags with or without `v` prefix
+      # Supports: v0.4.0, 0.4.0, v0.4, 0.4
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+'
+
+jobs:
+  pypi:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    # Environment for trusted publishing
+    environment:
+      name: release
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Install Python 3.10
+        run: uv python install 3.10
+
+      - name: Build
+        run: uv build
+
+      - name: Publish
+        run: uv publish

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ share/python-wheels/
 *.egg
 MANIFEST
 
+# Auto-generated version file
+torchdr/_version.py
+
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,95 @@
+# Release Process
+
+TorchDR uses automated releases via GitHub Actions. Versions are automatically extracted from git tags using `setuptools-scm`.
+
+## Creating a New Release
+
+### 1. Prepare the release
+
+```bash
+# Update RELEASES.rst with changelog for the new version
+# Commit any final changes
+git add RELEASES.rst
+git commit -m "Prepare release v0.4.0"
+git push
+```
+
+### 2. Create and push a version tag
+
+```bash
+# Create a new tag (use v prefix for consistency)
+git tag v0.4.0
+
+# Push the tag to trigger automatic release
+git push origin v0.4.0
+```
+
+### 3. Automated workflow
+
+Once the tag is pushed, GitHub Actions will automatically:
+- Build the package (both wheel and source distribution)
+- Extract version `0.4.0` from the tag `v0.4.0`
+- Publish to PyPI via trusted publishing
+
+### 4. Verify the release
+
+- Check the [Actions tab](https://github.com/TorchDR/TorchDR/actions) for workflow status
+- Once complete, verify on [PyPI](https://pypi.org/project/torchdr/)
+
+## Version Numbering
+
+TorchDR follows [Semantic Versioning](https://semver.org/):
+- **Major** (X.0.0): Breaking changes
+- **Minor** (0.X.0): New features, backward compatible
+- **Patch** (0.0.X): Bug fixes, backward compatible
+
+Supported tag formats (all work the same):
+- `v0.4.0` ✅ (recommended)
+- `0.4.0` ✅
+- `v0.4` ✅
+- `0.4` ✅
+
+## Development Versions
+
+Between releases, `setuptools-scm` automatically generates development versions:
+- Format: `0.3.dev44+g0d06a62.d20251110`
+  - `0.3`: Base version from latest tag
+  - `dev44`: 44 commits since that tag
+  - `g0d06a62`: Current commit hash
+  - `d20251110`: Date
+
+## PyPI Trusted Publishing Setup
+
+The release workflow uses [PyPI Trusted Publishing](https://docs.pypi.org/trusted-publishers/) which is more secure than API tokens.
+
+To configure (one-time setup for new maintainers):
+1. Go to [PyPI project settings](https://pypi.org/manage/project/torchdr/settings/publishing/)
+2. Add a new "Trusted Publisher":
+   - **Owner**: TorchDR
+   - **Repository**: TorchDR
+   - **Workflow**: release.yml
+   - **Environment**: release
+
+## Troubleshooting
+
+### Tag already exists
+```bash
+# Delete local tag
+git tag -d v0.4.0
+
+# Delete remote tag
+git push origin :refs/tags/v0.4.0
+
+# Create new tag
+git tag v0.4.0
+git push origin v0.4.0
+```
+
+### Release failed
+- Check GitHub Actions logs for errors
+- Verify PyPI trusted publishing is configured
+- Ensure the tag matches the version pattern
+
+### Wrong version published
+- Yank the bad release on PyPI (doesn't delete it)
+- Fix the issue and create a new patch release

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,8 +52,10 @@ dynamic = ["version"]
 [tool.setuptools]
 packages = ["torchdr"]
 
-[tool.setuptools.dynamic]
-version = {attr = "torchdr.__about__.__version__"}
+[tool.setuptools_scm]
+version_file = "torchdr/_version.py"
+version_file_template = "__version__ = \"{version}\"\n"
+tag_regex = "^v?(?P<version>\\d+\\.\\d+(\\.\\d+)?)$"
 
 [project.urls]
 homepage = "https://torchdr.github.io/"

--- a/torchdr/__about__.py
+++ b/torchdr/__about__.py
@@ -2,6 +2,10 @@
 #
 # License: BSD 3-Clause License
 
+try:
+    from torchdr._version import __version__
+except ImportError:
+    __version__ = "0.0.0+unknown"
 
 __all__ = [
     "__title__",
@@ -14,7 +18,6 @@ __all__ = [
 
 __title__ = "torchdr"
 __summary__ = "Dimensionality Reduction Library using PyTorch"
-__version__ = "0.3"
 __author__ = "Hugues Van Assel"
 __license__ = "BSD-3-Clause-Clear"
 __url__ = "https://torchdr.github.io/"


### PR DESCRIPTION
## Summary

Implement automated PyPI releases triggered by git tags, using `setuptools-scm` for version management and GitHub Actions trusted publishing for secure deployment.

## Changes

### Version Management
- **Switch to setuptools-scm**: Version now automatically extracted from git tags instead of hardcoded in `__about__.py`
- **Backward compatibility**: `__about__.py` now imports from auto-generated `_version.py` with fallback for development
- **Development versions**: Between releases, versions like `0.3.dev44+g0d06a62.d20251110` are auto-generated

### GitHub Actions Workflow
- **New workflow**: `.github/workflows/release.yml` triggers on version tag push
- **Supported tag formats**: `v0.4.0`, `0.4.0`, `v0.4`, `0.4` (all work)
- **Uses `uv`**: Fast modern Python package manager for building and publishing
- **Trusted publishing**: Secure OIDC-based authentication (no API tokens needed)

### Documentation
- **RELEASING.md**: Complete guide for maintainers on creating releases
- **Setup instructions**: How to configure PyPI trusted publishing

### Configuration
- **pyproject.toml**: Added `[tool.setuptools_scm]` configuration with flexible tag regex
- **.gitignore**: Ignore auto-generated `torchdr/_version.py`

## Testing

Local build tested successfully:
```bash
$ uv build
# Built: torchdr-0.3.dev44+g0d06a62.d20251110.tar.gz
#        torchdr-0.3.dev44+g0d06a62.d20251110-py3-none-any.whl

$ python -c "import torchdr; print(torchdr.__version__)"
0.3.dev44+g0d06a62.d20251110
```

## Next Steps (After Merge)

1. **Configure PyPI trusted publishing**:
   - Go to https://pypi.org/manage/project/torchdr/settings/publishing/
   - Add trusted publisher with:
     - Owner: `TorchDR`
     - Repository: `TorchDR`
     - Workflow: `release.yml`
     - Environment: `release`

2. **Create GitHub environment**:
   - Settings → Environments → New environment: `release`
   - (Optional) Add protection rules

3. **Test with first release**:
   ```bash
   git tag v0.4.0
   git push origin v0.4.0
   ```

## Benefits

- ✅ Single source of truth for version (git tags)
- ✅ No manual version updates needed
- ✅ Automatic PyPI publishing on tag push
- ✅ Secure (no API tokens to manage)
- ✅ Development versions automatically tracked
- ✅ Standard modern Python packaging practices

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Automates PyPI releases from git tags and migrates versioning to setuptools-scm, with accompanying config and docs.
> 
> - **CI/Release**:
>   - Add `/.github/workflows/release.yml` to build (`uv build`) and publish (`uv publish`) on version tag pushes; uses OIDC permissions and `release` environment.
> - **Packaging/Versioning**:
>   - Switch to `setuptools-scm` for dynamic versions; add `[tool.setuptools_scm]` in `pyproject.toml` with `version_file`, template, and `tag_regex`.
>   - Update `torchdr/__about__.py` to import `__version__` from generated `torchdr/_version.py` with fallback.
>   - Ignore auto-generated `torchdr/_version.py` in `.gitignore`.
> - **Docs**:
>   - Add `RELEASING.md` with release steps and PyPI Trusted Publishing setup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit becfaff168b2a73edca23f6741dc34b376fc8449. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->