### PR TITLE
[Fix] Remove use_float16 parameter from FaissConfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,6 +140,7 @@ docs/source/sg_execution_times.rst
 # Misc
 .DS_Store
 .vscode
+.claude/
 dev
 
 # Data

--- a/torchdr/affinity/base.py
+++ b/torchdr/affinity/base.py
@@ -45,7 +45,7 @@ class Affinity(nn.Module, ABC):
         - "faiss": Use FAISS for fast k-NN computations with default settings
         - None: Use standard PyTorch operations
         - FaissConfig object: Use FAISS with custom configuration
-          (e.g., FaissConfig(use_float16=True, temp_memory=2.0))
+          (e.g., FaissConfig(temp_memory=2.0))
         Default is None.
     verbose : bool, optional
         Verbosity. Default is False.
@@ -375,20 +375,16 @@ class SparseAffinity(Affinity):
             if isinstance(backend, FaissConfig):
                 # Copy all parameters from the user's config, but override device
                 self._distributed_faiss_config = FaissConfig(
-                    use_float16=backend.use_float16,
                     temp_memory=backend.temp_memory,
                     device=local_rank,  # Override with current GPU
                     index_type=backend.index_type,
                     nprobe=backend.nprobe,
                     nlist=backend.nlist,
+                    **backend.faiss_kwargs,
                 )
             else:
                 # Create default config for this GPU
-                self._distributed_faiss_config = FaissConfig(
-                    use_float16=False,  # Better precision for affinity computations
-                    temp_memory="auto",
-                    device=local_rank,
-                )
+                self._distributed_faiss_config = FaissConfig(device=local_rank)
         else:
             self.rank = 0
             self.world_size = 1

--- a/torchdr/distance/base.py
+++ b/torchdr/distance/base.py
@@ -78,12 +78,8 @@ def pairwise_distances(
     >>> X = torch.randn(1000, 128)
     >>> distances = pairwise_distances(X, k=10, backend='faiss')
 
-    >>> # With float16 precision for GPU
-    >>> config = FaissConfig(use_float16=True)
-    >>> distances = pairwise_distances(X.cuda(), k=10, backend=config)
-
     >>> # Using FaissConfig with custom settings
-    >>> config = FaissConfig(use_float16=True, temp_memory=2.0)
+    >>> config = FaissConfig(temp_memory=2.0)
     >>> distances = pairwise_distances(X.cuda(), k=10, backend=config)
     """
     # Parse backend parameter

--- a/torchdr/tests/test_eval_comprehensive.py
+++ b/torchdr/tests/test_eval_comprehensive.py
@@ -171,7 +171,7 @@ def test_silhouette_with_faiss_config(backend):
         X, y = toy_dataset(100, "float32")
 
         # Test with FaissConfig
-        config = FaissConfig(use_float16=False)
+        config = FaissConfig()
         score_with_config = silhouette_score(X, y, backend=config)
         score_with_string = silhouette_score(X, y, backend="faiss")
 
@@ -428,7 +428,7 @@ def test_neighborhood_preservation_with_faiss_config():
         X = torch.randn(100, 50)
         Z = torch.randn(100, 2)
 
-        config = FaissConfig(use_float16=False)
+        config = FaissConfig()
         score = neighborhood_preservation(X, Z, K=10, backend=config)
         assert 0 <= score <= 1
 


### PR DESCRIPTION
## Summary

Remove the `use_float16` parameter from `FaissConfig` as it produces poor quality results and should not be presented as a standard option to users.

## Changes

- Convert `FaissConfig` from dataclass to regular class with `**kwargs` support
- Remove `use_float16` as an explicit parameter
- Add kwargs support for advanced FAISS options if users need them
- Update all documentation and examples to remove float16 references
- Update tests to remove `use_float16=False` parameters
- Fix `temp_memory` docstring to accurately describe FAISS defaults
- Add `.claude/` to `.gitignore`

## Rationale

Float16 precision in FAISS significantly degrades result quality for dimensionality reduction tasks. While it offers memory savings, the accuracy trade-off is too steep for most use cases. 

Users who absolutely need float16 for extreme memory constraints can still pass it via kwargs (e.g., `FaissConfig(useFloat16=True)`), but it is no longer a recommended or easily discoverable option.

## Test plan

- [x] All existing tests pass
- [x] Pre-commit hooks pass (ruff, codespell, etc.)
- [x] Updated tests to remove `use_float16` parameter usage

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes `use_float16` from `FaissConfig`, adds `**kwargs` support, updates FAISS GPU/index setup and distributed affinity usage, refreshes examples/tests, and ignores `.claude/`.
> 
> - **FAISS config**:
>   - Convert `FaissConfig` from dataclass to class; remove `use_float16` parameter; add `**kwargs` passthrough via `faiss_kwargs` and `__repr__`.
>   - Clarify `temp_memory` behavior in docstring/examples.
> - **Distance/FAISS backend**:
>   - Update `pairwise_distances`/`pairwise_distances_faiss` examples to drop float16 mentions.
>   - In `_setup_gpu_index`, stop setting `useFloat16`; apply extra kwargs to `GpuIndexFlatConfig`/`GpuIndexIVFFlatConfig`.
> - **Affinity (distributed)**:
>   - Build per-GPU `FaissConfig` without `use_float16`; propagate `**backend.faiss_kwargs` and set device via `LOCAL_RANK`.
> - **Tests**:
>   - Remove `use_float16=False` from `FaissConfig` usages in `test_eval_comprehensive.py`.
> - **Repo hygiene**:
>   - Add `.claude/` to `.gitignore`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ac61bd89ddb744cab99b3a94816dadc4cc8c5f7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->