### PR TITLE
[Fix] release badge GitHub token pool error

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![Documentation](https://img.shields.io/badge/Documentation-blue.svg)](https://torchdr.github.io/)
 [![Benchmark](https://img.shields.io/badge/Benchmarks-blue.svg)](https://github.com/TorchDR/TorchDR/tree/main/benchmarks)
-[![Version](https://img.shields.io/github/v/release/TorchDR/TorchDR.svg?color=blue)](https://github.com/TorchDR/TorchDR/releases)
+[![Version](https://img.shields.io/github/v/release/TorchDR/TorchDR.svg?color=blue&cacheSeconds=3600)](https://github.com/TorchDR/TorchDR/releases)
 [![License](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 [![Python 3.8+](https://img.shields.io/badge/python-3.8%2B-blue.svg)](https://www.python.org/downloads/release/python-3100/)
 [![Pytorch](https://img.shields.io/badge/PyTorch-ee4c2c?logo=pytorch&logoColor=white)](https://pytorch.org/get-started/locally/)


### PR DESCRIPTION
## Summary
Fix the intermittent "unable to select next Github token from pool" error on the release badge by adding a 1-hour cache parameter.

## Problem
The Version badge uses shields.io which queries GitHub's API to fetch release information. When shields.io exhausts its GitHub API rate limit tokens (60 requests/hour without auth), the badge displays "unable to select next Github token from pool" instead of the version number.

## Solution
Add `cacheSeconds=3600` parameter to the shields.io badge URL. This:
- Reduces API calls by caching the badge for 1 hour
- Eliminates rate limit issues since releases happen infrequently
- Maintains consistency with other shields.io badges in the README
- Uses shields.io's official solution for rate limiting

## Changes
- Updated README.md line 9: Added `&cacheSeconds=3600` to the Version badge URL

Since releases happen weeks/months apart, a 1-hour cache delay is completely acceptable and won't impact users seeing the latest version.