### PR TITLE
[BugFix] TSNEkhorn docstring: rename jit_compile to compile

### DIFF
--- a/torchdr/neighbor_embedding/tsnekhorn.py
+++ b/torchdr/neighbor_embedding/tsnekhorn.py
@@ -107,7 +107,7 @@ class TSNEkhorn(NeighborEmbedding):
         entropic affinity. Default is True.
     check_interval : int, optional
         Interval for checking the convergence of the algorithm, by default 50.
-    jit_compile : bool, optional
+    compile : bool, optional
         Whether to compile the algorithm using torch.compile. Default is False.
     """  # noqa: E501
 


### PR DESCRIPTION
The docstring incorrectly documented the parameter as `jit_compile` when the actual parameter name is `compile`. This fixes issue #235.

## Description

<!--- What types of changes does your code introduce? -->

<!--- Please link to an existing issue here if one exists. -->


## Checklist

<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**How to Contribute**](https://torchdr.github.io/torchdr.contributing.html) document.
- [ ] The documentation is up-to-date with the changes I made (check build artifacts).
- [ ] All tests passed, and additional code has been **covered with new tests**.
- [ ] I have added the PR to the [**RELEASES.rst**](RELEASES.rst) file.
