### PR TITLE
[Log] Add warning when distributed launch detected without GPU

### DIFF
--- a/torchdr/distributed/__init__.py
+++ b/torchdr/distributed/__init__.py
@@ -11,6 +11,7 @@ utilities for managing distributed multi-GPU computation.
 
 import atexit
 import os
+import warnings
 from typing import Tuple
 
 import torch
@@ -37,6 +38,15 @@ def _auto_setup_distributed():
     if "LOCAL_RANK" in os.environ and not dist.is_initialized():
         # Only setup distributed for GPU training
         if not torch.cuda.is_available():
+            warnings.warn(
+                "Distributed launch detected (LOCAL_RANK is set) but no GPU is "
+                "available. Distributed mode will not be initialized. "
+                "CPU workloads already leverage multi-threading and don't benefit "
+                "from multi-process distribution. Run without torchrun for best "
+                "CPU performance.",
+                UserWarning,
+                stacklevel=2,
+            )
             return
 
         local_rank = int(os.environ["LOCAL_RANK"])


### PR DESCRIPTION
When users launch scripts with torchrun on CPU-only machines, the distributed setup silently skips initialization, leading to multiple redundant processes running the same work. This adds a clear warning explaining that distributed mode is not initialized and that CPU workloads don't benefit from multi-process distribution.

Fixes the silent failure case where LOCAL_RANK is set but no GPU is available.

## Description

<!--- What types of changes does your code introduce? -->

<!--- Please link to an existing issue here if one exists. -->


## Checklist

<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**How to Contribute**](https://torchdr.github.io/torchdr.contributing.html) document.
- [ ] The documentation is up-to-date with the changes I made (check build artifacts).
- [ ] All tests passed, and additional code has been **covered with new tests**.
- [ ] I have added the PR to the [**RELEASES.rst**](RELEASES.rst) file.
