### PR TITLE
[Fix] Use --standalone in CLI to avoid port conflicts

### DIFF
--- a/torchdr/cli.py
+++ b/torchdr/cli.py
@@ -106,8 +106,10 @@ Arguments after the script name are passed directly to your script.
     print("  Backend: nccl")
 
     # Build torchrun command (single-node only)
+    # Use --standalone to avoid port conflicts on shared systems (uses localhost:0)
     cmd = [
         "torchrun",
+        "--standalone",
         f"--nproc_per_node={n_gpus}",
         args.script,
     ]

--- a/torchdr/tests/test_cli.py
+++ b/torchdr/tests/test_cli.py
@@ -45,6 +45,7 @@ class TestMain:
         mock_run.assert_called_once()
         cmd = mock_run.call_args[0][0]
         assert "torchrun" in cmd
+        assert "--standalone" in cmd
         assert "--nproc_per_node=4" in cmd
         assert "script.py" in cmd
 
@@ -61,6 +62,7 @@ class TestMain:
 
         assert exc_info.value.code == 0
         cmd = mock_run.call_args[0][0]
+        assert "--standalone" in cmd
         assert "--nproc_per_node=2" in cmd
 
     @patch("torchdr.cli.get_gpu_count")
@@ -100,6 +102,7 @@ class TestMain:
         assert "Warning" in captured.err
         # Should use only 2 GPUs
         cmd = mock_run.call_args[0][0]
+        assert "--standalone" in cmd
         assert "--nproc_per_node=2" in cmd
 
     @patch("torchdr.cli.subprocess.run")
@@ -117,6 +120,7 @@ class TestMain:
                 main()
 
         cmd = mock_run.call_args[0][0]
+        assert "--standalone" in cmd
         assert "--data" in cmd
         assert "/path" in cmd
         assert "--epochs" in cmd


### PR DESCRIPTION
## Summary

- Add `--standalone` flag to `torchrun` command in CLI to avoid port conflicts on shared HPC/SLURM nodes
- The default port 29500 caused `EADDRINUSE` errors when multiple jobs ran concurrently
- `--standalone` is PyTorch's official solution for single-node training, using `localhost:0` (OS-assigned free port)

## Test plan

- [x] Unit tests updated and passing
- [ ] Manual test: Run two concurrent `torchdr --gpus 1 script.py` commands on same node

Closes #249