### PR TITLE
[Feature] Add non-parametric transform for UMAP, LargeVis, and InfoTSNE

### DIFF
--- a/docs/source/torchdr.user_guide.rst
+++ b/docs/source/torchdr.user_guide.rst
@@ -134,6 +134,60 @@ In the above table, :math:`\mathrm{Neg}(i)` denotes the set of negative samples
 for point :math:`i`. They are usually sampled uniformly at random from the dataset.
 
 
+.. _non-parametric-transform-section:
+
+
+Transforming New Data with a Frozen Reference Embedding
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+:class:`UMAP <UMAP>`, :class:`LargeVis <LargeVis>`, and
+:class:`InfoTSNE <InfoTSNE>` support out-of-sample transformation. This makes it
+possible to fit a reference embedding once and then place unseen observations in
+the same low-dimensional space without moving the reference points::
+
+    from torchdr import UMAP
+
+    model = UMAP(n_neighbors=15, device="cuda")
+    Z_reference = model.fit_transform(X_reference)
+    Z_query = model.transform(X_query, X_train=X_reference)
+
+These methods are non-parametric: fitting does not learn an encoder that can be
+directly evaluated on ``X_query``. Instead, ``transform`` constructs a bipartite
+neighborhood graph between the query and reference observations. For every
+query observation, TorchDR:
+
+1. finds its nearest neighbors in ``X_train``;
+2. converts their input-space distances into method-specific affinity weights;
+3. initializes its position from the weighted average of the corresponding
+   reference embedding coordinates; and
+4. optimizes only the query coordinate, using the fitted reference embedding as
+   a frozen set of attractive neighbors and repulsive negative samples.
+
+Only the fitted reference embedding is retained by the estimator. The original
+input features are not stored, which avoids keeping another potentially large
+copy of the training data. Consequently, ``X_train`` passed to ``transform``
+must contain the exact samples used during fitting, in the same row order. The
+query and reference arrays must also have the same number of features and must
+use the same preprocessing. For example, when using a fitted scaler or PCA
+model, apply its ``transform`` method to both arrays before passing them to
+TorchDR.
+
+.. note::
+
+    Non-parametric transformation still performs nearest-neighbor search and a
+    short iterative optimization. It is therefore more expensive than applying
+    a learned encoder, but cheaper than fitting a new joint embedding. The
+    result is also not equivalent to calling ``fit_transform`` on the
+    concatenation of the reference and query data: reference coordinates remain
+    fixed, and the bipartite graph contains no query-to-query edges. This
+    transform path is intended for a single process and device rather than
+    distributed multi-GPU inference.
+
+For a complete reference/query workflow with preprocessing, visualization, and
+label-transfer evaluation, see
+:ref:`sphx_glr_auto_examples_basics_demo_non_parametric_transform_digits.py`.
+
+
 .. _spectral-section:
 
 

--- a/examples/basics/demo_non_parametric_transform_digits.py
+++ b/examples/basics/demo_non_parametric_transform_digits.py
@@ -1,0 +1,154 @@
+r"""
+Non-Parametric UMAP Transform on Handwritten Digits
+==================================================
+
+We fit a reference UMAP embedding on one subset of the sklearn handwritten
+digits dataset and then map unseen samples with :meth:`torchdr.UMAP.transform`
+instead of refitting on the full dataset. This mimics a deployment workflow
+where a reference embedding is already available and new samples only arrive
+with their input features.
+
+We use the built-in digits dataset rather than full MNIST so the example stays
+fully self-contained and lightweight enough for the documentation gallery. We
+report a simple deployment metric:
+10-NN label transfer accuracy from the reference embedding to the transformed
+query points.
+
+"""
+
+# Author: OpenAI Codex
+#
+# License: BSD 3-Clause License
+
+import os
+
+import matplotlib.pyplot as plt
+from sklearn.datasets import load_digits
+from sklearn.decomposition import PCA
+from sklearn.model_selection import train_test_split
+from sklearn.neighbors import KNeighborsClassifier
+
+from torchdr import UMAP
+
+
+RANDOM_STATE = 0
+N_REFERENCE = int(os.environ.get("TORCHDR_EXAMPLE_N_REFERENCE", "1200"))
+N_QUERY = int(os.environ.get("TORCHDR_EXAMPLE_N_QUERY", "500"))
+PCA_DIM = 50
+MAX_ITER = int(os.environ.get("TORCHDR_EXAMPLE_MAX_ITER", "100"))
+
+
+# %%
+# Load handwritten digits and prepare a reference/query split
+# -----------------------------------------------------------
+#
+# We keep a reference pool that is used during fitting and a disjoint query pool
+# that is embedded later only through :meth:`transform`.
+
+digits = load_digits()
+X = (digits.data / 16.0).astype("float32")
+y = digits.target.astype("int64")
+
+X_subset, _, y_subset, _ = train_test_split(
+    X,
+    y,
+    train_size=N_REFERENCE + N_QUERY,
+    stratify=y,
+    random_state=RANDOM_STATE,
+)
+
+X_reference, X_query, y_reference, y_query = train_test_split(
+    X_subset,
+    y_subset,
+    train_size=N_REFERENCE,
+    test_size=N_QUERY,
+    stratify=y_subset,
+    random_state=RANDOM_STATE,
+)
+
+
+# %%
+# Preprocess features and fit the reference embedding
+# ---------------------------------------------------
+#
+# We reduce the input features with PCA before fitting UMAP, then transform the
+# held-out query set with the non-parametric transform path.
+
+pca = PCA(n_components=PCA_DIM)
+X_reference_pca = pca.fit_transform(X_reference).astype("float32")
+X_query_pca = pca.transform(X_query).astype("float32")
+
+umap = UMAP(
+    n_components=2,
+    n_neighbors=15,
+    max_iter=MAX_ITER,
+    init="normal",
+    optimizer="SGD",
+    backend=None,
+    device="cpu",
+    random_state=RANDOM_STATE,
+)
+
+Z_reference = umap.fit_transform(X_reference_pca)
+Z_query = umap.transform(X_query_pca, X_train=X_reference_pca)
+
+
+# %%
+# Evaluate deployment-time label transfer
+# ---------------------------------------
+#
+# In a production setting, a simple use case is to classify or annotate new
+# points by comparing them to the already embedded reference set.
+
+knn = KNeighborsClassifier(n_neighbors=10)
+knn.fit(Z_reference, y_reference)
+label_transfer_accuracy = knn.score(Z_query, y_query)
+
+print(f"Reference samples: {len(X_reference_pca)}")
+print(f"Query samples: {len(X_query_pca)}")
+print(f"10-NN label transfer accuracy: {label_transfer_accuracy:.3f}")
+
+
+# %%
+# Visualize the reference and transformed query points
+# ----------------------------------------------------
+
+fig, axes = plt.subplots(1, 2, figsize=(12, 5))
+
+axes[0].scatter(
+    Z_reference[:, 0],
+    Z_reference[:, 1],
+    c=y_reference,
+    cmap="tab10",
+    s=4,
+    alpha=0.45,
+)
+axes[0].set_title("Reference embedding")
+axes[0].set_xticks([])
+axes[0].set_yticks([])
+
+axes[1].scatter(
+    Z_reference[:, 0],
+    Z_reference[:, 1],
+    c="lightgray",
+    s=3,
+    alpha=0.12,
+)
+scatter = axes[1].scatter(
+    Z_query[:, 0],
+    Z_query[:, 1],
+    c=y_query,
+    cmap="tab10",
+    s=7,
+    alpha=0.8,
+)
+axes[1].set_title(
+    f"Held-out query points\n10-NN transfer accuracy = {label_transfer_accuracy:.3f}"
+)
+axes[1].set_xticks([])
+axes[1].set_yticks([])
+
+handles, labels = scatter.legend_elements(prop="colors")
+fig.legend(handles, labels, loc="lower center", ncol=10, frameon=False)
+plt.subplots_adjust(bottom=0.16, wspace=0.08)
+plt.show()

--- a/examples/basics/demo_non_parametric_transform_digits.py
+++ b/examples/basics/demo_non_parametric_transform_digits.py
@@ -9,10 +9,10 @@ where a reference embedding is already available and new samples only arrive
 with their input features.
 
 We use the built-in digits dataset rather than full MNIST so the example stays
-fully self-contained and lightweight enough for the documentation gallery. We
-report a simple deployment metric:
-10-NN label transfer accuracy from the reference embedding to the transformed
-query points.
+fully self-contained and lightweight enough for the documentation gallery. By
+default, we fit the reference embedding on 1,400 points and transform 300
+inference-only query points. We report a simple deployment metric: 10-NN label
+transfer accuracy from the reference embedding to the transformed query points.
 
 """
 
@@ -32,10 +32,10 @@ from torchdr import UMAP
 
 
 RANDOM_STATE = 0
-N_REFERENCE = int(os.environ.get("TORCHDR_EXAMPLE_N_REFERENCE", "1200"))
-N_QUERY = int(os.environ.get("TORCHDR_EXAMPLE_N_QUERY", "500"))
+N_REFERENCE = int(os.environ.get("TORCHDR_EXAMPLE_N_REFERENCE", "1400"))
+N_QUERY = int(os.environ.get("TORCHDR_EXAMPLE_N_QUERY", "300"))
 PCA_DIM = 50
-MAX_ITER = int(os.environ.get("TORCHDR_EXAMPLE_MAX_ITER", "100"))
+MAX_ITER = int(os.environ.get("TORCHDR_EXAMPLE_MAX_ITER", "150"))
 
 
 # %%
@@ -49,20 +49,17 @@ digits = load_digits()
 X = (digits.data / 16.0).astype("float32")
 y = digits.target.astype("int64")
 
-X_subset, _, y_subset, _ = train_test_split(
-    X,
-    y,
-    train_size=N_REFERENCE + N_QUERY,
-    stratify=y,
-    random_state=RANDOM_STATE,
-)
+if N_REFERENCE + N_QUERY > len(X):
+    raise ValueError(
+        f"Requested {N_REFERENCE + N_QUERY} samples but digits only contains {len(X)}."
+    )
 
 X_reference, X_query, y_reference, y_query = train_test_split(
-    X_subset,
-    y_subset,
+    X,
+    y,
     train_size=N_REFERENCE,
     test_size=N_QUERY,
-    stratify=y_subset,
+    stratify=y,
     random_state=RANDOM_STATE,
 )
 
@@ -82,7 +79,7 @@ umap = UMAP(
     n_components=2,
     n_neighbors=15,
     max_iter=MAX_ITER,
-    init="normal",
+    init="pca",
     optimizer="SGD",
     backend=None,
     device="cpu",
@@ -104,8 +101,8 @@ knn = KNeighborsClassifier(n_neighbors=10)
 knn.fit(Z_reference, y_reference)
 label_transfer_accuracy = knn.score(Z_query, y_query)
 
-print(f"Reference samples: {len(X_reference_pca)}")
-print(f"Query samples: {len(X_query_pca)}")
+print(f"Reference samples used for fit: {len(X_reference_pca)}")
+print(f"Query samples used for transform only: {len(X_query_pca)}")
 print(f"10-NN label transfer accuracy: {label_transfer_accuracy:.3f}")
 
 
@@ -120,10 +117,10 @@ axes[0].scatter(
     Z_reference[:, 1],
     c=y_reference,
     cmap="tab10",
-    s=4,
-    alpha=0.45,
+    s=5,
+    alpha=0.55,
 )
-axes[0].set_title("Reference embedding")
+axes[0].set_title(f"Reference embedding\nfit on {len(X_reference_pca)} points")
 axes[0].set_xticks([])
 axes[0].set_yticks([])
 
@@ -143,7 +140,9 @@ scatter = axes[1].scatter(
     alpha=0.8,
 )
 axes[1].set_title(
-    f"Held-out query points\n10-NN transfer accuracy = {label_transfer_accuracy:.3f}"
+    "Inference-only query points\n"
+    f"transform on {len(X_query_pca)} points, "
+    f"10-NN accuracy = {label_transfer_accuracy:.3f}"
 )
 axes[1].set_xticks([])
 axes[1].set_yticks([])

--- a/examples/basics/demo_non_parametric_transform_digits.py
+++ b/examples/basics/demo_non_parametric_transform_digits.py
@@ -1,5 +1,5 @@
 r"""
-Non-Parametric UMAP Transform on Handwritten Digits
+UMAP Non-Parametric Transform on Handwritten Digits
 ==================================================
 
 We fit a reference UMAP embedding on one subset of the sklearn handwritten
@@ -120,7 +120,7 @@ axes[0].scatter(
     s=5,
     alpha=0.55,
 )
-axes[0].set_title(f"Reference embedding\nfit on {len(X_reference_pca)} points")
+axes[0].set_title(f"UMAP reference embedding\nfit on {len(X_reference_pca)} points")
 axes[0].set_xticks([])
 axes[0].set_yticks([])
 
@@ -140,7 +140,7 @@ scatter = axes[1].scatter(
     alpha=0.8,
 )
 axes[1].set_title(
-    "Inference-only query points\n"
+    "UMAP transform on inference-only query points\n"
     f"transform on {len(X_query_pca)} points, "
     f"10-NN accuracy = {label_transfer_accuracy:.3f}"
 )

--- a/examples/basics/demo_non_parametric_transform_digits.py
+++ b/examples/basics/demo_non_parametric_transform_digits.py
@@ -16,8 +16,6 @@ transfer accuracy from the reference embedding to the transformed query points.
 
 """
 
-# Author: OpenAI Codex
-#
 # License: BSD 3-Clause License
 
 import os

--- a/examples/basics/demo_non_parametric_transform_digits.py
+++ b/examples/basics/demo_non_parametric_transform_digits.py
@@ -1,6 +1,6 @@
 r"""
 UMAP Non-Parametric Transform on Handwritten Digits
-==================================================
+===================================================
 
 We fit a reference UMAP embedding on one subset of the sklearn handwritten
 digits dataset and then map unseen samples with :meth:`torchdr.UMAP.transform`

--- a/torchdr/affinity_matcher.py
+++ b/torchdr/affinity_matcher.py
@@ -348,6 +348,9 @@ class AffinityMatcher(DRModule):
                         )
                     break
 
+        # Store training embedding on CPU for non-parametric transform.
+        self.embedding_train_ = self.embedding_.data.detach().cpu().clone()
+
         self.clear_memory()
         return self.embedding_
 

--- a/torchdr/affinity_matcher.py
+++ b/torchdr/affinity_matcher.py
@@ -348,9 +348,6 @@ class AffinityMatcher(DRModule):
                         )
                     break
 
-        # Store training embedding on CPU for non-parametric transform.
-        self.embedding_train_ = self.embedding_.data.detach().cpu().clone()
-
         self.clear_memory()
         return self.embedding_
 

--- a/torchdr/base.py
+++ b/torchdr/base.py
@@ -150,16 +150,21 @@ class DRModule(BaseEstimator, nn.Module, ABC):
         self.is_fitted_ = True
         return self.embedding_
 
-    def transform(self, X: Optional[ArrayLike] = None) -> ArrayLike:
+    def transform(self, X: Optional[ArrayLike] = None, **kwargs) -> ArrayLike:
         """Transform data into the learned embedding space.
 
         If ``X`` is None, returns the training embedding. When an encoder
         is set, new data is transformed via ``encoder(X)``.
+        For non-parametric neighbor embedding models (UMAP, LargeVis, ...),
+        pass the training data as ``X_train`` keyword argument.
 
         Parameters
         ----------
         X : ArrayLike of shape (n_samples, n_features), optional
             Data to transform. If None, returns the training embedding.
+        **kwargs
+            Additional keyword arguments passed to :meth:`_transform`.
+            For non-parametric models, ``X_train`` is required.
 
         Returns
         -------
@@ -179,11 +184,29 @@ class DRModule(BaseEstimator, nn.Module, ABC):
                 X_tensor = to_torch(X).to(device=self.device_)
                 with torch.no_grad():
                     return self.encoder(X_tensor)
-            raise NotImplementedError(
-                "Transforming new data is not implemented for this model."
-            )
+            return self._transform(X, **kwargs)
 
         return self.embedding_
+
+    def _transform(self, X: ArrayLike, **kwargs) -> ArrayLike:
+        """Transform new data (subclasses override this).
+
+        Parameters
+        ----------
+        X : ArrayLike of shape (n_samples, n_features)
+            Data to transform.
+        **kwargs
+            Subclass-specific arguments.
+
+        Returns
+        -------
+        embedding : ArrayLike of shape (n_samples, n_components)
+        """
+        raise NotImplementedError(
+            "Transforming new data without an encoder is not supported "
+            "for this model. Pass an encoder to enable transform, or use "
+            "a model that supports non-parametric transform (e.g. UMAP)."
+        )
 
     # --- Core algorithm (must be implemented by subclasses) ---
 

--- a/torchdr/base.py
+++ b/torchdr/base.py
@@ -142,6 +142,14 @@ class DRModule(BaseEstimator, nn.Module, ABC):
                     self.embedding_.data = embedding_unique[inverse_indices]
                 else:
                     self.embedding_ = embedding_unique[inverse_indices]
+
+                # Transform-capable estimators keep a lightweight copy of the
+                # fitted reference embedding.  `_fit_transform` only sees the
+                # unique rows, whereas callers are documented to pass the
+                # original training data to `transform`.  Keep both objects in
+                # the same index space after duplicate expansion.
+                if hasattr(self, "embedding_train_"):
+                    self.embedding_train_ = self.embedding_.detach().cpu().clone()
             else:
                 self.embedding_ = self._fit_transform(X, y=y)
         else:
@@ -178,15 +186,18 @@ class DRModule(BaseEstimator, nn.Module, ABC):
             )
 
         if X is not None:
-            if getattr(self, "encoder", None) is not None:
-                from torchdr.utils import to_torch
-
-                X_tensor = to_torch(X).to(device=self.device_)
-                with torch.no_grad():
-                    return self.encoder(X_tensor)
-            return self._transform(X, **kwargs)
+            return self._transform_new_data(X, **kwargs)
 
         return self.embedding_
+
+    @handle_input_output()
+    def _transform_new_data(self, X: torch.Tensor, **kwargs) -> ArrayLike:
+        """Transform validated new data and preserve its input backend."""
+        if getattr(self, "encoder", None) is not None:
+            X = X.to(device=self.device_)
+            with torch.no_grad():
+                return self.encoder(X)
+        return self._transform(X, **kwargs)
 
     def _transform(self, X: ArrayLike, **kwargs) -> ArrayLike:
         """Transform new data (subclasses override this).

--- a/torchdr/neighbor_embedding/base.py
+++ b/torchdr/neighbor_embedding/base.py
@@ -566,31 +566,10 @@ class NegativeSamplingNeighborEmbedding(NeighborEmbedding):
         repulsion_strength: float = 1.0,
         n_negatives: int = 5,
         check_interval: int = 50,
-        exclude_neighbors_from_negative_sampling: Optional[bool] = None,
+        exclude_neighbors_from_negative_sampling: bool = False,
         compile: bool = False,
         **kwargs,
     ):
-        legacy_exclude_neighbors = kwargs.pop("discard_NNs", None)
-        if legacy_exclude_neighbors is not None:
-            if (
-                exclude_neighbors_from_negative_sampling is not None
-                and exclude_neighbors_from_negative_sampling != legacy_exclude_neighbors
-            ):
-                raise ValueError(
-                    "[TorchDR] ERROR : received conflicting values for "
-                    "'exclude_neighbors_from_negative_sampling' and the deprecated "
-                    "'discard_NNs' alias."
-                )
-            warnings.warn(
-                "[TorchDR] 'discard_NNs' is deprecated. Use "
-                "'exclude_neighbors_from_negative_sampling' instead.",
-                FutureWarning,
-                stacklevel=2,
-            )
-            exclude_neighbors_from_negative_sampling = legacy_exclude_neighbors
-        elif exclude_neighbors_from_negative_sampling is None:
-            exclude_neighbors_from_negative_sampling = False
-
         super().__init__(
             affinity_in=affinity_in,
             affinity_out=affinity_out,
@@ -621,8 +600,6 @@ class NegativeSamplingNeighborEmbedding(NeighborEmbedding):
         self.exclude_neighbors_from_negative_sampling = (
             exclude_neighbors_from_negative_sampling
         )
-        # Backward-compatible alias kept for one deprecation cycle.
-        self.discard_NNs = self.exclude_neighbors_from_negative_sampling
 
     def _fit_transform(self, X: torch.Tensor, y: Optional[Any] = None) -> torch.Tensor:
         """Fit and keep a CPU copy of the embedding only when transform is supported.

--- a/torchdr/neighbor_embedding/base.py
+++ b/torchdr/neighbor_embedding/base.py
@@ -661,7 +661,8 @@ class NegativeSamplingNeighborEmbedding(NeighborEmbedding):
     def _compute_bipartite_affinity(self, C, indices):
         """Compute bipartite affinity from new points to training points.
 
-        Subclasses must override this method.
+        Default implementation uses entropic affinity (for LargeVis, InfoTSNE).
+        UMAP overrides this with its own formula.
 
         Parameters
         ----------
@@ -675,27 +676,31 @@ class NegativeSamplingNeighborEmbedding(NeighborEmbedding):
         affinity : torch.Tensor of shape (n_new, k)
             Bipartite affinity weights (non-negative, not symmetrized).
         """
-        raise NotImplementedError(
-            f"{self.__class__.__name__} does not implement "
-            "_compute_bipartite_affinity for transform."
+        from torchdr.affinity.entropic import _log_Pe
+        from torchdr.utils import binary_search, logsumexp_red
+
+        perplexity = self._get_n_neighbors_transform()
+        target_entropy = (
+            torch.log(torch.tensor(perplexity, dtype=C.dtype, device=C.device)) + 1
         )
 
-    def _compute_transform_loss(
-        self, embedding_new, train_emb, nn_indices, affinity, n_train
-    ):
-        """Compute the transform loss (autograd mode). Subclasses override."""
-        raise NotImplementedError(
-            f"{self.__class__.__name__} does not implement _compute_transform_loss."
+        def entropy_gap(eps):
+            log_P = _log_Pe(C, eps)
+            log_P_norm = log_P - logsumexp_red(log_P, dim=1)
+            H = -(log_P_norm.exp() * log_P_norm).sum(dim=1)
+            return H - target_entropy
+
+        eps = binary_search(
+            f=entropy_gap,
+            n=C.shape[0],
+            max_iter=getattr(self, "max_iter_affinity", 100),
+            dtype=C.dtype,
+            device=C.device,
         )
 
-    def _compute_transform_gradients(
-        self, embedding_new, train_emb, nn_indices, affinity, n_train
-    ):
-        """Compute transform gradients (closed-form mode). Subclasses override."""
-        raise NotImplementedError(
-            f"{self.__class__.__name__} does not implement "
-            "_compute_transform_gradients."
-        )
+        log_P = _log_Pe(C, eps)
+        log_P = log_P - logsumexp_red(log_P, dim=1)
+        return log_P.exp()
 
     def _transform(self, X_new, X_train=None):
         """Transform new data using non-parametric neighbor embedding.
@@ -760,8 +765,62 @@ class NegativeSamplingNeighborEmbedding(NeighborEmbedding):
         )
         return embedding_new
 
+    def _enter_transform(self, embedding_new, train_emb, affinity, nn_indices):
+        """Save fit-time state and set up for transform.
+
+        Builds a combined embedding ``[embedding_new, train_emb]`` so that
+        the existing ``_compute_loss`` / ``_compute_gradients`` methods
+        work unmodified — queries index into the new part and keys index
+        into the training part.
+
+        Subclasses can override to set up additional state (e.g. UMAP's
+        edge-sampling buffers). Must call ``super()._enter_transform(...)``.
+
+        Returns
+        -------
+        saved : dict
+            State to restore in :meth:`_exit_transform`.
+        """
+        n_new = embedding_new.shape[0]
+        n_train = train_emb.shape[0]
+
+        saved = {}
+        for attr in (
+            "embedding_",
+            "chunk_indices_",
+            "NN_indices_",
+            "affinity_in_",
+            "n_samples_in_",
+            "early_exaggeration_coeff_",
+            "n_iter_",
+        ):
+            saved[attr] = getattr(self, attr, None)
+
+        self.chunk_indices_ = torch.arange(n_new, device=self.device_)
+        # Offset NN indices into the combined [new | train] space
+        self.NN_indices_ = nn_indices + n_new
+        self.affinity_in_ = affinity
+        self.n_samples_in_ = n_new + n_train
+        self.early_exaggeration_coeff_ = 1
+        self.n_iter_ = torch.tensor(0, device=self.device_)
+
+        return saved
+
+    def _exit_transform(self, saved):
+        """Restore fit-time state after transform."""
+        for attr, value in saved.items():
+            if value is not None:
+                setattr(self, attr, value)
+            elif hasattr(self, attr):
+                delattr(self, attr)
+
     def _optimize_transform(self, embedding_new, affinity, nn_indices, train_emb):
         """Optimize new embeddings with frozen training embeddings via SGD.
+
+        Uses the concatenation trick: builds
+        ``embedding_ = cat([embedding_new, train_emb])`` so that the
+        existing ``_compute_loss`` / ``_compute_gradients`` methods
+        can be reused without modification.
 
         Parameters
         ----------
@@ -779,6 +838,7 @@ class NegativeSamplingNeighborEmbedding(NeighborEmbedding):
         embedding_new : torch.Tensor of shape (n_new, n_components)
             Optimized positions.
         """
+        n_new = embedding_new.shape[0]
         n_train = train_emb.shape[0]
         embedding_new = torch.nn.Parameter(embedding_new.clone())
 
@@ -787,24 +847,37 @@ class NegativeSamplingNeighborEmbedding(NeighborEmbedding):
             lr = self.lr / 4.0
         else:
             lr = 0.25
-        max_iter = min(self.max_iter // 3, 100)
+        max_iter_transform = min(self.max_iter // 3, 100)
 
         optimizer = torch.optim.SGD([embedding_new], lr=lr)
 
-        for step in range(max_iter):
-            optimizer.zero_grad(set_to_none=True)
+        saved = self._enter_transform(embedding_new, train_emb, affinity, nn_indices)
 
-            if getattr(self, "_use_closed_form_gradients", False):
-                grad = self._compute_transform_gradients(
-                    embedding_new, train_emb, nn_indices, affinity, n_train
-                )
-                embedding_new.grad = grad
-            else:
-                loss = self._compute_transform_loss(
-                    embedding_new, train_emb, nn_indices, affinity, n_train
-                )
-                loss.backward()
+        try:
+            for step in range(max_iter_transform):
+                # Rebuild combined embedding each step (new points change)
+                self.embedding_ = torch.cat([embedding_new, train_emb.detach()], dim=0)
+                self.n_iter_.fill_(step)
 
-            optimizer.step()
+                # Sample negatives from training set (offset by n_new)
+                self.neg_indices_ = torch.randint(
+                    n_new,
+                    n_new + n_train,
+                    (n_new, self.n_negatives),
+                    device=self.device_,
+                )
+
+                optimizer.zero_grad(set_to_none=True)
+
+                if getattr(self, "_use_closed_form_gradients", False):
+                    gradients = self._compute_gradients()
+                    embedding_new.grad = gradients
+                else:
+                    loss = self._compute_loss()
+                    loss.backward()
+
+                optimizer.step()
+        finally:
+            self._exit_transform(saved)
 
         return embedding_new.data

--- a/torchdr/neighbor_embedding/base.py
+++ b/torchdr/neighbor_embedding/base.py
@@ -13,10 +13,9 @@ import torch.distributed as dist
 from torch.utils.data import DataLoader
 
 from torchdr.affinity import Affinity
-from torchdr.affinity.entropic import _log_Pe
 from torchdr.distance import FaissConfig, pairwise_distances
 from torchdr.affinity_matcher import AffinityMatcher
-from torchdr.utils import to_torch, binary_search, logsumexp_red
+from torchdr.utils import to_torch
 
 
 class NeighborEmbedding(AffinityMatcher):
@@ -577,6 +576,17 @@ class NegativeSamplingNeighborEmbedding(NeighborEmbedding):
         self.n_negatives = n_negatives
         self.discard_NNs = discard_NNs
 
+    def _fit_transform(self, X: torch.Tensor, y: Optional[Any] = None) -> torch.Tensor:
+        """Fit and keep a CPU copy only for models that support transform."""
+        embedding = super()._fit_transform(X, y)
+
+        if self._supports_non_parametric_transform():
+            self.embedding_train_ = embedding.detach().cpu().clone()
+        elif hasattr(self, "embedding_train_"):
+            delattr(self, "embedding_train_")
+
+        return embedding
+
     def on_affinity_computation_end(self):
         """Build per-row exclusion indices for negative sampling."""
         super().on_affinity_computation_end()
@@ -662,8 +672,7 @@ class NegativeSamplingNeighborEmbedding(NeighborEmbedding):
     def _compute_bipartite_affinity(self, C, indices):
         """Compute bipartite affinity from new points to training points.
 
-        Default implementation uses entropic affinity (for LargeVis, InfoTSNE).
-        UMAP overrides this with its own formula.
+        Subclasses must implement this method.
 
         Parameters
         ----------
@@ -677,28 +686,68 @@ class NegativeSamplingNeighborEmbedding(NeighborEmbedding):
         affinity : torch.Tensor of shape (n_new, k)
             Bipartite affinity weights (non-negative, not symmetrized).
         """
-        perplexity = self._get_n_neighbors_transform()
-        target_entropy = (
-            torch.log(torch.tensor(perplexity, dtype=C.dtype, device=C.device)) + 1
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not implement "
+            "_compute_bipartite_affinity for transform."
         )
 
-        def entropy_gap(eps):
-            log_P = _log_Pe(C, eps)
-            log_P_norm = log_P - logsumexp_red(log_P, dim=1)
-            H = -(log_P_norm.exp() * log_P_norm).sum(dim=1)
-            return H - target_entropy
-
-        eps = binary_search(
-            f=entropy_gap,
-            n=C.shape[0],
-            max_iter=getattr(self, "max_iter_affinity", 100),
-            dtype=C.dtype,
-            device=C.device,
+    def _supports_non_parametric_transform(self):
+        """Return whether the subclass implements non-parametric transform."""
+        return (
+            self.__class__._compute_bipartite_affinity
+            is not NegativeSamplingNeighborEmbedding._compute_bipartite_affinity
         )
 
-        log_P = _log_Pe(C, eps)
-        log_P = log_P - logsumexp_red(log_P, dim=1)
-        return log_P.exp()
+    def _get_transform_learning_rate(self):
+        """Return the transform learning rate as 1/4 of the fit-time LR."""
+        if self.lr == "auto":
+            early_exaggeration = getattr(self, "early_exaggeration_coeff", 1) or 1
+            fit_lr = max(self.n_samples_in_ / early_exaggeration / 4, 50)
+            return float(fit_lr) / 4.0
+        if isinstance(self.lr, (int, float)):
+            return float(self.lr) / 4.0
+
+        raise RuntimeError(
+            "[TorchDR] Transform learning rate is unavailable. "
+            "Fit the model before calling transform."
+        )
+
+    def _sample_transform_neg_indices(self, n_new, n_train, nn_indices):
+        """Sample negatives from the training set for transform optimization."""
+        if not self.discard_NNs:
+            return torch.randint(
+                n_new,
+                n_new + n_train,
+                (n_new, self.n_negatives),
+                device=self.device_,
+            )
+
+        exclusion = nn_indices.long().sort(dim=1).values
+        n_possible = n_train - exclusion.shape[1]
+        if self.n_negatives > n_possible:
+            raise ValueError(
+                f"[TorchDR] ERROR : requested {self.n_negatives} transform negatives but "
+                f"only {n_possible} training points are available after excluding neighbors."
+            )
+
+        negatives = torch.randint(
+            0,
+            n_train,
+            (n_new, self.n_negatives),
+            device=self.device_,
+        )
+
+        collisions = (negatives.unsqueeze(-1) == exclusion.unsqueeze(1)).any(dim=2)
+        while collisions.any():
+            negatives[collisions] = torch.randint(
+                0,
+                n_train,
+                (collisions.sum().item(),),
+                device=self.device_,
+            )
+            collisions = (negatives.unsqueeze(-1) == exclusion.unsqueeze(1)).any(dim=2)
+
+        return negatives + n_new
 
     def _transform(self, X_new, X_train=None):
         """Transform new data using non-parametric neighbor embedding.
@@ -721,6 +770,11 @@ class NegativeSamplingNeighborEmbedding(NeighborEmbedding):
         embedding_new : torch.Tensor of shape (n_new, n_components)
             Embedding of the new data.
         """
+        if not self._supports_non_parametric_transform():
+            raise NotImplementedError(
+                f"{self.__class__.__name__} does not support non-parametric transform."
+            )
+
         if X_train is None:
             raise ValueError(
                 "[TorchDR] X_train is required for non-parametric transform. "
@@ -841,10 +895,7 @@ class NegativeSamplingNeighborEmbedding(NeighborEmbedding):
         embedding_new = torch.nn.Parameter(embedding_new.clone())
 
         # LR: 1/4 of fit-time LR (following umap-learn)
-        if isinstance(self.lr, (int, float)):
-            lr = self.lr / 4.0
-        else:
-            lr = 0.25
+        lr = self._get_transform_learning_rate()
         max_iter_transform = min(self.max_iter // 3, 100)
 
         optimizer = torch.optim.SGD([embedding_new], lr=lr)
@@ -857,12 +908,8 @@ class NegativeSamplingNeighborEmbedding(NeighborEmbedding):
                 self.embedding_ = torch.cat([embedding_new, train_emb.detach()], dim=0)
                 self.n_iter_.fill_(step)
 
-                # Sample negatives from training set (offset by n_new)
-                self.neg_indices_ = torch.randint(
-                    n_new,
-                    n_new + n_train,
-                    (n_new, self.n_negatives),
-                    device=self.device_,
+                self.neg_indices_ = self._sample_transform_neg_indices(
+                    n_new, n_train, nn_indices
                 )
 
                 optimizer.zero_grad(set_to_none=True)

--- a/torchdr/neighbor_embedding/base.py
+++ b/torchdr/neighbor_embedding/base.py
@@ -13,9 +13,10 @@ import torch.distributed as dist
 from torch.utils.data import DataLoader
 
 from torchdr.affinity import Affinity
+from torchdr.affinity.entropic import _log_Pe
 from torchdr.distance import FaissConfig, pairwise_distances
 from torchdr.affinity_matcher import AffinityMatcher
-from torchdr.utils import to_torch
+from torchdr.utils import to_torch, binary_search, logsumexp_red
 
 
 class NeighborEmbedding(AffinityMatcher):
@@ -676,9 +677,6 @@ class NegativeSamplingNeighborEmbedding(NeighborEmbedding):
         affinity : torch.Tensor of shape (n_new, k)
             Bipartite affinity weights (non-negative, not symmetrized).
         """
-        from torchdr.affinity.entropic import _log_Pe
-        from torchdr.utils import binary_search, logsumexp_red
-
         perplexity = self._get_n_neighbors_transform()
         target_entropy = (
             torch.log(torch.tensor(perplexity, dtype=C.dtype, device=C.device)) + 1

--- a/torchdr/neighbor_embedding/base.py
+++ b/torchdr/neighbor_embedding/base.py
@@ -443,11 +443,32 @@ class NegativeSamplingNeighborEmbedding(NeighborEmbedding):
     - The sampled indices are stored in :attr:`neg_indices_` and refreshed
       every iteration via :meth:`on_training_step_start`.
 
+    **Non-parametric transform support:**
+
+    This family also provides the shared machinery for *out-of-sample*
+    non-parametric transform. The base implementation handles the generic
+    transform lifecycle:
+
+    - find nearest neighbors from new points to the reference training set;
+    - build a bipartite affinity from new points to training points;
+    - initialize new embeddings from that bipartite graph;
+    - optimize only the new points while keeping the fitted training
+      embedding frozen.
+
+    The design is intentionally split so the base class owns the generic
+    transform pipeline, while each algorithm only provides the
+    method-specific bipartite affinity through
+    :meth:`_compute_bipartite_affinity`. This keeps the out-of-sample logic
+    centralized and prevents each subclass from reimplementing the same
+    transform scaffolding.
+
     **Inherits** distributed multi-GPU support from
     :class:`NeighborEmbedding`.
 
     **Subclasses** must implement :meth:`_compute_attractive_loss` and
     :meth:`_compute_repulsive_loss` (or the gradient equivalents).
+    Subclasses that support non-parametric transform must additionally
+    implement :meth:`_compute_bipartite_affinity`.
 
     **Direct subclasses**: :class:`UMAP`, :class:`LargeVis`,
     :class:`InfoTSNE`, :class:`PACMAP`.
@@ -604,7 +625,13 @@ class NegativeSamplingNeighborEmbedding(NeighborEmbedding):
         self.discard_NNs = self.exclude_neighbors_from_negative_sampling
 
     def _fit_transform(self, X: torch.Tensor, y: Optional[Any] = None) -> torch.Tensor:
-        """Fit and keep a CPU copy only for models that support transform."""
+        """Fit and keep a CPU copy of the embedding only when transform is supported.
+
+        The transform path needs access to the fitted reference embedding, but
+        storing that extra CPU copy for every estimator would be wasteful.
+        The copy is therefore created only for subclasses that opt into the
+        non-parametric transform pipeline.
+        """
         embedding = super()._fit_transform(X, y)
 
         if self._supports_non_parametric_transform():
@@ -700,7 +727,11 @@ class NegativeSamplingNeighborEmbedding(NeighborEmbedding):
     def _compute_bipartite_affinity(self, C, indices):
         """Compute bipartite affinity from new points to training points.
 
-        Subclasses must implement this method.
+        This hook is the method-specific part of the shared non-parametric
+        transform pipeline. The base class handles neighbor search,
+        initialization, and optimization; subclasses only need to define how
+        distances from new points to training neighbors are converted into
+        affinity weights.
 
         Parameters
         ----------
@@ -720,7 +751,11 @@ class NegativeSamplingNeighborEmbedding(NeighborEmbedding):
         )
 
     def _supports_non_parametric_transform(self):
-        """Return whether the subclass implements non-parametric transform."""
+        """Return whether the subclass opted into non-parametric transform.
+
+        Support is explicit: a subclass enables the shared transform pipeline
+        by overriding :meth:`_compute_bipartite_affinity`.
+        """
         return (
             self.__class__._compute_bipartite_affinity
             is not NegativeSamplingNeighborEmbedding._compute_bipartite_affinity
@@ -757,7 +792,14 @@ class NegativeSamplingNeighborEmbedding(NeighborEmbedding):
         return min(self.max_iter // 3, 100)
 
     def _sample_transform_neg_indices(self, n_new, n_train, nn_indices):
-        """Sample negatives from the training set for transform optimization."""
+        """Sample transform negatives from the frozen training embedding.
+
+        During non-parametric transform, repulsive negatives are drawn only
+        from the reference training points. When
+        :attr:`exclude_neighbors_from_negative_sampling` is enabled, the
+        positive training neighbors of each new point are removed from that
+        negative pool.
+        """
         if not self.exclude_neighbors_from_negative_sampling:
             return torch.randint(
                 n_new,
@@ -788,7 +830,13 @@ class NegativeSamplingNeighborEmbedding(NeighborEmbedding):
         return compressed + shifts + n_new
 
     def _initialize_transform_embedding(self, affinity, nn_indices, train_emb):
-        """Initialize transformed points from the bipartite neighbor graph."""
+        """Initialize transformed points from the bipartite neighbor graph.
+
+        The default initialization is the affinity-weighted average of the
+        training neighbors' fitted embeddings. Subclasses can override this to
+        match algorithm-specific initialization rules while still reusing the
+        shared transform pipeline.
+        """
         weights = affinity / affinity.sum(dim=1, keepdim=True).clamp(min=1e-10)
         neighbor_emb = train_emb[nn_indices.long()]
         return (weights.unsqueeze(-1) * neighbor_emb).sum(dim=1)
@@ -798,7 +846,8 @@ class NegativeSamplingNeighborEmbedding(NeighborEmbedding):
 
         Finds nearest neighbors in the training data, builds a bipartite
         affinity graph, initializes positions from that graph, and optimizes
-        with frozen training embeddings.
+        only the new points while keeping the fitted training embedding
+        frozen.
 
         Parameters
         ----------
@@ -867,7 +916,9 @@ class NegativeSamplingNeighborEmbedding(NeighborEmbedding):
         Builds a combined embedding ``[embedding_new, train_emb]`` so that
         the existing ``_compute_loss`` / ``_compute_gradients`` methods
         work unmodified — queries index into the new part and keys index
-        into the training part.
+        into the training part. This is the key design choice that keeps the
+        transform code small: the transform path reuses the usual objective
+        implementation instead of introducing a second optimization codepath.
 
         Subclasses can override to set up additional state (e.g. UMAP's
         edge-sampling buffers). Must call ``super()._enter_transform(...)``.
@@ -916,7 +967,8 @@ class NegativeSamplingNeighborEmbedding(NeighborEmbedding):
         Uses the concatenation trick: builds
         ``embedding_ = cat([embedding_new, train_emb])`` so that the
         existing ``_compute_loss`` / ``_compute_gradients`` methods
-        can be reused without modification.
+        can be reused without modification. Only ``embedding_new`` is a trainable
+        parameter; ``train_emb`` acts as the frozen reference geometry.
 
         Parameters
         ----------

--- a/torchdr/neighbor_embedding/base.py
+++ b/torchdr/neighbor_embedding/base.py
@@ -13,8 +13,9 @@ import torch.distributed as dist
 from torch.utils.data import DataLoader
 
 from torchdr.affinity import Affinity
-from torchdr.distance import FaissConfig
+from torchdr.distance import FaissConfig, pairwise_distances
 from torchdr.affinity_matcher import AffinityMatcher
+from torchdr.utils import to_torch
 
 
 class NeighborEmbedding(AffinityMatcher):
@@ -647,3 +648,163 @@ class NegativeSamplingNeighborEmbedding(NeighborEmbedding):
             neg_indices = negatives + shifts
 
         self.register_buffer("neg_indices_", neg_indices, persistent=False)
+
+    # --- Non-parametric transform ---
+
+    def _get_n_neighbors_transform(self):
+        """Return the number of neighbors for the transform kNN search."""
+        for attr in ("n_neighbors", "perplexity"):
+            if hasattr(self, attr):
+                return int(getattr(self, attr))
+        raise ValueError("[TorchDR] Cannot determine n_neighbors for transform.")
+
+    def _compute_bipartite_affinity(self, C, indices):
+        """Compute bipartite affinity from new points to training points.
+
+        Subclasses must override this method.
+
+        Parameters
+        ----------
+        C : torch.Tensor of shape (n_new, k)
+            Distances from new points to their k nearest training neighbors.
+        indices : torch.Tensor of shape (n_new, k)
+            Indices of k nearest training neighbors.
+
+        Returns
+        -------
+        affinity : torch.Tensor of shape (n_new, k)
+            Bipartite affinity weights (non-negative, not symmetrized).
+        """
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not implement "
+            "_compute_bipartite_affinity for transform."
+        )
+
+    def _compute_transform_loss(
+        self, embedding_new, train_emb, nn_indices, affinity, n_train
+    ):
+        """Compute the transform loss (autograd mode). Subclasses override."""
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not implement _compute_transform_loss."
+        )
+
+    def _compute_transform_gradients(
+        self, embedding_new, train_emb, nn_indices, affinity, n_train
+    ):
+        """Compute transform gradients (closed-form mode). Subclasses override."""
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not implement "
+            "_compute_transform_gradients."
+        )
+
+    def _transform(self, X_new, X_train=None):
+        """Transform new data using non-parametric neighbor embedding.
+
+        Finds nearest neighbors in the training data, builds a bipartite
+        affinity graph, initializes positions as weighted averages of
+        training neighbors' embeddings, and optimizes with frozen training
+        embeddings.
+
+        Parameters
+        ----------
+        X_new : array-like of shape (n_new, n_features)
+            New data to transform.
+        X_train : array-like of shape (n_train, n_features)
+            Training data used during fit. Required because training data
+            is not stored to avoid memory overhead.
+
+        Returns
+        -------
+        embedding_new : torch.Tensor of shape (n_new, n_components)
+            Embedding of the new data.
+        """
+        if X_train is None:
+            raise ValueError(
+                "[TorchDR] X_train is required for non-parametric transform. "
+                "Pass the training data: model.transform(X_new, X_train=X_train)"
+            )
+
+        if not hasattr(self, "embedding_train_"):
+            raise RuntimeError(
+                "[TorchDR] Training embedding not available. "
+                "Call fit() or fit_transform() first."
+            )
+
+        X_new = to_torch(X_new).to(device=self.device_)
+        X_train = to_torch(X_train).to(device=self.device_)
+
+        # Step 1: kNN from new points to training points
+        k = self._get_n_neighbors_transform()
+        C, nn_indices = pairwise_distances(
+            X=X_new,
+            Y=X_train,
+            metric=self.metric,
+            backend=self.backend,
+            k=k,
+            return_indices=True,
+            device=self.device_,
+        )
+
+        # Step 2: bipartite affinity (subclass-specific)
+        affinity = self._compute_bipartite_affinity(C, nn_indices)
+
+        # Step 3: initialize as weighted average of training neighbors
+        weights = affinity / affinity.sum(dim=1, keepdim=True).clamp(min=1e-10)
+        train_emb = self.embedding_train_.to(device=self.device_)
+        neighbor_emb = train_emb[nn_indices.long()]  # (n_new, k, n_components)
+        embedding_new = (weights.unsqueeze(-1) * neighbor_emb).sum(dim=1)
+
+        # Step 4: optimize with frozen training embeddings
+        embedding_new = self._optimize_transform(
+            embedding_new, affinity, nn_indices, train_emb
+        )
+        return embedding_new
+
+    def _optimize_transform(self, embedding_new, affinity, nn_indices, train_emb):
+        """Optimize new embeddings with frozen training embeddings via SGD.
+
+        Parameters
+        ----------
+        embedding_new : torch.Tensor of shape (n_new, n_components)
+            Initial positions for new points.
+        affinity : torch.Tensor of shape (n_new, k)
+            Bipartite affinity from new to training points.
+        nn_indices : torch.Tensor of shape (n_new, k)
+            Indices of nearest training neighbors.
+        train_emb : torch.Tensor of shape (n_train, n_components)
+            Frozen training embeddings.
+
+        Returns
+        -------
+        embedding_new : torch.Tensor of shape (n_new, n_components)
+            Optimized positions.
+        """
+        n_train = train_emb.shape[0]
+        embedding_new = torch.nn.Parameter(embedding_new.clone())
+
+        # LR: 1/4 of fit-time LR (following umap-learn)
+        if isinstance(self.lr, (int, float)):
+            lr = self.lr / 4.0
+        else:
+            lr = 0.25
+        max_iter = min(self.max_iter // 3, 100)
+
+        optimizer = torch.optim.SGD([embedding_new], lr=lr)
+
+        for step in range(max_iter):
+            optimizer.zero_grad(set_to_none=True)
+
+            if getattr(self, "_use_closed_form_gradients", False):
+                grad = self._compute_transform_gradients(
+                    embedding_new, train_emb, nn_indices, affinity, n_train
+                )
+                embedding_new.grad = grad
+            else:
+                loss = self._compute_transform_loss(
+                    embedding_new, train_emb, nn_indices, affinity, n_train
+                )
+                loss.backward()
+
+            optimizer.step()
+
+        return embedding_new.data

--- a/torchdr/neighbor_embedding/base.py
+++ b/torchdr/neighbor_embedding/base.py
@@ -437,8 +437,9 @@ class NegativeSamplingNeighborEmbedding(NeighborEmbedding):
 
     - At each iteration, :attr:`n_negatives` indices are sampled uniformly
       (excluding the point itself) for each point in the local chunk.
-    - When :attr:`discard_NNs` is ``True``, nearest neighbors are also
-      excluded from the negative samples to avoid conflicting gradients.
+    - When :attr:`exclude_neighbors_from_negative_sampling` is ``True``,
+      nearest neighbors are also excluded from the negative samples to avoid
+      conflicting gradients.
     - The sampled indices are stored in :attr:`neg_indices_` and refreshed
       every iteration via :meth:`on_training_step_start`.
 
@@ -508,8 +509,9 @@ class NegativeSamplingNeighborEmbedding(NeighborEmbedding):
         Number of negative samples to use. Default is 5.
     check_interval : int, optional
         Number of iterations between two checks for convergence. Default is 50.
-    discard_NNs : bool, optional
-        Whether to discard nearest neighbors from negative sampling. Default is False.
+    exclude_neighbors_from_negative_sampling : bool, optional
+        Whether to exclude nearest neighbors from negative sampling.
+        Default is False.
     compile : bool, default=False
         Whether to use torch.compile for faster computation.
     **kwargs
@@ -543,10 +545,31 @@ class NegativeSamplingNeighborEmbedding(NeighborEmbedding):
         repulsion_strength: float = 1.0,
         n_negatives: int = 5,
         check_interval: int = 50,
-        discard_NNs: bool = False,
+        exclude_neighbors_from_negative_sampling: Optional[bool] = None,
         compile: bool = False,
         **kwargs,
     ):
+        legacy_exclude_neighbors = kwargs.pop("discard_NNs", None)
+        if legacy_exclude_neighbors is not None:
+            if (
+                exclude_neighbors_from_negative_sampling is not None
+                and exclude_neighbors_from_negative_sampling != legacy_exclude_neighbors
+            ):
+                raise ValueError(
+                    "[TorchDR] ERROR : received conflicting values for "
+                    "'exclude_neighbors_from_negative_sampling' and the deprecated "
+                    "'discard_NNs' alias."
+                )
+            warnings.warn(
+                "[TorchDR] 'discard_NNs' is deprecated. Use "
+                "'exclude_neighbors_from_negative_sampling' instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            exclude_neighbors_from_negative_sampling = legacy_exclude_neighbors
+        elif exclude_neighbors_from_negative_sampling is None:
+            exclude_neighbors_from_negative_sampling = False
+
         super().__init__(
             affinity_in=affinity_in,
             affinity_out=affinity_out,
@@ -574,7 +597,11 @@ class NegativeSamplingNeighborEmbedding(NeighborEmbedding):
         )
 
         self.n_negatives = n_negatives
-        self.discard_NNs = discard_NNs
+        self.exclude_neighbors_from_negative_sampling = (
+            exclude_neighbors_from_negative_sampling
+        )
+        # Backward-compatible alias kept for one deprecation cycle.
+        self.discard_NNs = self.exclude_neighbors_from_negative_sampling
 
     def _fit_transform(self, X: torch.Tensor, y: Optional[Any] = None) -> torch.Tensor:
         """Fit and keep a CPU copy only for models that support transform."""
@@ -595,10 +622,11 @@ class NegativeSamplingNeighborEmbedding(NeighborEmbedding):
         global_self_idx = self.chunk_indices_.unsqueeze(1)
 
         # Optionally include NN indices (rows aligned with local slice)
-        if self.discard_NNs:
+        if self.exclude_neighbors_from_negative_sampling:
             if not hasattr(self, "NN_indices_"):
                 self.logger.warning(
-                    "NN_indices_ not found. Cannot discard NNs from negative sampling."
+                    "NN_indices_ not found. Cannot exclude neighbors from "
+                    "negative sampling."
                 )
                 exclude = global_self_idx
             else:
@@ -730,7 +758,7 @@ class NegativeSamplingNeighborEmbedding(NeighborEmbedding):
 
     def _sample_transform_neg_indices(self, n_new, n_train, nn_indices):
         """Sample negatives from the training set for transform optimization."""
-        if not self.discard_NNs:
+        if not self.exclude_neighbors_from_negative_sampling:
             return torch.randint(
                 n_new,
                 n_new + n_train,

--- a/torchdr/neighbor_embedding/base.py
+++ b/torchdr/neighbor_embedding/base.py
@@ -698,19 +698,31 @@ class NegativeSamplingNeighborEmbedding(NeighborEmbedding):
             is not NegativeSamplingNeighborEmbedding._compute_bipartite_affinity
         )
 
+    def _get_fit_learning_rate(self):
+        """Return the learning rate configured at the start of fit."""
+        saved_lr = getattr(self, "lr_", None)
+        had_lr = hasattr(self, "lr_")
+        saved_early_exaggeration = getattr(self, "early_exaggeration_coeff_", None)
+        had_early_exaggeration = hasattr(self, "early_exaggeration_coeff_")
+
+        try:
+            self.early_exaggeration_coeff_ = self.early_exaggeration_coeff
+            self._set_learning_rate()
+            return float(self.lr_)
+        finally:
+            if had_lr:
+                self.lr_ = saved_lr
+            elif hasattr(self, "lr_"):
+                delattr(self, "lr_")
+
+            if had_early_exaggeration:
+                self.early_exaggeration_coeff_ = saved_early_exaggeration
+            elif hasattr(self, "early_exaggeration_coeff_"):
+                delattr(self, "early_exaggeration_coeff_")
+
     def _get_transform_learning_rate(self):
         """Return the transform learning rate as 1/4 of the fit-time LR."""
-        if self.lr == "auto":
-            early_exaggeration = getattr(self, "early_exaggeration_coeff", 1) or 1
-            fit_lr = max(self.n_samples_in_ / early_exaggeration / 4, 50)
-            return float(fit_lr) / 4.0
-        if isinstance(self.lr, (int, float)):
-            return float(self.lr) / 4.0
-
-        raise RuntimeError(
-            "[TorchDR] Transform learning rate is unavailable. "
-            "Fit the model before calling transform."
-        )
+        return self._get_fit_learning_rate() / 4.0
 
     def _sample_transform_neg_indices(self, n_new, n_train, nn_indices):
         """Sample negatives from the training set for transform optimization."""

--- a/torchdr/neighbor_embedding/base.py
+++ b/torchdr/neighbor_embedding/base.py
@@ -724,6 +724,10 @@ class NegativeSamplingNeighborEmbedding(NeighborEmbedding):
         """Return the transform learning rate as 1/4 of the fit-time LR."""
         return self._get_fit_learning_rate() / 4.0
 
+    def _get_max_iter_transform(self):
+        """Return the number of optimization steps used during transform."""
+        return min(self.max_iter // 3, 100)
+
     def _sample_transform_neg_indices(self, n_new, n_train, nn_indices):
         """Sample negatives from the training set for transform optimization."""
         if not self.discard_NNs:
@@ -735,39 +739,38 @@ class NegativeSamplingNeighborEmbedding(NeighborEmbedding):
             )
 
         exclusion = nn_indices.long().sort(dim=1).values
-        n_possible = n_train - exclusion.shape[1]
-        if self.n_negatives > n_possible:
+        n_excluded = exclusion.shape[1]
+        n_possible = n_train - n_excluded
+        if n_possible <= 0:
             raise ValueError(
-                f"[TorchDR] ERROR : requested {self.n_negatives} transform negatives but "
-                f"only {n_possible} training points are available after excluding neighbors."
+                "[TorchDR] ERROR : no candidates are available for transform negative "
+                "sampling after excluding neighbors."
             )
 
-        negatives = torch.randint(
+        compressed = torch.randint(
             0,
-            n_train,
+            n_possible,
             (n_new, self.n_negatives),
             device=self.device_,
         )
+        adjusted_exclusion = exclusion - torch.arange(
+            n_excluded, device=exclusion.device, dtype=exclusion.dtype
+        )
+        shifts = torch.searchsorted(adjusted_exclusion, compressed, right=True)
+        return compressed + shifts + n_new
 
-        collisions = (negatives.unsqueeze(-1) == exclusion.unsqueeze(1)).any(dim=2)
-        while collisions.any():
-            negatives[collisions] = torch.randint(
-                0,
-                n_train,
-                (collisions.sum().item(),),
-                device=self.device_,
-            )
-            collisions = (negatives.unsqueeze(-1) == exclusion.unsqueeze(1)).any(dim=2)
-
-        return negatives + n_new
+    def _initialize_transform_embedding(self, affinity, nn_indices, train_emb):
+        """Initialize transformed points from the bipartite neighbor graph."""
+        weights = affinity / affinity.sum(dim=1, keepdim=True).clamp(min=1e-10)
+        neighbor_emb = train_emb[nn_indices.long()]
+        return (weights.unsqueeze(-1) * neighbor_emb).sum(dim=1)
 
     def _transform(self, X_new, X_train=None):
         """Transform new data using non-parametric neighbor embedding.
 
         Finds nearest neighbors in the training data, builds a bipartite
-        affinity graph, initializes positions as weighted averages of
-        training neighbors' embeddings, and optimizes with frozen training
-        embeddings.
+        affinity graph, initializes positions from that graph, and optimizes
+        with frozen training embeddings.
 
         Parameters
         ----------
@@ -817,11 +820,12 @@ class NegativeSamplingNeighborEmbedding(NeighborEmbedding):
         # Step 2: bipartite affinity (subclass-specific)
         affinity = self._compute_bipartite_affinity(C, nn_indices)
 
-        # Step 3: initialize as weighted average of training neighbors
-        weights = affinity / affinity.sum(dim=1, keepdim=True).clamp(min=1e-10)
         train_emb = self.embedding_train_.to(device=self.device_)
-        neighbor_emb = train_emb[nn_indices.long()]  # (n_new, k, n_components)
-        embedding_new = (weights.unsqueeze(-1) * neighbor_emb).sum(dim=1)
+
+        # Step 3: initialize from the bipartite graph
+        embedding_new = self._initialize_transform_embedding(
+            affinity, nn_indices, train_emb
+        )
 
         # Step 4: optimize with frozen training embeddings
         embedding_new = self._optimize_transform(
@@ -908,7 +912,7 @@ class NegativeSamplingNeighborEmbedding(NeighborEmbedding):
 
         # LR: 1/4 of fit-time LR (following umap-learn)
         lr = self._get_transform_learning_rate()
-        max_iter_transform = min(self.max_iter // 3, 100)
+        max_iter_transform = self._get_max_iter_transform()
 
         optimizer = torch.optim.SGD([embedding_new], lr=lr)
 

--- a/torchdr/neighbor_embedding/base.py
+++ b/torchdr/neighbor_embedding/base.py
@@ -13,9 +13,16 @@ import torch.distributed as dist
 from torch.utils.data import DataLoader
 
 from torchdr.affinity import Affinity
+from torchdr.affinity.entropic import _log_Pe
 from torchdr.distance import FaissConfig, pairwise_distances
 from torchdr.affinity_matcher import AffinityMatcher
-from torchdr.utils import to_torch
+from torchdr.utils import (
+    binary_search,
+    entropy,
+    logsumexp_red,
+    to_torch,
+    validate_tensor,
+)
 
 
 class NeighborEmbedding(AffinityMatcher):
@@ -533,6 +540,8 @@ class NegativeSamplingNeighborEmbedding(NeighborEmbedding):
     exclude_neighbors_from_negative_sampling : bool, optional
         Whether to exclude nearest neighbors from negative sampling.
         Default is False.
+    discard_NNs : bool, optional
+        Deprecated alias for ``exclude_neighbors_from_negative_sampling``.
     compile : bool, default=False
         Whether to use torch.compile for faster computation.
     **kwargs
@@ -566,7 +575,8 @@ class NegativeSamplingNeighborEmbedding(NeighborEmbedding):
         repulsion_strength: float = 1.0,
         n_negatives: int = 5,
         check_interval: int = 50,
-        exclude_neighbors_from_negative_sampling: bool = False,
+        exclude_neighbors_from_negative_sampling: Optional[bool] = None,
+        discard_NNs: Optional[bool] = None,
         compile: bool = False,
         **kwargs,
     ):
@@ -596,9 +606,30 @@ class NegativeSamplingNeighborEmbedding(NeighborEmbedding):
             **kwargs,
         )
 
+        if (
+            exclude_neighbors_from_negative_sampling is not None
+            and discard_NNs is not None
+            and bool(exclude_neighbors_from_negative_sampling) != bool(discard_NNs)
+        ):
+            raise ValueError(
+                "[TorchDR] Conflicting values were provided for "
+                "exclude_neighbors_from_negative_sampling and its deprecated "
+                "alias discard_NNs."
+            )
+        if discard_NNs is not None:
+            warnings.warn(
+                "`discard_NNs` is deprecated; use "
+                "`exclude_neighbors_from_negative_sampling` instead.",
+                FutureWarning,
+                stacklevel=3,
+            )
+
         self.n_negatives = n_negatives
-        self.exclude_neighbors_from_negative_sampling = (
-            exclude_neighbors_from_negative_sampling
+        self.discard_NNs = discard_NNs
+        self.exclude_neighbors_from_negative_sampling = bool(
+            discard_NNs
+            if exclude_neighbors_from_negative_sampling is None
+            else exclude_neighbors_from_negative_sampling
         )
 
     def _fit_transform(self, X: torch.Tensor, y: Optional[Any] = None) -> torch.Tensor:
@@ -650,56 +681,148 @@ class NegativeSamplingNeighborEmbedding(NeighborEmbedding):
             "negative_exclusion_indices_", exclude_sorted, persistent=False
         )
 
-        # Safety check on number of available negatives
-        n_possible = self.n_samples_in_ - self.negative_exclusion_indices_.shape[1]
-        if self.n_negatives > n_possible and self.verbose:
+        adjusted_exclusion, n_available = self._prepare_exclusion_sampling(
+            exclude_sorted, self.n_samples_in_
+        )
+        self.register_buffer(
+            "negative_adjusted_exclusion_", adjusted_exclusion, persistent=False
+        )
+        self.register_buffer(
+            "negative_available_counts_", n_available, persistent=False
+        )
+
+    @staticmethod
+    def _prepare_exclusion_sampling(exclusion, n_candidates):
+        """Prepare row-wise exclusions for uniform compressed-index sampling.
+
+        Invalid padding indices and duplicate exclusions are ignored.  The
+        returned adjusted values map a uniform draw in the compressed range
+        back into ``[0, n_candidates)`` with ``torch.searchsorted``.
+        """
+        exclusion = exclusion.long()
+        if exclusion.ndim != 2:
+            raise ValueError("[TorchDR] exclusion indices must be a 2D tensor.")
+        if n_candidates < 1:
+            raise ValueError("[TorchDR] negative sampling requires candidates.")
+
+        sentinel = torch.full_like(exclusion, n_candidates)
+        valid = (exclusion >= 0) & (exclusion < n_candidates)
+        exclusion = torch.where(valid, exclusion, sentinel).sort(dim=1).values
+        valid = exclusion < n_candidates
+
+        unique = valid.clone()
+        if exclusion.shape[1] > 1:
+            unique[:, 1:] &= exclusion[:, 1:] != exclusion[:, :-1]
+
+        n_excluded = unique.sum(dim=1)
+        n_available = n_candidates - n_excluded
+        if (n_available <= 0).any():
             raise ValueError(
-                f"[TorchDR] ERROR : requested {self.n_negatives} negatives but "
-                f"only {n_possible} available."
+                "[TorchDR] No candidates remain after applying negative-sampling "
+                "exclusions."
             )
+
+        width = exclusion.shape[1]
+        columns = torch.arange(width, device=exclusion.device, dtype=torch.long)
+        compact = (n_candidates + columns).unsqueeze(0).expand_as(exclusion).clone()
+        compact_positions = unique.cumsum(dim=1) - 1
+        rows = torch.arange(exclusion.shape[0], device=exclusion.device)
+        rows = rows.unsqueeze(1).expand_as(exclusion)
+        compact[rows[unique], compact_positions[unique]] = exclusion[unique]
+
+        # For the j-th sorted exclusion e_j, compare compressed indices against
+        # e_j - j.  Sentinel entries become n_candidates and remain at the end.
+        adjusted_exclusion = (compact - columns).contiguous()
+        return adjusted_exclusion, n_available.long()
+
+    @staticmethod
+    def _draw_with_exclusions(adjusted_exclusion, n_available, n_draws, offset=0):
+        """Draw uniformly with replacement from row-wise allowed indices."""
+        compressed = (
+            torch.rand(
+                (adjusted_exclusion.shape[0], n_draws),
+                device=adjusted_exclusion.device,
+            )
+            * n_available.unsqueeze(1)
+        ).long()
+        shifts = torch.searchsorted(adjusted_exclusion, compressed, right=True)
+        return compressed + shifts + offset
 
     def on_training_step_start(self):
         """Sample negatives using a unified path for single- and multi-GPU."""
         super().on_training_step_start()
 
-        chunk_size = len(self.chunk_indices_)
-        device = self.embedding_.device
-
-        exclusion = self.negative_exclusion_indices_
-        excl_width = exclusion.shape[1]
-
-        # Only excluding self-indices
-        if excl_width == 1:
-            negatives = torch.randint(
-                0,
-                self.n_samples_in_ - 1,
-                (chunk_size, self.n_negatives),
-                device=device,
-            )
-            self_idx = self.chunk_indices_.unsqueeze(1)
-            neg_indices = negatives + (negatives >= self_idx).long()
-
-        # Excluding self-indices and NNs indices (computed in on_affinity_computation_end)
-        else:
-            negatives = torch.randint(
-                1,
-                self.n_samples_in_ - excl_width,
-                (chunk_size, self.n_negatives),
-                device=device,
-            )
-            shifts = torch.searchsorted(exclusion, negatives, right=True)
-            neg_indices = negatives + shifts
+        neg_indices = self._draw_with_exclusions(
+            self.negative_adjusted_exclusion_,
+            self.negative_available_counts_,
+            self.n_negatives,
+        )
 
         self.register_buffer("neg_indices_", neg_indices, persistent=False)
 
     # --- Non-parametric transform ---
 
-    def _get_n_neighbors_transform(self):
-        """Return the number of neighbors for the transform kNN search."""
-        for attr in ("n_neighbors", "perplexity"):
-            if hasattr(self, attr):
-                return int(getattr(self, attr))
-        raise ValueError("[TorchDR] Cannot determine n_neighbors for transform.")
+    def _get_n_neighbors_transform(self, n_train):
+        """Return a valid support size for the transform kNN search.
+
+        UMAP uses its configured neighborhood size.  Entropic methods need a
+        support larger than their effective perplexity; this mirrors the
+        ``3 * perplexity`` sparse support used by :class:`EntropicAffinity`.
+        """
+        if n_train < 3:
+            raise ValueError(
+                "[TorchDR] At least 3 training samples are required for transform."
+            )
+        if hasattr(self, "n_neighbors"):
+            requested = int(self.n_neighbors)
+        elif hasattr(self, "perplexity"):
+            requested = int(3 * self.perplexity)
+        else:
+            raise ValueError("[TorchDR] Cannot determine n_neighbors for transform.")
+
+        # The dense distance helper reserves k >= n_train for a full matrix and
+        # does not return indices, so keep a proper k-NN result on every backend.
+        return max(2, min(requested, n_train - 1))
+
+    def _compute_bipartite_entropic_affinity(self, C):
+        """Build a fit-scaled entropic affinity on a bipartite distance graph."""
+        support_size = C.shape[1]
+        if self.perplexity > support_size:
+            raise ValueError(
+                f"[TorchDR] Transform perplexity ({self.perplexity}) exceeds "
+                f"the available neighbor support ({support_size}). Use a larger "
+                "training reference set or a smaller perplexity."
+            )
+        if self.perplexity == support_size:
+            # The only distribution attaining maximal entropy log(k) is the
+            # uniform distribution. Avoid sending this boundary root toward an
+            # effectively infinite bandwidth.
+            return torch.full_like(C, 1.0 / (C.shape[0] * support_size))
+
+        perplexity = torch.tensor(self.perplexity, dtype=C.dtype, device=C.device)
+        target_entropy = perplexity.log() + 1
+
+        def entropy_gap(eps):
+            log_P = _log_Pe(C, eps)
+            log_P_normalized = log_P - logsumexp_red(log_P, dim=1)
+            return entropy(log_P_normalized, log=True).reshape(-1) - target_entropy
+
+        eps = binary_search(
+            f=entropy_gap,
+            n=C.shape[0],
+            max_iter=self.max_iter_affinity,
+            dtype=C.dtype,
+            device=C.device,
+        )
+
+        log_P = _log_Pe(C, eps)
+        log_P -= logsumexp_red(log_P, dim=1)
+
+        # Fit-time EntropicAffinity gives every row mass 1 / n so the complete
+        # attractive distribution has unit mass.  Preserve that invariant for
+        # the n_new bipartite query rows.
+        log_P -= torch.log(torch.tensor(C.shape[0], dtype=C.dtype, device=C.device))
+        return log_P.exp()
 
     def _compute_bipartite_affinity(self, C, indices):
         """Compute bipartite affinity from new points to training points.
@@ -785,28 +908,16 @@ class NegativeSamplingNeighborEmbedding(NeighborEmbedding):
                 device=self.device_,
             )
 
-        exclusion = nn_indices.long().sort(dim=1).values
-        n_excluded = exclusion.shape[1]
-        n_possible = n_train - n_excluded
-        if n_possible <= 0:
-            raise ValueError(
-                "[TorchDR] ERROR : no candidates are available for transform negative "
-                "sampling after excluding neighbors."
-            )
-
-        compressed = torch.randint(
-            0,
-            n_possible,
-            (n_new, self.n_negatives),
-            device=self.device_,
+        adjusted_exclusion, n_available = self._prepare_exclusion_sampling(
+            nn_indices, n_train
         )
-        adjusted_exclusion = exclusion - torch.arange(
-            n_excluded, device=exclusion.device, dtype=exclusion.dtype
+        return self._draw_with_exclusions(
+            adjusted_exclusion, n_available, self.n_negatives, offset=n_new
         )
-        shifts = torch.searchsorted(adjusted_exclusion, compressed, right=True)
-        return compressed + shifts + n_new
 
-    def _initialize_transform_embedding(self, affinity, nn_indices, train_emb):
+    def _initialize_transform_embedding(
+        self, affinity, nn_indices, train_emb, neighbor_distances=None
+    ):
         """Initialize transformed points from the bipartite neighbor graph.
 
         The default initialization is the affinity-weighted average of the
@@ -831,8 +942,9 @@ class NegativeSamplingNeighborEmbedding(NeighborEmbedding):
         X_new : array-like of shape (n_new, n_features)
             New data to transform.
         X_train : array-like of shape (n_train, n_features)
-            Training data used during fit. Required because training data
-            is not stored to avoid memory overhead.
+            Training data used during fit, with the same samples and row order.
+            Required because training features are not stored to avoid memory
+            overhead.
 
         Returns
         -------
@@ -856,11 +968,32 @@ class NegativeSamplingNeighborEmbedding(NeighborEmbedding):
                 "Call fit() or fit_transform() first."
             )
 
-        X_new = to_torch(X_new).to(device=self.device_)
-        X_train = to_torch(X_train).to(device=self.device_)
+        X_new = validate_tensor(to_torch(X_new))
+        X_train = validate_tensor(to_torch(X_train))
+
+        if X_new.shape[1] != self.n_features_in_:
+            raise ValueError(
+                f"[TorchDR] X_new has {X_new.shape[1]} features, but the model "
+                f"was fitted with {self.n_features_in_}."
+            )
+        if X_train.shape[1] != self.n_features_in_:
+            raise ValueError(
+                f"[TorchDR] X_train has {X_train.shape[1]} features, but the model "
+                f"was fitted with {self.n_features_in_}."
+            )
+        if X_train.shape[0] != self.embedding_train_.shape[0]:
+            raise ValueError(
+                f"[TorchDR] X_train has {X_train.shape[0]} samples, but the fitted "
+                f"reference embedding has {self.embedding_train_.shape[0]}. Pass "
+                "the same training samples, in the same order, that were used in fit."
+            )
+
+        compute_dtype = self.embedding_train_.dtype
+        X_new = X_new.to(device=self.device_, dtype=compute_dtype)
+        X_train = X_train.to(device=self.device_, dtype=compute_dtype)
 
         # Step 1: kNN from new points to training points
-        k = self._get_n_neighbors_transform()
+        k = self._get_n_neighbors_transform(X_train.shape[0])
         C, nn_indices = pairwise_distances(
             X=X_new,
             Y=X_train,
@@ -870,6 +1003,10 @@ class NegativeSamplingNeighborEmbedding(NeighborEmbedding):
             return_indices=True,
             device=self.device_,
         )
+        if self.metric in {"euclidean", "sqeuclidean", "manhattan"}:
+            # Round-off in the quadratic squared-distance formula can produce
+            # tiny negative values, including for exact cross-set matches.
+            C.clamp_min_(0)
 
         # Step 2: bipartite affinity (subclass-specific)
         affinity = self._compute_bipartite_affinity(C, nn_indices)
@@ -878,7 +1015,7 @@ class NegativeSamplingNeighborEmbedding(NeighborEmbedding):
 
         # Step 3: initialize from the bipartite graph
         embedding_new = self._initialize_transform_embedding(
-            affinity, nn_indices, train_emb
+            affinity, nn_indices, train_emb, neighbor_distances=C
         )
 
         # Step 4: optimize with frozen training embeddings
@@ -906,7 +1043,6 @@ class NegativeSamplingNeighborEmbedding(NeighborEmbedding):
             State to restore in :meth:`_exit_transform`.
         """
         n_new = embedding_new.shape[0]
-        n_train = train_emb.shape[0]
 
         saved = {}
         for attr in (
@@ -917,23 +1053,40 @@ class NegativeSamplingNeighborEmbedding(NeighborEmbedding):
             "n_samples_in_",
             "early_exaggeration_coeff_",
             "n_iter_",
+            "neg_indices_",
         ):
-            saved[attr] = getattr(self, attr, None)
+            saved[attr] = (hasattr(self, attr), getattr(self, attr, None))
 
-        self.chunk_indices_ = torch.arange(n_new, device=self.device_)
-        # Offset NN indices into the combined [new | train] space
-        self.NN_indices_ = nn_indices + n_new
-        self.affinity_in_ = affinity
-        self.n_samples_in_ = n_new + n_train
-        self.early_exaggeration_coeff_ = 1
-        self.n_iter_ = torch.tensor(0, device=self.device_)
+        chunk_indices = torch.arange(n_new, device=self.device_)
+        transform_nn_indices = nn_indices + n_new
+        transform_n_iter = torch.tensor(0, device=self.device_)
+
+        try:
+            # Most embeddings are leaf tensors, but hyperbolic initialization
+            # uses an nn.Parameter. Remove its registration before assigning a
+            # temporary concatenated tensor in the optimization loop.
+            if isinstance(self.embedding_, torch.nn.Parameter):
+                delattr(self, "embedding_")
+
+            self.chunk_indices_ = chunk_indices
+            self.NN_indices_ = transform_nn_indices
+            self.affinity_in_ = affinity
+            # Existing objectives normalize over query rows. The concatenated
+            # embedding contains reference rows for indexing, but only new rows
+            # are optimized and must contribute to this normalization.
+            self.n_samples_in_ = n_new
+            self.early_exaggeration_coeff_ = 1
+            self.n_iter_ = transform_n_iter
+        except Exception:
+            self._exit_transform(saved)
+            raise
 
         return saved
 
     def _exit_transform(self, saved):
         """Restore fit-time state after transform."""
-        for attr, value in saved.items():
-            if value is not None:
+        for attr, (existed, value) in saved.items():
+            if existed:
                 setattr(self, attr, value)
             elif hasattr(self, attr):
                 delattr(self, attr)
@@ -973,10 +1126,18 @@ class NegativeSamplingNeighborEmbedding(NeighborEmbedding):
 
         optimizer = torch.optim.SGD([embedding_new], lr=lr)
 
-        saved = self._enter_transform(embedding_new, train_emb, affinity, nn_indices)
-
+        saved = None
         try:
+            saved = self._enter_transform(
+                embedding_new, train_emb, affinity, nn_indices
+            )
             for step in range(max_iter_transform):
+                # Match the linear learning-rate decay used by UMAP's transform
+                # and by the default fit schedulers of these methods.
+                optimizer.param_groups[0]["lr"] = lr * (
+                    1.0 - step / max(max_iter_transform, 1)
+                )
+
                 # Rebuild combined embedding each step (new points change)
                 self.embedding_ = torch.cat([embedding_new, train_emb.detach()], dim=0)
                 self.n_iter_.fill_(step)
@@ -996,6 +1157,7 @@ class NegativeSamplingNeighborEmbedding(NeighborEmbedding):
 
                 optimizer.step()
         finally:
-            self._exit_transform(saved)
+            if saved is not None:
+                self._exit_transform(saved)
 
-        return embedding_new.data
+        return embedding_new.detach()

--- a/torchdr/neighbor_embedding/infotsne.py
+++ b/torchdr/neighbor_embedding/infotsne.py
@@ -9,7 +9,7 @@ import torch
 
 from torchdr.affinity import EntropicAffinity
 from torchdr.neighbor_embedding.base import NegativeSamplingNeighborEmbedding
-from torchdr.utils import logsumexp_red, cross_entropy_loss, binary_search
+from torchdr.utils import logsumexp_red, cross_entropy_loss
 from torchdr.distance import FaissConfig, pairwise_distances_indexed
 
 
@@ -195,57 +195,3 @@ class InfoTSNE(NegativeSamplingNeighborEmbedding):
         )
         log_Q = -(1 + distances_sq).log()
         return logsumexp_red(log_Q, dim=1).sum() / self.n_samples_in_
-
-    # --- Non-parametric transform ---
-
-    def _compute_bipartite_affinity(self, C, indices):
-        """Entropic bipartite affinity: exp(-d / sigma) normalized per row."""
-        from torchdr.affinity.entropic import _log_Pe
-
-        target_entropy = (
-            torch.log(torch.tensor(self.perplexity, dtype=C.dtype, device=C.device)) + 1
-        )
-
-        def entropy_gap(eps):
-            log_P = _log_Pe(C, eps)
-            log_P_normalized = log_P - logsumexp_red(log_P, dim=1)
-            H = -(log_P_normalized.exp() * log_P_normalized).sum(dim=1)
-            return H - target_entropy
-
-        eps = binary_search(
-            f=entropy_gap,
-            n=C.shape[0],
-            max_iter=self.max_iter_affinity,
-            dtype=C.dtype,
-            device=C.device,
-        )
-
-        log_P = _log_Pe(C, eps)
-        log_P = log_P - logsumexp_red(log_P, dim=1)
-        return log_P.exp()
-
-    def _compute_transform_loss(
-        self, embedding_new, train_emb, nn_indices, affinity, n_train
-    ):
-        """InfoTSNE transform loss with bipartite indexing."""
-        n_new = embedding_new.shape[0]
-
-        # Attractive: cross-entropy with log Student-t kernel
-        new_points = embedding_new
-        neighbor_points = train_emb[nn_indices.long()]
-        diff_attr = new_points.unsqueeze(1) - neighbor_points
-        distances_sq_attr = (diff_attr**2).sum(dim=-1)
-        log_Q_attr = -(1 + distances_sq_attr).log()
-        attractive_loss = cross_entropy_loss(affinity, log_Q_attr, log=True)
-
-        # Repulsive: logsumexp over negative samples
-        neg_indices = torch.randint(
-            0, n_train, (n_new, self.n_negatives), device=embedding_new.device
-        )
-        neg_points = train_emb[neg_indices.long()]
-        diff_rep = new_points.unsqueeze(1) - neg_points
-        distances_sq_rep = (diff_rep**2).sum(dim=-1)
-        log_Q_rep = -(1 + distances_sq_rep).log()
-        repulsive_loss = logsumexp_red(log_Q_rep, dim=1).sum() / n_new
-
-        return attractive_loss + self.repulsion_strength * repulsive_loss

--- a/torchdr/neighbor_embedding/infotsne.py
+++ b/torchdr/neighbor_embedding/infotsne.py
@@ -32,6 +32,8 @@ class InfoTSNE(NegativeSamplingNeighborEmbedding):
     ----
     This implementation supports multi-GPU training when launched with ``torchrun``.
     Set ``distributed='auto'`` (default) to automatically detect and use multiple GPUs.
+    It also supports the shared non-parametric transform path implemented in
+    :class:`NegativeSamplingNeighborEmbedding`.
 
     Parameters
     ----------
@@ -200,7 +202,13 @@ class InfoTSNE(NegativeSamplingNeighborEmbedding):
         return logsumexp_red(log_Q, dim=1).sum() / self.n_samples_in_
 
     def _compute_bipartite_affinity(self, C, indices):
-        """Entropic bipartite affinity: exp(-d / sigma) normalized per row."""
+        """Build the InfoTSNE bipartite affinity used during transform.
+
+        This is the InfoTSNE-specific hook for the shared non-parametric
+        transform pipeline in :class:`NegativeSamplingNeighborEmbedding`.
+        It converts distances from each new point to its training neighbors
+        into a row-normalized entropic affinity.
+        """
         target_entropy = (
             torch.log(torch.tensor(self.perplexity, dtype=C.dtype, device=C.device)) + 1
         )

--- a/torchdr/neighbor_embedding/infotsne.py
+++ b/torchdr/neighbor_embedding/infotsne.py
@@ -8,8 +8,9 @@ from typing import Dict, Union, Optional, Type
 import torch
 
 from torchdr.affinity import EntropicAffinity
+from torchdr.affinity.entropic import _log_Pe
 from torchdr.neighbor_embedding.base import NegativeSamplingNeighborEmbedding
-from torchdr.utils import logsumexp_red, cross_entropy_loss
+from torchdr.utils import logsumexp_red, cross_entropy_loss, binary_search
 from torchdr.distance import FaissConfig, pairwise_distances_indexed
 
 
@@ -195,3 +196,27 @@ class InfoTSNE(NegativeSamplingNeighborEmbedding):
         )
         log_Q = -(1 + distances_sq).log()
         return logsumexp_red(log_Q, dim=1).sum() / self.n_samples_in_
+
+    def _compute_bipartite_affinity(self, C, indices):
+        """Entropic bipartite affinity: exp(-d / sigma) normalized per row."""
+        target_entropy = (
+            torch.log(torch.tensor(self.perplexity, dtype=C.dtype, device=C.device)) + 1
+        )
+
+        def entropy_gap(eps):
+            log_P = _log_Pe(C, eps)
+            log_P_norm = log_P - logsumexp_red(log_P, dim=1)
+            H = -(log_P_norm.exp() * log_P_norm).sum(dim=1)
+            return H - target_entropy
+
+        eps = binary_search(
+            f=entropy_gap,
+            n=C.shape[0],
+            max_iter=self.max_iter_affinity,
+            dtype=C.dtype,
+            device=C.device,
+        )
+
+        log_P = _log_Pe(C, eps)
+        log_P = log_P - logsumexp_red(log_P, dim=1)
+        return log_P.exp()

--- a/torchdr/neighbor_embedding/infotsne.py
+++ b/torchdr/neighbor_embedding/infotsne.py
@@ -9,7 +9,7 @@ import torch
 
 from torchdr.affinity import EntropicAffinity
 from torchdr.neighbor_embedding.base import NegativeSamplingNeighborEmbedding
-from torchdr.utils import logsumexp_red, cross_entropy_loss
+from torchdr.utils import logsumexp_red, cross_entropy_loss, binary_search
 from torchdr.distance import FaissConfig, pairwise_distances_indexed
 
 
@@ -195,3 +195,57 @@ class InfoTSNE(NegativeSamplingNeighborEmbedding):
         )
         log_Q = -(1 + distances_sq).log()
         return logsumexp_red(log_Q, dim=1).sum() / self.n_samples_in_
+
+    # --- Non-parametric transform ---
+
+    def _compute_bipartite_affinity(self, C, indices):
+        """Entropic bipartite affinity: exp(-d / sigma) normalized per row."""
+        from torchdr.affinity.entropic import _log_Pe
+
+        target_entropy = (
+            torch.log(torch.tensor(self.perplexity, dtype=C.dtype, device=C.device)) + 1
+        )
+
+        def entropy_gap(eps):
+            log_P = _log_Pe(C, eps)
+            log_P_normalized = log_P - logsumexp_red(log_P, dim=1)
+            H = -(log_P_normalized.exp() * log_P_normalized).sum(dim=1)
+            return H - target_entropy
+
+        eps = binary_search(
+            f=entropy_gap,
+            n=C.shape[0],
+            max_iter=self.max_iter_affinity,
+            dtype=C.dtype,
+            device=C.device,
+        )
+
+        log_P = _log_Pe(C, eps)
+        log_P = log_P - logsumexp_red(log_P, dim=1)
+        return log_P.exp()
+
+    def _compute_transform_loss(
+        self, embedding_new, train_emb, nn_indices, affinity, n_train
+    ):
+        """InfoTSNE transform loss with bipartite indexing."""
+        n_new = embedding_new.shape[0]
+
+        # Attractive: cross-entropy with log Student-t kernel
+        new_points = embedding_new
+        neighbor_points = train_emb[nn_indices.long()]
+        diff_attr = new_points.unsqueeze(1) - neighbor_points
+        distances_sq_attr = (diff_attr**2).sum(dim=-1)
+        log_Q_attr = -(1 + distances_sq_attr).log()
+        attractive_loss = cross_entropy_loss(affinity, log_Q_attr, log=True)
+
+        # Repulsive: logsumexp over negative samples
+        neg_indices = torch.randint(
+            0, n_train, (n_new, self.n_negatives), device=embedding_new.device
+        )
+        neg_points = train_emb[neg_indices.long()]
+        diff_rep = new_points.unsqueeze(1) - neg_points
+        distances_sq_rep = (diff_rep**2).sum(dim=-1)
+        log_Q_rep = -(1 + distances_sq_rep).log()
+        repulsive_loss = logsumexp_red(log_Q_rep, dim=1).sum() / n_new
+
+        return attractive_loss + self.repulsion_strength * repulsive_loss

--- a/torchdr/neighbor_embedding/infotsne.py
+++ b/torchdr/neighbor_embedding/infotsne.py
@@ -132,7 +132,7 @@ class InfoTSNE(NegativeSamplingNeighborEmbedding):
         n_negatives: int = 300,
         sparsity: bool = True,
         check_interval: int = 50,
-        exclude_neighbors_from_negative_sampling: Optional[bool] = None,
+        exclude_neighbors_from_negative_sampling: bool = False,
         compile: bool = False,
         distributed: Union[bool, str] = "auto",
         **kwargs,
@@ -173,9 +173,7 @@ class InfoTSNE(NegativeSamplingNeighborEmbedding):
             early_exaggeration_iter=early_exaggeration_iter,
             n_negatives=n_negatives,
             check_interval=check_interval,
-            exclude_neighbors_from_negative_sampling=(
-                exclude_neighbors_from_negative_sampling
-            ),
+            exclude_neighbors_from_negative_sampling=exclude_neighbors_from_negative_sampling,
             compile=compile,
             distributed=distributed,
             **kwargs,

--- a/torchdr/neighbor_embedding/infotsne.py
+++ b/torchdr/neighbor_embedding/infotsne.py
@@ -90,8 +90,8 @@ class InfoTSNE(NegativeSamplingNeighborEmbedding):
         Whether to use sparsity mode for the input affinity. Default is True.
     check_interval : int, optional
         Interval for checking convergence, by default 50.
-    discard_NNs : bool, optional
-        Whether to discard the nearest neighbors from the negative sampling.
+    exclude_neighbors_from_negative_sampling : bool, optional
+        Whether to exclude nearest neighbors from negative sampling.
         Default is False.
     compile : bool, optional
         Whether to compile the loss function with `torch.compile` for faster
@@ -130,7 +130,7 @@ class InfoTSNE(NegativeSamplingNeighborEmbedding):
         n_negatives: int = 300,
         sparsity: bool = True,
         check_interval: int = 50,
-        discard_NNs: bool = False,
+        exclude_neighbors_from_negative_sampling: Optional[bool] = None,
         compile: bool = False,
         distributed: Union[bool, str] = "auto",
         **kwargs,
@@ -171,7 +171,9 @@ class InfoTSNE(NegativeSamplingNeighborEmbedding):
             early_exaggeration_iter=early_exaggeration_iter,
             n_negatives=n_negatives,
             check_interval=check_interval,
-            discard_NNs=discard_NNs,
+            exclude_neighbors_from_negative_sampling=(
+                exclude_neighbors_from_negative_sampling
+            ),
             compile=compile,
             distributed=distributed,
             **kwargs,

--- a/torchdr/neighbor_embedding/infotsne.py
+++ b/torchdr/neighbor_embedding/infotsne.py
@@ -8,9 +8,8 @@ from typing import Dict, Union, Optional, Type
 import torch
 
 from torchdr.affinity import EntropicAffinity
-from torchdr.affinity.entropic import _log_Pe
 from torchdr.neighbor_embedding.base import NegativeSamplingNeighborEmbedding
-from torchdr.utils import logsumexp_red, cross_entropy_loss, binary_search
+from torchdr.utils import logsumexp_red, cross_entropy_loss
 from torchdr.distance import FaissConfig, pairwise_distances_indexed
 
 
@@ -95,6 +94,8 @@ class InfoTSNE(NegativeSamplingNeighborEmbedding):
     exclude_neighbors_from_negative_sampling : bool, optional
         Whether to exclude nearest neighbors from negative sampling.
         Default is False.
+    discard_NNs : bool, optional
+        Deprecated alias for ``exclude_neighbors_from_negative_sampling``.
     compile : bool, optional
         Whether to compile the loss function with `torch.compile` for faster
         computation. Default is False.
@@ -132,7 +133,8 @@ class InfoTSNE(NegativeSamplingNeighborEmbedding):
         n_negatives: int = 300,
         sparsity: bool = True,
         check_interval: int = 50,
-        exclude_neighbors_from_negative_sampling: bool = False,
+        exclude_neighbors_from_negative_sampling: Optional[bool] = None,
+        discard_NNs: Optional[bool] = None,
         compile: bool = False,
         distributed: Union[bool, str] = "auto",
         **kwargs,
@@ -174,6 +176,7 @@ class InfoTSNE(NegativeSamplingNeighborEmbedding):
             n_negatives=n_negatives,
             check_interval=check_interval,
             exclude_neighbors_from_negative_sampling=exclude_neighbors_from_negative_sampling,
+            discard_NNs=discard_NNs,
             compile=compile,
             distributed=distributed,
             **kwargs,
@@ -207,24 +210,4 @@ class InfoTSNE(NegativeSamplingNeighborEmbedding):
         It converts distances from each new point to its training neighbors
         into a row-normalized entropic affinity.
         """
-        target_entropy = (
-            torch.log(torch.tensor(self.perplexity, dtype=C.dtype, device=C.device)) + 1
-        )
-
-        def entropy_gap(eps):
-            log_P = _log_Pe(C, eps)
-            log_P_norm = log_P - logsumexp_red(log_P, dim=1)
-            H = -(log_P_norm.exp() * log_P_norm).sum(dim=1)
-            return H - target_entropy
-
-        eps = binary_search(
-            f=entropy_gap,
-            n=C.shape[0],
-            max_iter=self.max_iter_affinity,
-            dtype=C.dtype,
-            device=C.device,
-        )
-
-        log_P = _log_Pe(C, eps)
-        log_P = log_P - logsumexp_red(log_P, dim=1)
-        return log_P.exp()
+        return self._compute_bipartite_entropic_affinity(C)

--- a/torchdr/neighbor_embedding/largevis.py
+++ b/torchdr/neighbor_embedding/largevis.py
@@ -9,7 +9,7 @@ import torch
 
 from torchdr.affinity import EntropicAffinity
 from torchdr.neighbor_embedding.base import NegativeSamplingNeighborEmbedding
-from torchdr.utils import cross_entropy_loss, sum_red
+from torchdr.utils import cross_entropy_loss, sum_red, binary_search, logsumexp_red
 from torchdr.distance import FaissConfig, pairwise_distances_indexed
 
 
@@ -199,3 +199,60 @@ class LargeVis(NegativeSamplingNeighborEmbedding):
         Q = 1.0 / (1.0 + distances_sq)
         Q = Q / (Q + 1)
         return cross_entropy_loss(self.affinity_in_, Q)
+
+    # --- Non-parametric transform ---
+
+    def _compute_bipartite_affinity(self, C, indices):
+        """Entropic bipartite affinity: exp(-d / sigma) normalized per row."""
+        from torchdr.affinity.entropic import _log_Pe
+
+        target_entropy = (
+            torch.log(torch.tensor(self.perplexity, dtype=C.dtype, device=C.device)) + 1
+        )
+
+        def entropy_gap(eps):
+            log_P = _log_Pe(C, eps)
+            log_P_normalized = log_P - logsumexp_red(log_P, dim=1)
+            H = -(log_P_normalized.exp() * log_P_normalized).sum(dim=1)
+            return H - target_entropy
+
+        eps = binary_search(
+            f=entropy_gap,
+            n=C.shape[0],
+            max_iter=self.max_iter_affinity,
+            dtype=C.dtype,
+            device=C.device,
+        )
+
+        log_P = _log_Pe(C, eps)
+        # Normalize per row (row-stochastic)
+        log_P = log_P - logsumexp_red(log_P, dim=1)
+        return log_P.exp()
+
+    def _compute_transform_loss(
+        self, embedding_new, train_emb, nn_indices, affinity, n_train
+    ):
+        """LargeVis transform loss with bipartite indexing."""
+        n_new = embedding_new.shape[0]
+
+        # Attractive: cross-entropy between bipartite affinity and output kernel
+        new_points = embedding_new  # (n_new, d)
+        neighbor_points = train_emb[nn_indices.long()]  # (n_new, k, d)
+        diff_attr = new_points.unsqueeze(1) - neighbor_points
+        distances_sq_attr = (diff_attr**2).sum(dim=-1)  # (n_new, k)
+        Q_attr = 1.0 / (1.0 + distances_sq_attr)
+        Q_attr = Q_attr / (Q_attr + 1)
+        attractive_loss = cross_entropy_loss(affinity, Q_attr)
+
+        # Repulsive: negative sampling from training points
+        neg_indices = torch.randint(
+            0, n_train, (n_new, self.n_negatives), device=embedding_new.device
+        )
+        neg_points = train_emb[neg_indices.long()]
+        diff_rep = new_points.unsqueeze(1) - neg_points
+        distances_sq_rep = (diff_rep**2).sum(dim=-1)
+        Q_rep = 1.0 / (1.0 + distances_sq_rep)
+        Q_rep = Q_rep / (Q_rep + 1)
+        repulsive_loss = -sum_red((1 - Q_rep).log(), dim=(0, 1)) / n_new
+
+        return attractive_loss + self.repulsion_strength * repulsive_loss

--- a/torchdr/neighbor_embedding/largevis.py
+++ b/torchdr/neighbor_embedding/largevis.py
@@ -134,7 +134,7 @@ class LargeVis(NegativeSamplingNeighborEmbedding):
         early_exaggeration_coeff: Optional[float] = None,
         early_exaggeration_iter: Optional[int] = None,
         check_interval: int = 50,
-        exclude_neighbors_from_negative_sampling: Optional[bool] = None,
+        exclude_neighbors_from_negative_sampling: bool = False,
         compile: bool = False,
         distributed: Union[bool, str] = "auto",
         **kwargs,
@@ -175,9 +175,7 @@ class LargeVis(NegativeSamplingNeighborEmbedding):
             early_exaggeration_iter=early_exaggeration_iter,
             n_negatives=n_negatives,
             check_interval=check_interval,
-            exclude_neighbors_from_negative_sampling=(
-                exclude_neighbors_from_negative_sampling
-            ),
+            exclude_neighbors_from_negative_sampling=exclude_neighbors_from_negative_sampling,
             compile=compile,
             distributed=distributed,
             **kwargs,

--- a/torchdr/neighbor_embedding/largevis.py
+++ b/torchdr/neighbor_embedding/largevis.py
@@ -93,8 +93,8 @@ class LargeVis(NegativeSamplingNeighborEmbedding):
         Default is None (no early exaggeration).
     early_exaggeration_iter : int, optional
         Number of iterations for early exaggeration. Default is None.
-    discard_NNs : bool, optional
-        Whether to discard the nearest neighbors from the negative sampling.
+    exclude_neighbors_from_negative_sampling : bool, optional
+        Whether to exclude nearest neighbors from negative sampling.
         Default is False.
     compile : bool, optional
         Whether to compile the algorithm using torch.compile. Default is False.
@@ -132,7 +132,7 @@ class LargeVis(NegativeSamplingNeighborEmbedding):
         early_exaggeration_coeff: Optional[float] = None,
         early_exaggeration_iter: Optional[int] = None,
         check_interval: int = 50,
-        discard_NNs: bool = False,
+        exclude_neighbors_from_negative_sampling: Optional[bool] = None,
         compile: bool = False,
         distributed: Union[bool, str] = "auto",
         **kwargs,
@@ -173,7 +173,9 @@ class LargeVis(NegativeSamplingNeighborEmbedding):
             early_exaggeration_iter=early_exaggeration_iter,
             n_negatives=n_negatives,
             check_interval=check_interval,
-            discard_NNs=discard_NNs,
+            exclude_neighbors_from_negative_sampling=(
+                exclude_neighbors_from_negative_sampling
+            ),
             compile=compile,
             distributed=distributed,
             **kwargs,

--- a/torchdr/neighbor_embedding/largevis.py
+++ b/torchdr/neighbor_embedding/largevis.py
@@ -8,8 +8,9 @@ from typing import Dict, Optional, Union, Type
 import torch
 
 from torchdr.affinity import EntropicAffinity
+from torchdr.affinity.entropic import _log_Pe
 from torchdr.neighbor_embedding.base import NegativeSamplingNeighborEmbedding
-from torchdr.utils import cross_entropy_loss, sum_red
+from torchdr.utils import cross_entropy_loss, sum_red, binary_search, logsumexp_red
 from torchdr.distance import FaissConfig, pairwise_distances_indexed
 
 
@@ -199,3 +200,27 @@ class LargeVis(NegativeSamplingNeighborEmbedding):
         Q = 1.0 / (1.0 + distances_sq)
         Q = Q / (Q + 1)
         return cross_entropy_loss(self.affinity_in_, Q)
+
+    def _compute_bipartite_affinity(self, C, indices):
+        """Entropic bipartite affinity: exp(-d / sigma) normalized per row."""
+        target_entropy = (
+            torch.log(torch.tensor(self.perplexity, dtype=C.dtype, device=C.device)) + 1
+        )
+
+        def entropy_gap(eps):
+            log_P = _log_Pe(C, eps)
+            log_P_norm = log_P - logsumexp_red(log_P, dim=1)
+            H = -(log_P_norm.exp() * log_P_norm).sum(dim=1)
+            return H - target_entropy
+
+        eps = binary_search(
+            f=entropy_gap,
+            n=C.shape[0],
+            max_iter=self.max_iter_affinity,
+            dtype=C.dtype,
+            device=C.device,
+        )
+
+        log_P = _log_Pe(C, eps)
+        log_P = log_P - logsumexp_red(log_P, dim=1)
+        return log_P.exp()

--- a/torchdr/neighbor_embedding/largevis.py
+++ b/torchdr/neighbor_embedding/largevis.py
@@ -32,6 +32,8 @@ class LargeVis(NegativeSamplingNeighborEmbedding):
     ----
     This implementation supports multi-GPU training when launched with ``torchrun``.
     Set ``distributed='auto'`` (default) to automatically detect and use multiple GPUs.
+    It also supports the shared non-parametric transform path implemented in
+    :class:`NegativeSamplingNeighborEmbedding`.
 
     Parameters
     ----------
@@ -204,7 +206,13 @@ class LargeVis(NegativeSamplingNeighborEmbedding):
         return cross_entropy_loss(self.affinity_in_, Q)
 
     def _compute_bipartite_affinity(self, C, indices):
-        """Entropic bipartite affinity: exp(-d / sigma) normalized per row."""
+        """Build the LargeVis bipartite affinity used during transform.
+
+        This is the LargeVis-specific hook for the shared non-parametric
+        transform pipeline in :class:`NegativeSamplingNeighborEmbedding`.
+        It converts distances from each new point to its training neighbors
+        into a row-normalized entropic affinity.
+        """
         target_entropy = (
             torch.log(torch.tensor(self.perplexity, dtype=C.dtype, device=C.device)) + 1
         )

--- a/torchdr/neighbor_embedding/largevis.py
+++ b/torchdr/neighbor_embedding/largevis.py
@@ -9,7 +9,7 @@ import torch
 
 from torchdr.affinity import EntropicAffinity
 from torchdr.neighbor_embedding.base import NegativeSamplingNeighborEmbedding
-from torchdr.utils import cross_entropy_loss, sum_red, binary_search, logsumexp_red
+from torchdr.utils import cross_entropy_loss, sum_red
 from torchdr.distance import FaissConfig, pairwise_distances_indexed
 
 
@@ -199,60 +199,3 @@ class LargeVis(NegativeSamplingNeighborEmbedding):
         Q = 1.0 / (1.0 + distances_sq)
         Q = Q / (Q + 1)
         return cross_entropy_loss(self.affinity_in_, Q)
-
-    # --- Non-parametric transform ---
-
-    def _compute_bipartite_affinity(self, C, indices):
-        """Entropic bipartite affinity: exp(-d / sigma) normalized per row."""
-        from torchdr.affinity.entropic import _log_Pe
-
-        target_entropy = (
-            torch.log(torch.tensor(self.perplexity, dtype=C.dtype, device=C.device)) + 1
-        )
-
-        def entropy_gap(eps):
-            log_P = _log_Pe(C, eps)
-            log_P_normalized = log_P - logsumexp_red(log_P, dim=1)
-            H = -(log_P_normalized.exp() * log_P_normalized).sum(dim=1)
-            return H - target_entropy
-
-        eps = binary_search(
-            f=entropy_gap,
-            n=C.shape[0],
-            max_iter=self.max_iter_affinity,
-            dtype=C.dtype,
-            device=C.device,
-        )
-
-        log_P = _log_Pe(C, eps)
-        # Normalize per row (row-stochastic)
-        log_P = log_P - logsumexp_red(log_P, dim=1)
-        return log_P.exp()
-
-    def _compute_transform_loss(
-        self, embedding_new, train_emb, nn_indices, affinity, n_train
-    ):
-        """LargeVis transform loss with bipartite indexing."""
-        n_new = embedding_new.shape[0]
-
-        # Attractive: cross-entropy between bipartite affinity and output kernel
-        new_points = embedding_new  # (n_new, d)
-        neighbor_points = train_emb[nn_indices.long()]  # (n_new, k, d)
-        diff_attr = new_points.unsqueeze(1) - neighbor_points
-        distances_sq_attr = (diff_attr**2).sum(dim=-1)  # (n_new, k)
-        Q_attr = 1.0 / (1.0 + distances_sq_attr)
-        Q_attr = Q_attr / (Q_attr + 1)
-        attractive_loss = cross_entropy_loss(affinity, Q_attr)
-
-        # Repulsive: negative sampling from training points
-        neg_indices = torch.randint(
-            0, n_train, (n_new, self.n_negatives), device=embedding_new.device
-        )
-        neg_points = train_emb[neg_indices.long()]
-        diff_rep = new_points.unsqueeze(1) - neg_points
-        distances_sq_rep = (diff_rep**2).sum(dim=-1)
-        Q_rep = 1.0 / (1.0 + distances_sq_rep)
-        Q_rep = Q_rep / (Q_rep + 1)
-        repulsive_loss = -sum_red((1 - Q_rep).log(), dim=(0, 1)) / n_new
-
-        return attractive_loss + self.repulsion_strength * repulsive_loss

--- a/torchdr/neighbor_embedding/largevis.py
+++ b/torchdr/neighbor_embedding/largevis.py
@@ -8,9 +8,8 @@ from typing import Dict, Optional, Union, Type
 import torch
 
 from torchdr.affinity import EntropicAffinity
-from torchdr.affinity.entropic import _log_Pe
 from torchdr.neighbor_embedding.base import NegativeSamplingNeighborEmbedding
-from torchdr.utils import cross_entropy_loss, sum_red, binary_search, logsumexp_red
+from torchdr.utils import cross_entropy_loss, sum_red
 from torchdr.distance import FaissConfig, pairwise_distances_indexed
 
 
@@ -98,6 +97,8 @@ class LargeVis(NegativeSamplingNeighborEmbedding):
     exclude_neighbors_from_negative_sampling : bool, optional
         Whether to exclude nearest neighbors from negative sampling.
         Default is False.
+    discard_NNs : bool, optional
+        Deprecated alias for ``exclude_neighbors_from_negative_sampling``.
     compile : bool, optional
         Whether to compile the algorithm using torch.compile. Default is False.
     distributed : bool or 'auto', optional
@@ -134,7 +135,8 @@ class LargeVis(NegativeSamplingNeighborEmbedding):
         early_exaggeration_coeff: Optional[float] = None,
         early_exaggeration_iter: Optional[int] = None,
         check_interval: int = 50,
-        exclude_neighbors_from_negative_sampling: bool = False,
+        exclude_neighbors_from_negative_sampling: Optional[bool] = None,
+        discard_NNs: Optional[bool] = None,
         compile: bool = False,
         distributed: Union[bool, str] = "auto",
         **kwargs,
@@ -176,6 +178,7 @@ class LargeVis(NegativeSamplingNeighborEmbedding):
             n_negatives=n_negatives,
             check_interval=check_interval,
             exclude_neighbors_from_negative_sampling=exclude_neighbors_from_negative_sampling,
+            discard_NNs=discard_NNs,
             compile=compile,
             distributed=distributed,
             **kwargs,
@@ -211,24 +214,4 @@ class LargeVis(NegativeSamplingNeighborEmbedding):
         It converts distances from each new point to its training neighbors
         into a row-normalized entropic affinity.
         """
-        target_entropy = (
-            torch.log(torch.tensor(self.perplexity, dtype=C.dtype, device=C.device)) + 1
-        )
-
-        def entropy_gap(eps):
-            log_P = _log_Pe(C, eps)
-            log_P_norm = log_P - logsumexp_red(log_P, dim=1)
-            H = -(log_P_norm.exp() * log_P_norm).sum(dim=1)
-            return H - target_entropy
-
-        eps = binary_search(
-            f=entropy_gap,
-            n=C.shape[0],
-            max_iter=self.max_iter_affinity,
-            dtype=C.dtype,
-            device=C.device,
-        )
-
-        log_P = _log_Pe(C, eps)
-        log_P = log_P - logsumexp_red(log_P, dim=1)
-        return log_P.exp()
+        return self._compute_bipartite_entropic_affinity(C)

--- a/torchdr/neighbor_embedding/pacmap.py
+++ b/torchdr/neighbor_embedding/pacmap.py
@@ -25,6 +25,10 @@ class PACMAP(NegativeSamplingNeighborEmbedding):
     where :math:`\mathrm{NB}(i)`, :math:`\mathrm{MN}(i)` and :math:`\mathrm{FP}(i)` are the nearest neighbors, mid-near neighbors and far neighbors of point :math:`i` respectively,
     and :math:`d_{ij} = 1 + \|\mathbf{z}_i - \mathbf{z}_j\|^2` (more details in :cite:`wang2021understanding`).
 
+    Unlike UMAP, LargeVis, and InfoTSNE, PACMAP does not currently implement
+    the bipartite affinity hook needed for the shared non-parametric transform
+    pipeline, so :meth:`transform` is not supported for unseen points.
+
     Parameters
     ----------
     n_neighbors : int, optional

--- a/torchdr/neighbor_embedding/pacmap.py
+++ b/torchdr/neighbor_embedding/pacmap.py
@@ -117,16 +117,13 @@ class PACMAP(NegativeSamplingNeighborEmbedding):
         FP_ratio: float = 2,
         check_interval: int = 50,
         iter_per_phase: int = 100,
-        exclude_neighbors_from_negative_sampling: Optional[bool] = None,
+        exclude_neighbors_from_negative_sampling: bool = True,
         compile: bool = False,
         distributed: Union[bool, str] = False,
         **kwargs,
     ):
         if distributed:
             raise ValueError("[TorchDR] ERROR : PACMAP does not support distributed.")
-
-        if exclude_neighbors_from_negative_sampling is None:
-            exclude_neighbors_from_negative_sampling = True
 
         self.n_neighbors = n_neighbors
         self.metric = metric
@@ -164,9 +161,7 @@ class PACMAP(NegativeSamplingNeighborEmbedding):
             random_state=random_state,
             check_interval=check_interval,
             n_negatives=self.n_further,
-            exclude_neighbors_from_negative_sampling=(
-                exclude_neighbors_from_negative_sampling
-            ),
+            exclude_neighbors_from_negative_sampling=exclude_neighbors_from_negative_sampling,
             compile=compile,
             distributed=distributed,
             **kwargs,

--- a/torchdr/neighbor_embedding/pacmap.py
+++ b/torchdr/neighbor_embedding/pacmap.py
@@ -76,8 +76,8 @@ class PACMAP(NegativeSamplingNeighborEmbedding):
         Interval for checking convergence, by default 50.
     iter_per_phase : int, optional
         Number of iterations for each phase of the algorithm, by default 100.
-    discard_NNs : bool, optional
-        Whether to discard the nearest neighbors from the negative sampling.
+    exclude_neighbors_from_negative_sampling : bool, optional
+        Whether to exclude nearest neighbors from negative sampling.
         Default is True.
     compile : bool, optional
         Whether to compile the algorithm using torch.compile. Default is False.
@@ -113,13 +113,16 @@ class PACMAP(NegativeSamplingNeighborEmbedding):
         FP_ratio: float = 2,
         check_interval: int = 50,
         iter_per_phase: int = 100,
-        discard_NNs: bool = True,
+        exclude_neighbors_from_negative_sampling: Optional[bool] = None,
         compile: bool = False,
         distributed: Union[bool, str] = False,
         **kwargs,
     ):
         if distributed:
             raise ValueError("[TorchDR] ERROR : PACMAP does not support distributed.")
+
+        if exclude_neighbors_from_negative_sampling is None:
+            exclude_neighbors_from_negative_sampling = True
 
         self.n_neighbors = n_neighbors
         self.metric = metric
@@ -157,7 +160,9 @@ class PACMAP(NegativeSamplingNeighborEmbedding):
             random_state=random_state,
             check_interval=check_interval,
             n_negatives=self.n_further,
-            discard_NNs=discard_NNs,
+            exclude_neighbors_from_negative_sampling=(
+                exclude_neighbors_from_negative_sampling
+            ),
             compile=compile,
             distributed=distributed,
             **kwargs,

--- a/torchdr/neighbor_embedding/pacmap.py
+++ b/torchdr/neighbor_embedding/pacmap.py
@@ -83,6 +83,8 @@ class PACMAP(NegativeSamplingNeighborEmbedding):
     exclude_neighbors_from_negative_sampling : bool, optional
         Whether to exclude nearest neighbors from negative sampling.
         Default is True.
+    discard_NNs : bool, optional
+        Deprecated alias for ``exclude_neighbors_from_negative_sampling``.
     compile : bool, optional
         Whether to compile the algorithm using torch.compile. Default is False.
     distributed : bool or 'auto', optional
@@ -117,13 +119,20 @@ class PACMAP(NegativeSamplingNeighborEmbedding):
         FP_ratio: float = 2,
         check_interval: int = 50,
         iter_per_phase: int = 100,
-        exclude_neighbors_from_negative_sampling: bool = True,
+        exclude_neighbors_from_negative_sampling: Optional[bool] = None,
+        discard_NNs: Optional[bool] = None,
         compile: bool = False,
         distributed: Union[bool, str] = False,
         **kwargs,
     ):
         if distributed:
             raise ValueError("[TorchDR] ERROR : PACMAP does not support distributed.")
+
+        # PACMAP historically excluded neighbors by default.  ``None`` lets us
+        # preserve that default while still detecting whether the deprecated
+        # alias was supplied on its own.
+        if exclude_neighbors_from_negative_sampling is None and discard_NNs is None:
+            exclude_neighbors_from_negative_sampling = True
 
         self.n_neighbors = n_neighbors
         self.metric = metric
@@ -162,6 +171,7 @@ class PACMAP(NegativeSamplingNeighborEmbedding):
             check_interval=check_interval,
             n_negatives=self.n_further,
             exclude_neighbors_from_negative_sampling=exclude_neighbors_from_negative_sampling,
+            discard_NNs=discard_NNs,
             compile=compile,
             distributed=distributed,
             **kwargs,

--- a/torchdr/neighbor_embedding/umap.py
+++ b/torchdr/neighbor_embedding/umap.py
@@ -157,7 +157,7 @@ class UMAP(NegativeSamplingNeighborEmbedding):
         metric: str = "sqeuclidean",
         negative_sample_rate: int = 5,
         check_interval: int = 50,
-        exclude_neighbors_from_negative_sampling: Optional[bool] = None,
+        exclude_neighbors_from_negative_sampling: bool = False,
         compile: bool = False,
         distributed: Union[bool, str] = "auto",
         **kwargs,
@@ -209,9 +209,7 @@ class UMAP(NegativeSamplingNeighborEmbedding):
             verbose=verbose,
             random_state=random_state,
             check_interval=check_interval,
-            exclude_neighbors_from_negative_sampling=(
-                exclude_neighbors_from_negative_sampling
-            ),
+            exclude_neighbors_from_negative_sampling=exclude_neighbors_from_negative_sampling,
             compile=compile,
             n_negatives=self.n_negatives,
             distributed=distributed,

--- a/torchdr/neighbor_embedding/umap.py
+++ b/torchdr/neighbor_embedding/umap.py
@@ -56,6 +56,8 @@ class UMAP(NegativeSamplingNeighborEmbedding):
     ----
     This implementation supports multi-GPU training when launched with ``torchrun``.
     Set ``distributed='auto'`` (default) to automatically detect and use multiple GPUs.
+    It also supports the shared non-parametric transform path implemented in
+    :class:`NegativeSamplingNeighborEmbedding`.
 
     Parameters
     ----------
@@ -298,7 +300,13 @@ class UMAP(NegativeSamplingNeighborEmbedding):
     # --- Non-parametric transform ---
 
     def _compute_bipartite_affinity(self, C, indices):
-        """UMAP bipartite affinity: exp(-(d - rho) / sigma), no symmetrization."""
+        """Build the UMAP bipartite affinity used during transform.
+
+        This is the UMAP-specific hook for the shared non-parametric transform
+        pipeline in :class:`NegativeSamplingNeighborEmbedding`. It mirrors the
+        unsymmetrized UMAP neighbor graph construction on the bipartite graph
+        from new points to the fitted training set.
+        """
         rho = kmin(C, k=1, dim=1)[0].squeeze(-1).contiguous()
 
         log_n_neighbors = torch.log2(
@@ -320,7 +328,11 @@ class UMAP(NegativeSamplingNeighborEmbedding):
         return _log_P_UMAP(C, rho, eps).exp()
 
     def _make_transform_epochs_per_sample(self, affinity, n_epochs):
-        """Convert transform edge strengths into UMAP's epoch schedule."""
+        """Convert transform edge strengths into UMAP's epoch schedule.
+
+        This keeps the transform path aligned with UMAP's usual edge-sampling
+        logic while still using TorchDR's vectorized, mask-based optimizer.
+        """
         epochs_per_sample = torch.full_like(affinity, float("inf"))
         if n_epochs <= 0:
             return epochs_per_sample
@@ -338,7 +350,12 @@ class UMAP(NegativeSamplingNeighborEmbedding):
         return epochs_per_sample
 
     def _initialize_transform_embedding(self, affinity, nn_indices, train_emb):
-        """Match UMAP's exact-neighbor initialization when possible."""
+        """Match UMAP's transform initialization when exact matches exist.
+
+        The default weighted-average initialization from the base class is kept,
+        except that rows with an affinity of 1 are snapped to the corresponding
+        training embedding exactly, as in ``umap-learn``.
+        """
         embedding_new = super()._initialize_transform_embedding(
             affinity, nn_indices, train_emb
         )
@@ -357,7 +374,9 @@ class UMAP(NegativeSamplingNeighborEmbedding):
         """Set up UMAP edge-sampling state for transform.
 
         Reuses the same edge-sampling schedule as fit, but on the bipartite
-        graph between new points and the frozen training embedding.
+        graph between new points and the frozen training embedding. The actual
+        optimization still runs through TorchDR's vectorized mask-based update
+        path rather than ``umap-learn``'s edge-wise CPU loop.
         """
         saved = super()._enter_transform(embedding_new, train_emb, affinity, nn_indices)
 

--- a/torchdr/neighbor_embedding/umap.py
+++ b/torchdr/neighbor_embedding/umap.py
@@ -317,45 +317,21 @@ class UMAP(NegativeSamplingNeighborEmbedding):
 
         return _log_P_UMAP(C, rho, eps).exp()
 
-    @torch.no_grad()
-    def _compute_transform_gradients(
-        self, embedding_new, train_emb, nn_indices, affinity, n_train
-    ):
-        """Compute UMAP attractive + repulsive gradients for transform.
+    def _enter_transform(self, embedding_new, train_emb, affinity, nn_indices):
+        """Set up UMAP edge-sampling state for transform.
 
-        Mirrors the fit-time gradient computation but operates on a bipartite
-        graph (new points → training points) with frozen training embeddings.
+        Sets ``epochs_per_sample`` and ``epoch_of_next_sample`` to zeros so
+        all edges are active every iteration (no edge-sampling during transform).
         """
-        # --- Attractive gradients ---
-        new_points = embedding_new.data  # (n_new, d)
-        neighbor_points = train_emb[nn_indices.long()]  # (n_new, k, d)
-        diff_attr = new_points.unsqueeze(1) - neighbor_points  # (n_new, k, d)
-        D = (diff_attr**2).sum(dim=-1)  # (n_new, k) sqeuclidean
+        saved = super()._enter_transform(embedding_new, train_emb, affinity, nn_indices)
 
-        positive_edges = D > 0
-        D_ = 1 + self._a * D**self._b
-        D_coeff = D.pow(self._b - 1)
-        D_coeff.mul_(2 * self._a * self._b).div_(D_)
-        D_coeff.masked_fill_(~positive_edges, 0)
+        # Save UMAP-specific state
+        for attr in ("epochs_per_sample", "epoch_of_next_sample", "mask_affinity_in_"):
+            saved[attr] = getattr(self, attr, None)
 
-        attractive_grad = torch.einsum("ijk,ij->ik", diff_attr, D_coeff)
-        attractive_grad.clamp_(-4, 4)
+        # All edges active every step (no edge-sampling for transform)
+        n_new, k = affinity.shape
+        self.epochs_per_sample = torch.zeros(n_new, k, device=self.device_)
+        self.epoch_of_next_sample = torch.zeros(n_new, k, device=self.device_)
 
-        # --- Repulsive gradients ---
-        neg_indices = torch.randint(
-            0,
-            n_train,
-            (embedding_new.shape[0], self.n_negatives),
-            device=embedding_new.device,
-        )
-        neg_points = train_emb[neg_indices.long()]  # (n_new, n_neg, d)
-        diff_rep = new_points.unsqueeze(1) - neg_points  # (n_new, n_neg, d)
-        D_neg = (diff_rep**2).sum(dim=-1)  # (n_new, n_neg)
-
-        D_neg_ = 1 + self._a * D_neg**self._b
-        D_neg_coeff = D_neg.add(self._eps).mul(D_neg_).reciprocal_().mul_(-2 * self._b)
-
-        repulsive_grad = torch.einsum("ijk,ij->ik", diff_rep, D_neg_coeff)
-        repulsive_grad.clamp_(-4, 4)
-
-        return attractive_grad + self.repulsion_strength * repulsive_grad
+        return saved

--- a/torchdr/neighbor_embedding/umap.py
+++ b/torchdr/neighbor_embedding/umap.py
@@ -9,8 +9,10 @@ import torch
 import numpy as np
 
 from torchdr.affinity import UMAPAffinity
+from torchdr.affinity.knn_normalized import _log_P_UMAP
 from torchdr.neighbor_embedding.base import NegativeSamplingNeighborEmbedding
 from torchdr.distance import pairwise_distances_indexed, FaissConfig
+from torchdr.utils import binary_search, kmin
 
 from scipy.optimize import curve_fit
 
@@ -290,3 +292,70 @@ class UMAP(NegativeSamplingNeighborEmbedding):
         grad = torch.einsum("ijk,ij->ik", diff, D)
         grad.clamp_(-4, 4)  # clamp as in umap repo
         return grad
+
+    # --- Non-parametric transform ---
+
+    def _compute_bipartite_affinity(self, C, indices):
+        """UMAP bipartite affinity: exp(-(d - rho) / sigma), no symmetrization."""
+        rho = kmin(C, k=1, dim=1)[0].squeeze(-1).contiguous()
+
+        log_n_neighbors = torch.log2(
+            torch.tensor(self.n_neighbors, dtype=C.dtype, device=C.device)
+        )
+
+        def marginal_gap(eps):
+            log_marg = _log_P_UMAP(C, rho, eps).logsumexp(1)
+            return log_marg.exp().squeeze() - log_n_neighbors
+
+        eps = binary_search(
+            f=marginal_gap,
+            n=C.shape[0],
+            max_iter=self.max_iter_affinity,
+            dtype=C.dtype,
+            device=C.device,
+        )
+
+        return _log_P_UMAP(C, rho, eps).exp()
+
+    @torch.no_grad()
+    def _compute_transform_gradients(
+        self, embedding_new, train_emb, nn_indices, affinity, n_train
+    ):
+        """Compute UMAP attractive + repulsive gradients for transform.
+
+        Mirrors the fit-time gradient computation but operates on a bipartite
+        graph (new points → training points) with frozen training embeddings.
+        """
+        # --- Attractive gradients ---
+        new_points = embedding_new.data  # (n_new, d)
+        neighbor_points = train_emb[nn_indices.long()]  # (n_new, k, d)
+        diff_attr = new_points.unsqueeze(1) - neighbor_points  # (n_new, k, d)
+        D = (diff_attr**2).sum(dim=-1)  # (n_new, k) sqeuclidean
+
+        positive_edges = D > 0
+        D_ = 1 + self._a * D**self._b
+        D_coeff = D.pow(self._b - 1)
+        D_coeff.mul_(2 * self._a * self._b).div_(D_)
+        D_coeff.masked_fill_(~positive_edges, 0)
+
+        attractive_grad = torch.einsum("ijk,ij->ik", diff_attr, D_coeff)
+        attractive_grad.clamp_(-4, 4)
+
+        # --- Repulsive gradients ---
+        neg_indices = torch.randint(
+            0,
+            n_train,
+            (embedding_new.shape[0], self.n_negatives),
+            device=embedding_new.device,
+        )
+        neg_points = train_emb[neg_indices.long()]  # (n_new, n_neg, d)
+        diff_rep = new_points.unsqueeze(1) - neg_points  # (n_new, n_neg, d)
+        D_neg = (diff_rep**2).sum(dim=-1)  # (n_new, n_neg)
+
+        D_neg_ = 1 + self._a * D_neg**self._b
+        D_neg_coeff = D_neg.add(self._eps).mul(D_neg_).reciprocal_().mul_(-2 * self._b)
+
+        repulsive_grad = torch.einsum("ijk,ij->ik", diff_rep, D_neg_coeff)
+        repulsive_grad.clamp_(-4, 4)
+
+        return attractive_grad + self.repulsion_strength * repulsive_grad

--- a/torchdr/neighbor_embedding/umap.py
+++ b/torchdr/neighbor_embedding/umap.py
@@ -317,11 +317,45 @@ class UMAP(NegativeSamplingNeighborEmbedding):
 
         return _log_P_UMAP(C, rho, eps).exp()
 
+    def _make_transform_epochs_per_sample(self, affinity, n_epochs):
+        """Convert transform edge strengths into UMAP's epoch schedule."""
+        epochs_per_sample = torch.full_like(affinity, float("inf"))
+        if n_epochs <= 0:
+            return epochs_per_sample
+
+        max_affinity = affinity.max()
+        if max_affinity <= 0:
+            return epochs_per_sample
+
+        threshold = max_affinity / float(n_epochs)
+        active_edges = affinity >= threshold
+        eps = torch.finfo(affinity.dtype).tiny
+        epochs_per_sample[active_edges] = max_affinity / affinity[active_edges].clamp(
+            min=eps
+        )
+        return epochs_per_sample
+
+    def _initialize_transform_embedding(self, affinity, nn_indices, train_emb):
+        """Match UMAP's exact-neighbor initialization when possible."""
+        embedding_new = super()._initialize_transform_embedding(
+            affinity, nn_indices, train_emb
+        )
+        exact_match = torch.isclose(
+            affinity, torch.ones_like(affinity), atol=1e-6, rtol=0.0
+        )
+        if exact_match.any():
+            exact_rows = exact_match.any(dim=1)
+            exact_cols = exact_match.to(torch.int64).argmax(dim=1)
+            embedding_new[exact_rows] = train_emb[
+                nn_indices[exact_rows, exact_cols[exact_rows]].long()
+            ]
+        return embedding_new
+
     def _enter_transform(self, embedding_new, train_emb, affinity, nn_indices):
         """Set up UMAP edge-sampling state for transform.
 
-        Sets ``epochs_per_sample`` and ``epoch_of_next_sample`` to zeros so
-        all edges are active every iteration (no edge-sampling during transform).
+        Reuses the same edge-sampling schedule as fit, but on the bipartite
+        graph between new points and the frozen training embedding.
         """
         saved = super()._enter_transform(embedding_new, train_emb, affinity, nn_indices)
 
@@ -329,9 +363,10 @@ class UMAP(NegativeSamplingNeighborEmbedding):
         for attr in ("epochs_per_sample", "epoch_of_next_sample", "mask_affinity_in_"):
             saved[attr] = getattr(self, attr, None)
 
-        # All edges active every step (no edge-sampling for transform)
-        n_new, k = affinity.shape
-        self.epochs_per_sample = torch.zeros(n_new, k, device=self.device_)
-        self.epoch_of_next_sample = torch.zeros(n_new, k, device=self.device_)
+        epochs_per_sample = self._make_transform_epochs_per_sample(
+            affinity, self._get_max_iter_transform()
+        )
+        self.epochs_per_sample = epochs_per_sample
+        self.epoch_of_next_sample = epochs_per_sample.clone()
 
         return saved

--- a/torchdr/neighbor_embedding/umap.py
+++ b/torchdr/neighbor_embedding/umap.py
@@ -115,8 +115,8 @@ class UMAP(NegativeSamplingNeighborEmbedding):
         Number of negative samples for the noise-contrastive loss, by default 10.
     check_interval : int, optional
         Check interval for the algorithm, by default 50.
-    discard_NNs : bool, optional
-        Whether to discard the nearest neighbors from the negative sampling.
+    exclude_neighbors_from_negative_sampling : bool, optional
+        Whether to exclude nearest neighbors from negative sampling.
         Default is False.
     compile : bool, optional
         Whether to compile the algorithm using torch.compile. Default is False.
@@ -155,7 +155,7 @@ class UMAP(NegativeSamplingNeighborEmbedding):
         metric: str = "sqeuclidean",
         negative_sample_rate: int = 5,
         check_interval: int = 50,
-        discard_NNs: bool = False,
+        exclude_neighbors_from_negative_sampling: Optional[bool] = None,
         compile: bool = False,
         distributed: Union[bool, str] = "auto",
         **kwargs,
@@ -207,7 +207,9 @@ class UMAP(NegativeSamplingNeighborEmbedding):
             verbose=verbose,
             random_state=random_state,
             check_interval=check_interval,
-            discard_NNs=discard_NNs,
+            exclude_neighbors_from_negative_sampling=(
+                exclude_neighbors_from_negative_sampling
+            ),
             compile=compile,
             n_negatives=self.n_negatives,
             distributed=distributed,

--- a/torchdr/neighbor_embedding/umap.py
+++ b/torchdr/neighbor_embedding/umap.py
@@ -12,7 +12,7 @@ from torchdr.affinity import UMAPAffinity
 from torchdr.affinity.knn_normalized import _log_P_UMAP
 from torchdr.neighbor_embedding.base import NegativeSamplingNeighborEmbedding
 from torchdr.distance import pairwise_distances_indexed, FaissConfig
-from torchdr.utils import binary_search, kmin
+from torchdr.utils import binary_search
 
 from scipy.optimize import curve_fit
 
@@ -120,6 +120,8 @@ class UMAP(NegativeSamplingNeighborEmbedding):
     exclude_neighbors_from_negative_sampling : bool, optional
         Whether to exclude nearest neighbors from negative sampling.
         Default is False.
+    discard_NNs : bool, optional
+        Deprecated alias for ``exclude_neighbors_from_negative_sampling``.
     compile : bool, optional
         Whether to compile the algorithm using torch.compile. Default is False.
     distributed : bool or 'auto', optional
@@ -157,7 +159,8 @@ class UMAP(NegativeSamplingNeighborEmbedding):
         metric: str = "sqeuclidean",
         negative_sample_rate: int = 5,
         check_interval: int = 50,
-        exclude_neighbors_from_negative_sampling: bool = False,
+        exclude_neighbors_from_negative_sampling: Optional[bool] = None,
+        discard_NNs: Optional[bool] = None,
         compile: bool = False,
         distributed: Union[bool, str] = "auto",
         **kwargs,
@@ -210,6 +213,7 @@ class UMAP(NegativeSamplingNeighborEmbedding):
             random_state=random_state,
             check_interval=check_interval,
             exclude_neighbors_from_negative_sampling=exclude_neighbors_from_negative_sampling,
+            discard_NNs=discard_NNs,
             compile=compile,
             n_negatives=self.n_negatives,
             distributed=distributed,
@@ -305,15 +309,23 @@ class UMAP(NegativeSamplingNeighborEmbedding):
         unsymmetrized UMAP neighbor graph construction on the bipartite graph
         from new points to the fitted training set.
         """
-        rho = kmin(C, k=1, dim=1)[0].squeeze(-1).contiguous()
+        # umap-learn reduces local_connectivity by one for transform.  With
+        # UMAP's default local_connectivity=1 this means rho=0, unlike fit-time
+        # graph construction.  Taking the nearest distance here would force one
+        # affinity to 1 for every query and make every point look like an exact
+        # match during initialization.
+        rho = torch.zeros(C.shape[0], dtype=C.dtype, device=C.device)
 
         log_n_neighbors = torch.log2(
             torch.tensor(self.n_neighbors, dtype=C.dtype, device=C.device)
         )
 
         def marginal_gap(eps):
-            log_marg = _log_P_UMAP(C, rho, eps).logsumexp(1)
-            return log_marg.exp().squeeze() - log_n_neighbors
+            # Match smooth_knn_dist's bipartite transform convention: the
+            # closest edge participates in the graph but is omitted from the
+            # bandwidth calibration sum.
+            log_marg = _log_P_UMAP(C[:, 1:], rho, eps).logsumexp(1)
+            return log_marg.exp().reshape(-1) - log_n_neighbors
 
         eps = binary_search(
             f=marginal_gap,
@@ -347,19 +359,25 @@ class UMAP(NegativeSamplingNeighborEmbedding):
         )
         return epochs_per_sample
 
-    def _initialize_transform_embedding(self, affinity, nn_indices, train_emb):
+    def _initialize_transform_embedding(
+        self, affinity, nn_indices, train_emb, neighbor_distances=None
+    ):
         """Match UMAP's transform initialization when exact matches exist.
 
         The default weighted-average initialization from the base class is kept,
-        except that rows with an affinity of 1 are snapped to the corresponding
-        training embedding exactly, as in ``umap-learn``.
+        except that rows containing a zero-distance neighbor are snapped to the
+        corresponding training embedding exactly, as in ``umap-learn``.
         """
         embedding_new = super()._initialize_transform_embedding(
-            affinity, nn_indices, train_emb
+            affinity,
+            nn_indices,
+            train_emb,
+            neighbor_distances=neighbor_distances,
         )
-        exact_match = torch.isclose(
-            affinity, torch.ones_like(affinity), atol=1e-6, rtol=0.0
-        )
+        if neighbor_distances is None:
+            return embedding_new
+
+        exact_match = neighbor_distances == 0
         if exact_match.any():
             exact_rows = exact_match.any(dim=1)
             exact_cols = exact_match.to(torch.int64).argmax(dim=1)
@@ -376,15 +394,15 @@ class UMAP(NegativeSamplingNeighborEmbedding):
         optimization still runs through TorchDR's vectorized mask-based update
         path rather than ``umap-learn``'s edge-wise CPU loop.
         """
+        epochs_per_sample = self._make_transform_epochs_per_sample(
+            affinity, self._get_max_iter_transform()
+        )
         saved = super()._enter_transform(embedding_new, train_emb, affinity, nn_indices)
 
         # Save UMAP-specific state
         for attr in ("epochs_per_sample", "epoch_of_next_sample", "mask_affinity_in_"):
-            saved[attr] = getattr(self, attr, None)
+            saved[attr] = (hasattr(self, attr), getattr(self, attr, None))
 
-        epochs_per_sample = self._make_transform_epochs_per_sample(
-            affinity, self._get_max_iter_transform()
-        )
         self.epochs_per_sample = epochs_per_sample
         self.epoch_of_next_sample = epochs_per_sample.clone()
 

--- a/torchdr/tests/test_transform.py
+++ b/torchdr/tests/test_transform.py
@@ -1,0 +1,133 @@
+"""Tests for non-parametric transform on neighbor embedding methods."""
+
+# License: BSD 3-Clause License
+
+import pytest
+import torch
+
+from torchdr.neighbor_embedding import UMAP, LargeVis, InfoTSNE
+from torchdr.tests.utils import toy_dataset
+from torchdr.utils import check_shape
+
+
+DEVICE = "cpu"
+
+
+@pytest.mark.parametrize(
+    "DRModel, kwargs",
+    [
+        (UMAP, {"n_neighbors": 10, "optimizer": "SGD"}),
+        (LargeVis, {"perplexity": 10}),
+        (InfoTSNE, {"perplexity": 10, "n_negatives": 10}),
+    ],
+)
+@pytest.mark.parametrize("dtype", ["float32", "float64"])
+def test_transform_shape(DRModel, kwargs, dtype):
+    """transform(X_new, X_train) returns correct shape."""
+    n_train, n_test = 100, 20
+    X_train, _ = toy_dataset(n_train, dtype)
+    X_test, _ = toy_dataset(n_test, dtype)
+
+    model = DRModel(
+        n_components=2,
+        device=DEVICE,
+        init="normal",
+        max_iter=100,
+        random_state=0,
+        **kwargs,
+    )
+    model.fit(X_train)
+    Z = model.transform(X_test, X_train=X_train)
+    check_shape(Z, (n_test, 2))
+    assert not torch.isnan(torch.as_tensor(Z)).any(), "Transform produced NaNs."
+
+
+def test_transform_none_returns_training():
+    """transform(None) returns the training embedding."""
+    n = 50
+    X, _ = toy_dataset(n, "float32")
+
+    model = UMAP(
+        n_components=2,
+        device=DEVICE,
+        init="normal",
+        max_iter=50,
+        random_state=0,
+        n_neighbors=10,
+        optimizer="SGD",
+    )
+    Z_fit = model.fit_transform(X)
+    Z_transform = model.transform()
+    assert torch.equal(torch.as_tensor(Z_fit), torch.as_tensor(Z_transform))
+
+
+def test_transform_missing_X_train_raises():
+    """transform(X_new) without X_train raises ValueError."""
+    n = 50
+    X, _ = toy_dataset(n, "float32")
+
+    model = UMAP(
+        n_components=2,
+        device=DEVICE,
+        init="normal",
+        max_iter=50,
+        random_state=0,
+        n_neighbors=10,
+        optimizer="SGD",
+    )
+    model.fit(X)
+
+    X_test, _ = toy_dataset(20, "float32")
+    with pytest.raises(ValueError, match="X_train is required"):
+        model.transform(X_test)
+
+
+def test_transform_not_fitted_raises():
+    """transform before fit raises ValueError."""
+    model = UMAP(n_components=2, n_neighbors=10, optimizer="SGD")
+    X_test, _ = toy_dataset(20, "float32")
+    with pytest.raises(ValueError, match="not fitted"):
+        model.transform(X_test, X_train=X_test)
+
+
+def test_transform_numpy_input():
+    """transform works with numpy input and returns numpy output."""
+    n_train, n_test = 80, 15
+    X_train, _ = toy_dataset(n_train, "float32")
+    X_test, _ = toy_dataset(n_test, "float32")
+
+    model = UMAP(
+        n_components=2,
+        device=DEVICE,
+        init="normal",
+        max_iter=50,
+        random_state=0,
+        n_neighbors=10,
+        optimizer="SGD",
+    )
+    model.fit(X_train)
+
+    # X_train and X_test are numpy arrays from toy_dataset
+    Z = model.transform(X_test, X_train=X_train)
+    assert Z.shape == (n_test, 2)
+
+
+def test_embedding_train_stored_on_cpu():
+    """embedding_train_ should be stored on CPU after fit."""
+    n = 50
+    X, _ = toy_dataset(n, "float32")
+
+    model = UMAP(
+        n_components=2,
+        device=DEVICE,
+        init="normal",
+        max_iter=50,
+        random_state=0,
+        n_neighbors=10,
+        optimizer="SGD",
+    )
+    model.fit(X)
+
+    assert hasattr(model, "embedding_train_")
+    assert model.embedding_train_.device == torch.device("cpu")
+    assert model.embedding_train_.shape == (n, 2)

--- a/torchdr/tests/test_transform.py
+++ b/torchdr/tests/test_transform.py
@@ -201,21 +201,6 @@ def test_transform_negative_sampling_discards_neighbors():
     assert not (neg_local.unsqueeze(-1) == nn_indices.unsqueeze(1)).any()
 
 
-def test_discard_nns_alias_is_supported_with_warning():
-    """The deprecated discard_NNs alias should still work for one cycle."""
-    with pytest.warns(FutureWarning, match="discard_NNs"):
-        model = UMAP(
-            n_components=2,
-            backend=BACKEND,
-            n_neighbors=2,
-            optimizer="SGD",
-            discard_NNs=True,
-        )
-
-    assert model.exclude_neighbors_from_negative_sampling is True
-    assert model.discard_NNs is True
-
-
 def test_umap_transform_init_uses_exact_neighbor_embedding():
     """UMAP transform should reuse the exact neighbor embedding when affinity is 1."""
     model = UMAP(

--- a/torchdr/tests/test_transform.py
+++ b/torchdr/tests/test_transform.py
@@ -11,6 +11,7 @@ from torchdr.utils import check_shape
 
 
 DEVICE = "cpu"
+BACKEND = None
 
 
 @pytest.mark.parametrize(
@@ -30,6 +31,7 @@ def test_transform_shape(DRModel, kwargs, dtype):
 
     model = DRModel(
         n_components=2,
+        backend=BACKEND,
         device=DEVICE,
         init="normal",
         max_iter=100,
@@ -49,6 +51,7 @@ def test_transform_none_returns_training():
 
     model = UMAP(
         n_components=2,
+        backend=BACKEND,
         device=DEVICE,
         init="normal",
         max_iter=50,
@@ -68,6 +71,7 @@ def test_transform_missing_X_train_raises():
 
     model = UMAP(
         n_components=2,
+        backend=BACKEND,
         device=DEVICE,
         init="normal",
         max_iter=50,
@@ -84,7 +88,7 @@ def test_transform_missing_X_train_raises():
 
 def test_transform_not_fitted_raises():
     """transform before fit raises ValueError."""
-    model = UMAP(n_components=2, n_neighbors=10, optimizer="SGD")
+    model = UMAP(n_components=2, n_neighbors=10, optimizer="SGD", backend=BACKEND)
     X_test, _ = toy_dataset(20, "float32")
     with pytest.raises(ValueError, match="not fitted"):
         model.transform(X_test, X_train=X_test)
@@ -98,6 +102,7 @@ def test_transform_numpy_input():
 
     model = UMAP(
         n_components=2,
+        backend=BACKEND,
         device=DEVICE,
         init="normal",
         max_iter=50,
@@ -119,6 +124,7 @@ def test_embedding_train_stored_on_cpu():
 
     model = UMAP(
         n_components=2,
+        backend=BACKEND,
         device=DEVICE,
         init="normal",
         max_iter=50,
@@ -135,7 +141,7 @@ def test_embedding_train_stored_on_cpu():
 
 def test_transform_unsupported_model_raises():
     """Models without bipartite affinity should fail fast in transform."""
-    model = PACMAP(n_components=2, n_neighbors=5)
+    model = PACMAP(n_components=2, n_neighbors=5, backend=BACKEND)
     model.is_fitted_ = True
     model.device_ = DEVICE
 
@@ -153,6 +159,7 @@ def test_transform_auto_lr_reuses_fit_learning_rate():
     X, _ = toy_dataset(50, "float32")
     model = LargeVis(
         n_components=2,
+        backend=BACKEND,
         device=DEVICE,
         init="normal",
         max_iter=10,
@@ -171,6 +178,7 @@ def test_transform_negative_sampling_discards_neighbors():
     """Transform negative sampling should exclude nearest neighbors when requested."""
     model = UMAP(
         n_components=2,
+        backend=BACKEND,
         device=DEVICE,
         init="normal",
         max_iter=10,
@@ -198,6 +206,7 @@ def test_embedding_train_not_stored_for_non_transform_model():
     X, _ = toy_dataset(40, "float32")
     model = TSNE(
         n_components=2,
+        backend=BACKEND,
         device=DEVICE,
         init="normal",
         max_iter=5,

--- a/torchdr/tests/test_transform.py
+++ b/torchdr/tests/test_transform.py
@@ -5,7 +5,7 @@
 import pytest
 import torch
 
-from torchdr.neighbor_embedding import UMAP, LargeVis, InfoTSNE
+from torchdr.neighbor_embedding import UMAP, LargeVis, InfoTSNE, PACMAP, TSNE
 from torchdr.tests.utils import toy_dataset
 from torchdr.utils import check_shape
 
@@ -131,3 +131,79 @@ def test_embedding_train_stored_on_cpu():
     assert hasattr(model, "embedding_train_")
     assert model.embedding_train_.device == torch.device("cpu")
     assert model.embedding_train_.shape == (n, 2)
+
+
+def test_transform_unsupported_model_raises():
+    """Models without bipartite affinity should fail fast in transform."""
+    model = PACMAP(n_components=2, n_neighbors=5)
+    model.is_fitted_ = True
+    model.device_ = DEVICE
+
+    X_test = torch.randn(5, 3)
+    X_train = torch.randn(20, 3)
+
+    with pytest.raises(
+        NotImplementedError, match="does not support non-parametric transform"
+    ):
+        model.transform(X_test, X_train=X_train)
+
+
+def test_transform_auto_lr_reuses_fit_learning_rate():
+    """Transform should reuse the fit-time LR when lr='auto'."""
+    X, _ = toy_dataset(50, "float32")
+    model = LargeVis(
+        n_components=2,
+        device=DEVICE,
+        init="normal",
+        max_iter=10,
+        random_state=0,
+        perplexity=10,
+    )
+    model.fit(X)
+
+    assert model.lr == "auto"
+    expected_fit_lr = max(model.n_samples_in_ / model.early_exaggeration_coeff / 4, 50)
+    assert model._get_transform_learning_rate() == pytest.approx(expected_fit_lr / 4.0)
+    assert model._get_transform_learning_rate() != pytest.approx(0.25)
+
+
+def test_transform_negative_sampling_discards_neighbors():
+    """Transform negative sampling should exclude nearest neighbors when requested."""
+    model = UMAP(
+        n_components=2,
+        device=DEVICE,
+        init="normal",
+        max_iter=10,
+        random_state=0,
+        n_neighbors=2,
+        negative_sample_rate=1,
+        discard_NNs=True,
+        optimizer="SGD",
+    )
+    model.device_ = DEVICE
+
+    nn_indices = torch.tensor([[0, 1], [1, 3]])
+    neg_indices = model._sample_transform_neg_indices(
+        n_new=2, n_train=5, nn_indices=nn_indices
+    )
+    neg_local = neg_indices - 2
+
+    assert neg_local.min() >= 0
+    assert neg_local.max() < 5
+    assert not (neg_local.unsqueeze(-1) == nn_indices.unsqueeze(1)).any()
+
+
+def test_embedding_train_not_stored_for_non_transform_model():
+    """Models without non-parametric transform should not keep a CPU clone."""
+    X, _ = toy_dataset(40, "float32")
+    model = TSNE(
+        n_components=2,
+        device=DEVICE,
+        init="normal",
+        max_iter=5,
+        random_state=0,
+        perplexity=10,
+    )
+    model.fit(X)
+
+    assert not hasattr(model, "embedding_train_")

--- a/torchdr/tests/test_transform.py
+++ b/torchdr/tests/test_transform.py
@@ -201,6 +201,62 @@ def test_transform_negative_sampling_discards_neighbors():
     assert not (neg_local.unsqueeze(-1) == nn_indices.unsqueeze(1)).any()
 
 
+def test_umap_transform_init_uses_exact_neighbor_embedding():
+    """UMAP transform should reuse the exact neighbor embedding when affinity is 1."""
+    model = UMAP(
+        n_components=2,
+        backend=BACKEND,
+        device=DEVICE,
+        init="normal",
+        max_iter=30,
+        random_state=0,
+        n_neighbors=2,
+        optimizer="SGD",
+    )
+    train_emb = torch.tensor([[0.0, 0.0], [1.0, 2.0], [3.0, 4.0]])
+    affinity = torch.tensor([[1.0, 0.25], [0.25, 0.75]])
+    nn_indices = torch.tensor([[1, 2], [0, 2]])
+
+    embedding_new = model._initialize_transform_embedding(
+        affinity, nn_indices, train_emb
+    )
+
+    assert torch.equal(embedding_new[0], train_emb[1])
+    expected = 0.25 * train_emb[0] + 0.75 * train_emb[2]
+    assert torch.allclose(embedding_new[1], expected)
+
+
+def test_umap_transform_uses_epoch_schedule():
+    """UMAP transform should keep fit-style epoch sampling instead of all-edges updates."""
+    model = UMAP(
+        n_components=2,
+        backend=BACKEND,
+        device=DEVICE,
+        init="normal",
+        max_iter=90,
+        random_state=0,
+        n_neighbors=2,
+        optimizer="SGD",
+    )
+    model.device_ = torch.device(DEVICE)
+
+    embedding_new = torch.zeros(2, 2)
+    train_emb = torch.zeros(4, 2)
+    affinity = torch.tensor([[1.0, 0.1], [0.05, 0.01]])
+    nn_indices = torch.tensor([[0, 1], [2, 3]])
+
+    saved = model._enter_transform(embedding_new, train_emb, affinity, nn_indices)
+    try:
+        assert torch.equal(model.epoch_of_next_sample, model.epochs_per_sample)
+        assert not torch.equal(
+            model.epochs_per_sample, torch.zeros_like(model.epochs_per_sample)
+        )
+        assert torch.isfinite(model.epochs_per_sample[0, 0])
+        assert torch.isinf(model.epochs_per_sample[1, 1])
+    finally:
+        model._exit_transform(saved)
+
+
 def test_embedding_train_not_stored_for_non_transform_model():
     """Models without non-parametric transform should not keep a CPU clone."""
     X, _ = toy_dataset(40, "float32")

--- a/torchdr/tests/test_transform.py
+++ b/torchdr/tests/test_transform.py
@@ -185,7 +185,7 @@ def test_transform_negative_sampling_discards_neighbors():
         random_state=0,
         n_neighbors=2,
         negative_sample_rate=1,
-        discard_NNs=True,
+        exclude_neighbors_from_negative_sampling=True,
         optimizer="SGD",
     )
     model.device_ = DEVICE
@@ -199,6 +199,21 @@ def test_transform_negative_sampling_discards_neighbors():
     assert neg_local.min() >= 0
     assert neg_local.max() < 5
     assert not (neg_local.unsqueeze(-1) == nn_indices.unsqueeze(1)).any()
+
+
+def test_discard_nns_alias_is_supported_with_warning():
+    """The deprecated discard_NNs alias should still work for one cycle."""
+    with pytest.warns(FutureWarning, match="discard_NNs"):
+        model = UMAP(
+            n_components=2,
+            backend=BACKEND,
+            n_neighbors=2,
+            optimizer="SGD",
+            discard_NNs=True,
+        )
+
+    assert model.exclude_neighbors_from_negative_sampling is True
+    assert model.discard_NNs is True
 
 
 def test_umap_transform_init_uses_exact_neighbor_embedding():

--- a/torchdr/tests/test_transform.py
+++ b/torchdr/tests/test_transform.py
@@ -2,6 +2,7 @@
 
 # License: BSD 3-Clause License
 
+import numpy as np
 import pytest
 import torch
 
@@ -114,6 +115,7 @@ def test_transform_numpy_input():
 
     # X_train and X_test are numpy arrays from toy_dataset
     Z = model.transform(X_test, X_train=X_train)
+    assert isinstance(Z, np.ndarray)
     assert Z.shape == (n_test, 2)
 
 
@@ -201,8 +203,29 @@ def test_transform_negative_sampling_discards_neighbors():
     assert not (neg_local.unsqueeze(-1) == nn_indices.unsqueeze(1)).any()
 
 
+def test_negative_sampling_handles_padding_and_duplicate_exclusions():
+    """The shared sampler must ignore invalid and repeated exclusion entries."""
+    exclusion = torch.tensor([[-1, 1, 1, 4], [0, 2, 2, 99]])
+    adjusted, n_available = UMAP._prepare_exclusion_sampling(exclusion, n_candidates=5)
+    draws = UMAP._draw_with_exclusions(adjusted, n_available, n_draws=2000)
+
+    assert draws.min() >= 0
+    assert draws.max() < 5
+    assert not torch.isin(draws[0], torch.tensor([1, 4])).any()
+    assert not torch.isin(draws[1], torch.tensor([0, 2])).any()
+    assert torch.equal(torch.unique(draws[0]).sort().values, torch.tensor([0, 2, 3]))
+    assert torch.equal(torch.unique(draws[1]).sort().values, torch.tensor([1, 3, 4]))
+
+
+def test_negative_sampling_rejects_fully_excluded_rows():
+    """A row with no valid negative candidate should fail deterministically."""
+    exclusion = torch.tensor([[0, 1, 1, -1]])
+    with pytest.raises(ValueError, match="No candidates remain"):
+        UMAP._prepare_exclusion_sampling(exclusion, n_candidates=2)
+
+
 def test_umap_transform_init_uses_exact_neighbor_embedding():
-    """UMAP transform should reuse the exact neighbor embedding when affinity is 1."""
+    """UMAP should snap only zero-distance matches, not arbitrary strong edges."""
     model = UMAP(
         n_components=2,
         backend=BACKEND,
@@ -216,14 +239,84 @@ def test_umap_transform_init_uses_exact_neighbor_embedding():
     train_emb = torch.tensor([[0.0, 0.0], [1.0, 2.0], [3.0, 4.0]])
     affinity = torch.tensor([[1.0, 0.25], [0.25, 0.75]])
     nn_indices = torch.tensor([[1, 2], [0, 2]])
+    neighbor_distances = torch.tensor([[0.0, 1.0], [0.1, 0.2]])
 
     embedding_new = model._initialize_transform_embedding(
-        affinity, nn_indices, train_emb
+        affinity, nn_indices, train_emb, neighbor_distances=neighbor_distances
     )
 
     assert torch.equal(embedding_new[0], train_emb[1])
     expected = 0.25 * train_emb[0] + 0.75 * train_emb[2]
     assert torch.allclose(embedding_new[1], expected)
+
+
+def test_umap_bipartite_affinity_only_marks_exact_matches():
+    """A nonzero nearest distance must not be assigned unit UMAP affinity."""
+    model = UMAP(
+        n_neighbors=3,
+        backend=BACKEND,
+        device=DEVICE,
+        optimizer="SGD",
+        max_iter_affinity=100,
+    )
+    distances = torch.tensor([[0.2, 0.5, 1.0], [0.0, 0.5, 1.0]], dtype=torch.float64)
+    indices = torch.tensor([[0, 1, 2], [0, 1, 2]])
+
+    affinity = model._compute_bipartite_affinity(distances, indices)
+
+    assert affinity[0, 0] < 1
+    assert affinity[1, 0] == 1
+    target_marginal = torch.log2(torch.tensor(3.0, dtype=affinity.dtype))
+    assert torch.allclose(
+        affinity[:, 1:].sum(dim=1),
+        target_marginal.expand(2),
+        atol=1e-5,
+        rtol=1e-5,
+    )
+
+
+@pytest.mark.parametrize("DRModel", [LargeVis, InfoTSNE])
+def test_entropic_transform_affinity_matches_fit_invariants(DRModel):
+    """Transform affinities should preserve perplexity and total unit mass."""
+    model = DRModel(
+        perplexity=3,
+        backend=BACKEND,
+        device=DEVICE,
+        max_iter_affinity=200,
+    )
+    distances = torch.tensor(
+        [
+            [0.0, 0.2, 0.5, 1.0, 1.8, 2.9, 4.3, 6.0, 8.0],
+            [0.1, 0.4, 0.9, 1.6, 2.5, 3.6, 4.9, 6.4, 8.1],
+        ],
+        dtype=torch.float64,
+    )
+    indices = torch.arange(9).expand(2, -1)
+
+    affinity = model._compute_bipartite_affinity(distances, indices)
+    row_probabilities = affinity / affinity.sum(dim=1, keepdim=True)
+    shannon_entropy = -(row_probabilities * row_probabilities.log()).sum(dim=1)
+
+    assert model._get_n_neighbors_transform(n_train=100) == 9
+    assert torch.allclose(
+        affinity.sum(dim=1), torch.full((2,), 0.5, dtype=affinity.dtype)
+    )
+    assert affinity.sum().item() == pytest.approx(1.0)
+    assert torch.allclose(
+        shannon_entropy,
+        torch.log(torch.tensor(3.0, dtype=affinity.dtype)).expand(2),
+        atol=1e-5,
+        rtol=1e-5,
+    )
+    assert not torch.allclose(
+        row_probabilities,
+        torch.full_like(row_probabilities, 1 / row_probabilities.shape[1]),
+    )
+
+    boundary_affinity = model._compute_bipartite_affinity(
+        distances[:, :3], indices[:, :3]
+    )
+    assert torch.equal(boundary_affinity, torch.full_like(boundary_affinity, 1 / 6))
 
 
 def test_umap_transform_uses_epoch_schedule():
@@ -247,6 +340,7 @@ def test_umap_transform_uses_epoch_schedule():
 
     saved = model._enter_transform(embedding_new, train_emb, affinity, nn_indices)
     try:
+        assert model.n_samples_in_ == embedding_new.shape[0]
         assert torch.equal(model.epoch_of_next_sample, model.epochs_per_sample)
         assert not torch.equal(
             model.epochs_per_sample, torch.zeros_like(model.epochs_per_sample)
@@ -255,6 +349,92 @@ def test_umap_transform_uses_epoch_schedule():
         assert torch.isinf(model.epochs_per_sample[1, 1])
     finally:
         model._exit_transform(saved)
+
+    assert model.embedding_ is None
+    assert not hasattr(model, "n_samples_in_")
+    assert not hasattr(model, "epochs_per_sample")
+
+
+def test_transform_restores_registered_parameter_embedding():
+    """Temporary concatenation must not corrupt Parameter registration."""
+    model = UMAP(
+        n_neighbors=2,
+        backend=BACKEND,
+        device=DEVICE,
+        optimizer="SGD",
+        max_iter=6,
+    )
+    model.device_ = torch.device(DEVICE)
+    original_embedding = torch.nn.Parameter(torch.randn(4, 2))
+    model.embedding_ = original_embedding
+    embedding_new = torch.zeros(2, 2)
+    train_emb = original_embedding.detach()
+    affinity = torch.tensor([[1.0, 0.2], [0.8, 0.4]])
+    nn_indices = torch.tensor([[0, 1], [2, 3]])
+
+    saved = model._enter_transform(embedding_new, train_emb, affinity, nn_indices)
+    model.embedding_ = torch.cat([embedding_new, train_emb], dim=0)
+    model._exit_transform(saved)
+
+    assert model.embedding_ is original_embedding
+    assert model._parameters["embedding_"] is original_embedding
+
+
+def test_transform_validates_reference_shape_and_features():
+    """Transform should reject references that cannot align with the fitted model."""
+    model = UMAP(n_neighbors=2, backend=BACKEND, device=DEVICE, optimizer="SGD")
+    model.is_fitted_ = True
+    model.device_ = torch.device(DEVICE)
+    model.n_features_in_ = 3
+    model.embedding_train_ = torch.randn(5, 2)
+
+    with pytest.raises(ValueError, match="X_new has 4 features"):
+        model.transform(torch.randn(2, 4), X_train=torch.randn(5, 3))
+    with pytest.raises(ValueError, match="X_train has 4 features"):
+        model.transform(torch.randn(2, 3), X_train=torch.randn(5, 4))
+    with pytest.raises(ValueError, match="same training samples"):
+        model.transform(torch.randn(2, 3), X_train=torch.randn(4, 3))
+
+
+def test_duplicate_training_rows_keep_reference_embedding_aligned():
+    """The stored reference must use the original, not deduplicated, row space."""
+    X_unique = torch.randn(8, 3)
+    X_train = torch.cat([X_unique, X_unique[:2]], dim=0)
+    model = UMAP(
+        n_neighbors=2,
+        backend=BACKEND,
+        device=DEVICE,
+        init="normal",
+        max_iter=6,
+        random_state=0,
+        optimizer="SGD",
+    )
+
+    model.fit(X_train)
+    fit_embedding = model.embedding_
+    fit_sample_count = model.n_samples_in_
+    transformed = model.transform(torch.randn(2, 3), X_train=X_train)
+
+    assert model.embedding_train_.shape[0] == X_train.shape[0]
+    assert transformed.shape == (2, 2)
+    assert model.embedding_ is fit_embedding
+    assert model.n_samples_in_ == fit_sample_count
+    assert not hasattr(model, "neg_indices_")
+
+
+def test_negative_sampling_parameter_alias_is_backward_compatible():
+    """The pre-PR public parameter remains usable during its deprecation window."""
+    with pytest.warns(FutureWarning, match="discard_NNs"):
+        model = UMAP(discard_NNs=True)
+    assert model.exclude_neighbors_from_negative_sampling is True
+
+    with pytest.raises(ValueError, match="Conflicting values"):
+        UMAP(
+            exclude_neighbors_from_negative_sampling=True,
+            discard_NNs=False,
+        )
+
+    assert PACMAP().exclude_neighbors_from_negative_sampling is True
 
 
 def test_embedding_train_not_stored_for_non_transform_model():


### PR DESCRIPTION
## Summary

- Add `transform(X_new, X_train=X_train)` for non-parametric neighbor embedding methods (UMAP, LargeVis, InfoTSNE)
- Follows the umap-learn approach: kNN search → bipartite affinity → weighted-average initialization → SGD optimization with frozen training embeddings
- Only `embedding_train_` (tiny: n × n_components) is stored after fit; training data must be passed explicitly at transform time to avoid hidden memory costs in multi-GPU settings

## Test plan

- [x] New tests in `test_transform.py` (11 tests): shape validation, NaN checks, error handling, numpy I/O, `embedding_train_` storage
- [x] Existing `test_neighbor_embedding.py` passes (20 tests)
- [x] Existing `test_parametric.py` passes (12 tests, encoder path unaffected)