### PR TITLE
[Fix] Correct PACMAP mid-near sample indices

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -44,6 +44,7 @@ Changed
 Fixed
 ~~~~~
 
+- Correct PACMAP mid-near pair selection to use global sample indices `PR #277 <https://github.com/TorchDR/TorchDR/pull/277>`_.
 - Fix memory leak in AffinityMatcher by freeing input data after initialization `PR #223 <https://github.com/TorchDR/TorchDR/pull/223>`_.
 - Fix PACMAP device handling `PR #215 <https://github.com/TorchDR/TorchDR/pull/215>`_.
 - Fix AffinityMatcher kwargs mutation `PR #240 <https://github.com/TorchDR/TorchDR/pull/240>`_.

--- a/torchdr/neighbor_embedding/pacmap.py
+++ b/torchdr/neighbor_embedding/pacmap.py
@@ -239,7 +239,9 @@ class PACMAP(NegativeSamplingNeighborEmbedding):
                     device=self.device,
                 )
                 _, idxs = kmin(D_mid_near_candidates, k=2, dim=1)
-                self.mid_near_indices[:, i] = idxs[:, 1]
+                self.mid_near_indices[:, i] = mid_near_candidates_indices.gather(
+                    1, idxs[:, 1].unsqueeze(1)
+                ).squeeze(1)
 
             Q_mid_near = 1 + pairwise_distances_indexed(
                 self.embedding_,

--- a/torchdr/neighbor_embedding/pacmap.py
+++ b/torchdr/neighbor_embedding/pacmap.py
@@ -240,7 +240,7 @@ class PACMAP(NegativeSamplingNeighborEmbedding):
                 )
                 _, idxs = kmin(D_mid_near_candidates, k=2, dim=1)
                 self.mid_near_indices[:, i] = mid_near_candidates_indices.gather(
-                    1, idxs[:, 1].unsqueeze(1)
+                    1, idxs[:, 1].long().unsqueeze(1)
                 ).squeeze(1)
 
             Q_mid_near = 1 + pairwise_distances_indexed(

--- a/torchdr/tests/test_neighbor_embedding.py
+++ b/torchdr/tests/test_neighbor_embedding.py
@@ -12,6 +12,7 @@ import pytest
 import torch
 from sklearn.metrics import silhouette_score
 
+import torchdr.neighbor_embedding.pacmap as pacmap_module
 from torchdr.neighbor_embedding import (
     SNE,
     TSNE,
@@ -37,6 +38,58 @@ DEVICE = "cpu"
 
 
 param_optim = {"lr": 1.0, "optimizer": "Adam", "optimizer_kwargs": None}
+
+
+def test_pacmap_mid_near_indices_are_global(monkeypatch):
+    """PACMAP should map selected candidate positions to sample indices."""
+    n_samples = 10
+    model = PACMAP(
+        n_neighbors=2,
+        MN_ratio=0.5,
+        backend=None,
+        device=DEVICE,
+    )
+    model.n_samples_in_ = n_samples
+    model.X_ = torch.arange(n_samples, dtype=torch.float32).unsqueeze(1)
+    model.embedding_ = torch.zeros(n_samples, 2)
+    model.NN_indices_ = torch.zeros(n_samples, 2, dtype=torch.long)
+    model.self_idxs = torch.arange(n_samples).unsqueeze(1)
+    model.mid_near_indices = torch.empty(n_samples, 1, dtype=torch.long)
+    model.w_NB = 1
+    model.w_MN = 1
+
+    compressed_candidates = torch.tensor([1, 6, 2, 3, 4, 5]).repeat(n_samples, 1)
+    observed = {}
+
+    def fake_randint(low, high, size, device=None):
+        assert (low, high, size) == (1, n_samples - 1, (n_samples, 6))
+        return compressed_candidates.clone().to(device)
+
+    call_count = 0
+
+    def fake_pairwise_distances_indexed(*args, key_indices, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return torch.zeros(n_samples, model.n_neighbors)
+        if call_count == 2:
+            observed["candidates"] = key_indices.clone()
+            return torch.arange(6, dtype=torch.float32).repeat(n_samples, 1)
+        observed["selected"] = key_indices.clone()
+        return torch.zeros(n_samples, model.n_mid_near)
+
+    monkeypatch.setattr(pacmap_module.torch, "randint", fake_randint)
+    monkeypatch.setattr(
+        pacmap_module,
+        "pairwise_distances_indexed",
+        fake_pairwise_distances_indexed,
+    )
+
+    model._compute_attractive_loss()
+
+    expected = observed["candidates"][:, 1]
+    assert torch.equal(observed["selected"].squeeze(1), expected)
+    assert torch.all(expected > 5)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

- Map PACMAP's selected mid-near candidate positions back to global sample indices.
- Add a deterministic regression test covering global indices above the six candidate positions.

## Checklist

- [x] I have read the How to Contribute document.
- [x] Documentation is unchanged because this fixes internal index selection.
- [x] All relevant tests passed and the fix is covered by a new test.
- [x] Added this PR to RELEASES.rst.

## Test plan

- [x] Full neighbor-embedding test module (21 passed).
- [x] Focused PACMAP regression test.
- [x] Pre-commit hooks for changed files.