### PR TITLE
[Fix] Preserve distributed IVFPQ settings

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -44,6 +44,7 @@ Changed
 Fixed
 ~~~~~
 
+- Preserve custom IVFPQ settings in distributed FAISS configurations `PR #278 <https://github.com/TorchDR/TorchDR/pull/278>`_.
 - Fix memory leak in AffinityMatcher by freeing input data after initialization `PR #223 <https://github.com/TorchDR/TorchDR/pull/223>`_.
 - Fix PACMAP device handling `PR #215 <https://github.com/TorchDR/TorchDR/pull/215>`_.
 - Fix AffinityMatcher kwargs mutation `PR #240 <https://github.com/TorchDR/TorchDR/pull/240>`_.

--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -44,7 +44,6 @@ Changed
 Fixed
 ~~~~~
 
-- Preserve custom IVFPQ settings in distributed FAISS configurations `PR #278 <https://github.com/TorchDR/TorchDR/pull/278>`_.
 - Fix memory leak in AffinityMatcher by freeing input data after initialization `PR #223 <https://github.com/TorchDR/TorchDR/pull/223>`_.
 - Fix PACMAP device handling `PR #215 <https://github.com/TorchDR/TorchDR/pull/215>`_.
 - Fix AffinityMatcher kwargs mutation `PR #240 <https://github.com/TorchDR/TorchDR/pull/240>`_.

--- a/torchdr/distributed/__init__.py
+++ b/torchdr/distributed/__init__.py
@@ -305,6 +305,8 @@ class DistributedContext:
                 index_type=base_config.index_type,
                 nprobe=base_config.nprobe,
                 nlist=base_config.nlist,
+                M=base_config.M,
+                nbits=base_config.nbits,
                 **base_config.faiss_kwargs,
             )
 

--- a/torchdr/tests/test_distributed.py
+++ b/torchdr/tests/test_distributed.py
@@ -201,3 +201,31 @@ class TestGetFaissConfig:
         assert config.temp_memory == 4.0
         assert config.index_type == "IVF"
         assert config.nprobe == 10
+
+    def test_with_ivfpq_base_config(self):
+        """Test preserving product quantization settings from a base config."""
+        from torchdr.distance import FaissConfig
+
+        ctx = DistributedContext()
+        ctx.local_rank = 2
+
+        base = FaissConfig(
+            temp_memory=1.5,
+            device=7,
+            index_type="IVFPQ",
+            nprobe=12,
+            nlist=256,
+            M=32,
+            nbits=6,
+            useFloat16=True,
+        )
+        config = ctx.get_faiss_config(base)
+
+        assert config.device == 2
+        assert config.temp_memory == 1.5
+        assert config.index_type == "IVFPQ"
+        assert config.nprobe == 12
+        assert config.nlist == 256
+        assert config.M == 32
+        assert config.nbits == 6
+        assert config.faiss_kwargs == {"useFloat16": True}


### PR DESCRIPTION
## Description

- Preserve custom product-quantization settings when creating a rank-local FAISS configuration.
- Continue overriding only the device with the local distributed rank.
- Add regression coverage for IVFPQ fields and advanced FAISS kwargs.

## Checklist

- [x] I have read the How to Contribute document.
- [x] Documentation is unchanged because the documented copy behavior is now honored.
- [x] Relevant tests pass and the fix is covered by a new test.
- [x] Added this PR to RELEASES.rst.

## Test plan

- [x] Distributed utility test module (17 passed).
- [x] Pre-commit hooks for changed files.