### PR TITLE
[Fix] Log the current gradient norm

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -44,6 +44,7 @@ Changed
 Fixed
 ~~~~~
 
+- Report the current optimization step's gradient norm in verbose logs `PR #280 <https://github.com/TorchDR/TorchDR/pull/280>`_.
 - Fix memory leak in AffinityMatcher by freeing input data after initialization `PR #223 <https://github.com/TorchDR/TorchDR/pull/223>`_.
 - Fix PACMAP device handling `PR #215 <https://github.com/TorchDR/TorchDR/pull/215>`_.
 - Fix AffinityMatcher kwargs mutation `PR #240 <https://github.com/TorchDR/TorchDR/pull/240>`_.

--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -44,7 +44,6 @@ Changed
 Fixed
 ~~~~~
 
-- Report the current optimization step's gradient norm in verbose logs `PR #280 <https://github.com/TorchDR/TorchDR/pull/280>`_.
 - Fix memory leak in AffinityMatcher by freeing input data after initialization `PR #223 <https://github.com/TorchDR/TorchDR/pull/223>`_.
 - Fix PACMAP device handling `PR #215 <https://github.com/TorchDR/TorchDR/pull/215>`_.
 - Fix AffinityMatcher kwargs mutation `PR #240 <https://github.com/TorchDR/TorchDR/pull/240>`_.

--- a/torchdr/affinity_matcher.py
+++ b/torchdr/affinity_matcher.py
@@ -304,7 +304,6 @@ class AffinityMatcher(DRModule):
             if torch.cuda.is_available():
                 torch.cuda.empty_cache()
 
-        grad_norm = float("nan")
         for step in range(self.max_iter):
             self.n_iter_.fill_(step)
 
@@ -318,16 +317,6 @@ class AffinityMatcher(DRModule):
                 f"at iter {step}.",
             )
 
-            if self.verbose and (self.n_iter_ % self.check_interval == 0):
-                lr = self.optimizer_.param_groups[0]["lr"]
-                msg_parts = []
-                if loss is not None:
-                    msg_parts.append(f"Loss: {loss.item():.2e}")
-                msg_parts.append(f"Grad norm: {grad_norm:.2e}")
-                msg_parts.append(f"LR: {lr:.2e}")
-                msg = " | ".join(msg_parts)
-                self.logger.info(f"[{self.n_iter_}/{self.max_iter}] {msg}")
-
             if self.n_iter_ % self.check_interval == 0:
                 if self.encoder is not None:
                     grad_norm = (
@@ -340,6 +329,17 @@ class AffinityMatcher(DRModule):
                     )
                 else:
                     grad_norm = self.embedding_.grad.norm(2).item()
+
+                if self.verbose:
+                    lr = self.optimizer_.param_groups[0]["lr"]
+                    msg_parts = []
+                    if loss is not None:
+                        msg_parts.append(f"Loss: {loss.item():.2e}")
+                    msg_parts.append(f"Grad norm: {grad_norm:.2e}")
+                    msg_parts.append(f"LR: {lr:.2e}")
+                    msg = " | ".join(msg_parts)
+                    self.logger.info(f"[{self.n_iter_}/{self.max_iter}] {msg}")
+
                 if grad_norm < self.min_grad_norm:
                     if self.verbose:
                         self.logger.info(

--- a/torchdr/tests/test_affinity_matcher.py
+++ b/torchdr/tests/test_affinity_matcher.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 import torch
 import numpy as np
@@ -65,6 +67,31 @@ def test_convergence_reached():
     )
     model.fit_transform(torch.rand(5, 2))
     assert model.n_iter_ < 2  # should converge in less than 2 iterations
+
+
+def test_verbose_logs_current_gradient_norm(caplog):
+    class TestAffinity(Affinity):
+        def __call__(self, X, **kwargs):
+            return X @ X.T
+
+        def _compute_affinity(self, X):
+            return X @ X.T
+
+    model = AffinityMatcher(
+        affinity_in=TestAffinity(),
+        affinity_out=TestAffinity(),
+        max_iter=1,
+        min_grad_norm=0,
+        verbose=True,
+        check_interval=1,
+    )
+
+    with caplog.at_level(logging.INFO, logger=model.logger.name):
+        model.fit_transform(torch.rand(5, 2))
+
+    expected = f"Grad norm: {model.embedding_.grad.norm(2).item():.2e}"
+    messages = [record.getMessage() for record in caplog.records]
+    assert any(expected in message for message in messages)
 
 
 def test_scheduler_not_configure_optimizer():


### PR DESCRIPTION
## Description

- Compute the gradient norm before emitting each checkpoint log.
- Keep convergence checks and verbose reporting on the same current-step value.
- Add a regression test matching the logged value to the actual step gradient.

## Checklist

- [x] I have read the How to Contribute document.
- [x] Documentation is unchanged because this corrects runtime reporting.
- [x] Relevant tests pass and the fix is covered by a new test.
- [x] Added this PR to RELEASES.rst.

## Test plan

- [x] AffinityMatcher test module (24 passed).
- [x] Pre-commit hooks for changed files.