### PR TITLE
[Fix] Release DataLoader metadata cache entries

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -44,6 +44,7 @@ Changed
 Fixed
 ~~~~~
 
+- Release cached DataLoader metadata when loaders are destroyed `PR #281 <https://github.com/TorchDR/TorchDR/pull/281>`_.
 - Fix memory leak in AffinityMatcher by freeing input data after initialization `PR #223 <https://github.com/TorchDR/TorchDR/pull/223>`_.
 - Fix PACMAP device handling `PR #215 <https://github.com/TorchDR/TorchDR/pull/215>`_.
 - Fix AffinityMatcher kwargs mutation `PR #240 <https://github.com/TorchDR/TorchDR/pull/240>`_.

--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -44,7 +44,6 @@ Changed
 Fixed
 ~~~~~
 
-- Release cached DataLoader metadata when loaders are destroyed `PR #281 <https://github.com/TorchDR/TorchDR/pull/281>`_.
 - Fix memory leak in AffinityMatcher by freeing input data after initialization `PR #223 <https://github.com/TorchDR/TorchDR/pull/223>`_.
 - Fix PACMAP device handling `PR #215 <https://github.com/TorchDR/TorchDR/pull/215>`_.
 - Fix AffinityMatcher kwargs mutation `PR #240 <https://github.com/TorchDR/TorchDR/pull/240>`_.

--- a/torchdr/distance/faiss.py
+++ b/torchdr/distance/faiss.py
@@ -7,6 +7,7 @@
 import torch
 import numpy as np
 import warnings
+from weakref import WeakKeyDictionary
 from typing import Union, Optional, Dict, Any, Tuple, List
 
 from torch.utils.data import (
@@ -21,7 +22,7 @@ from torchdr.utils.faiss import faiss
 LIST_METRICS_FAISS = ["euclidean", "sqeuclidean", "angular"]
 
 # Cache for DataLoader metadata to avoid redundant iterations
-_DATALOADER_METADATA_CACHE = {}
+_DATALOADER_METADATA_CACHE = WeakKeyDictionary()
 
 
 def get_dataloader_metadata(dataloader):
@@ -38,7 +39,7 @@ def get_dataloader_metadata(dataloader):
         Cached metadata dictionary with keys 'n_samples', 'n_features', 'dtype',
         or None if not cached.
     """
-    return _DATALOADER_METADATA_CACHE.get(id(dataloader))
+    return _DATALOADER_METADATA_CACHE.get(dataloader)
 
 
 def _cache_dataloader_metadata(dataloader, metadata):
@@ -51,7 +52,7 @@ def _cache_dataloader_metadata(dataloader, metadata):
     metadata : dict
         Metadata dictionary with keys 'n_samples', 'n_features', 'dtype'.
     """
-    _DATALOADER_METADATA_CACHE[id(dataloader)] = metadata
+    _DATALOADER_METADATA_CACHE[dataloader] = metadata
 
 
 def _is_deterministic_sampler(sampler):

--- a/torchdr/tests/test_dataloader.py
+++ b/torchdr/tests/test_dataloader.py
@@ -4,6 +4,9 @@
 #
 # License: BSD 3-Clause License
 
+import gc
+import weakref
+
 import pytest
 import torch
 from torch.testing import assert_close
@@ -14,7 +17,11 @@ from torchdr.distance import (
     pairwise_distances_faiss_from_dataloader,
     FaissConfig,
 )
-from torchdr.distance.faiss import get_dataloader_metadata
+from torchdr.distance.faiss import (
+    _DATALOADER_METADATA_CACHE,
+    _cache_dataloader_metadata,
+    get_dataloader_metadata,
+)
 from torchdr.utils import faiss
 
 
@@ -261,6 +268,23 @@ class TestDataLoaderOptimizations:
         # Verify results are correct
         assert dist.shape == (len(sample_data), k)
         assert idx.shape == (len(sample_data), k)
+
+    def test_metadata_cache_releases_destroyed_dataloader(self, sample_data):
+        """Cached metadata should not outlive its DataLoader."""
+        dataloader = DataLoader(
+            TensorDataset(sample_data), batch_size=100, shuffle=False
+        )
+        metadata = {"cache_test_marker": object()}
+        _cache_dataloader_metadata(dataloader, metadata)
+
+        dataloader_ref = weakref.ref(dataloader)
+        assert metadata in _DATALOADER_METADATA_CACHE.values()
+
+        del dataloader
+        gc.collect()
+
+        assert dataloader_ref() is None
+        assert metadata not in _DATALOADER_METADATA_CACHE.values()
 
     def test_shuffle_validation_sequential_sampler(self, sample_data):
         """Test that sequential sampler (shuffle=False) is accepted."""


### PR DESCRIPTION
## Description

- Key cached DataLoader metadata by weak references to loader objects.
- Remove metadata automatically when its DataLoader is destroyed.
- Prevent stale metadata from being returned after Python reuses an object ID.

## Checklist

- [x] I have read the How to Contribute document.
- [x] Documentation is unchanged because cache lifetime is internal behavior.
- [x] Relevant tests pass and cache cleanup is covered by a new test.
- [x] Added this PR to RELEASES.rst.

## Test plan

- [x] Full DataLoader test module (24 passed, 1 skipped).
- [x] Pre-commit hooks for changed files.