### PR TITLE
[Doc] Clarify neighborhood overlap metric

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -63,6 +63,7 @@ Removed
 Documentation
 ~~~~~~~~~~~~~
 
+- Clarify that neighborhood preservation reports overlap at K rather than Jaccard similarity `PR #282 <https://github.com/TorchDR/TorchDR/pull/282>`_.
 - Add multi-GPU distributed training documentation `PR #243 <https://github.com/TorchDR/TorchDR/pull/243>`_.
 - Add DistributedPCA documentation `PR #252 <https://github.com/TorchDR/TorchDR/pull/252>`_.
 - Add DataLoader feature documentation `PR #245 <https://github.com/TorchDR/TorchDR/pull/245>`_.

--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -63,7 +63,6 @@ Removed
 Documentation
 ~~~~~~~~~~~~~
 
-- Clarify that neighborhood preservation reports overlap at K rather than Jaccard similarity `PR #282 <https://github.com/TorchDR/TorchDR/pull/282>`_.
 - Add multi-GPU distributed training documentation `PR #243 <https://github.com/TorchDR/TorchDR/pull/243>`_.
 - Add DistributedPCA documentation `PR #252 <https://github.com/TorchDR/TorchDR/pull/252>`_.
 - Add DataLoader feature documentation `PR #245 <https://github.com/TorchDR/TorchDR/pull/245>`_.

--- a/torchdr/eval/neighborhood_preservation.py
+++ b/torchdr/eval/neighborhood_preservation.py
@@ -87,9 +87,12 @@ def neighborhood_preservation(
 
     Notes
     -----
-    The metric computes the Jaccard similarity (intersection over union) between
-    the K-nearest neighbor sets in the original and reduced spaces for each point,
-    then averages across all points.
+    For each point, the metric computes the fraction of its ``K`` original-space
+    nearest neighbors that also appear among its ``K`` embedding-space nearest
+    neighbors, then averages across all points. Equivalently, it divides the
+    neighborhood intersection size by ``K``. This is a neighborhood-overlap
+    (or neighbor-recall) score, not Jaccard similarity, whose denominator would
+    be the size of the neighborhood union.
 
     For large datasets, using backend='faiss' is recommended for efficiency.
     The metric excludes self-neighbors (i.e., the point itself).


### PR DESCRIPTION
## Description

- Describe neighborhood preservation as intersection size divided by K.
- Identify the score as neighborhood overlap or neighbor recall.
- Clarify that Jaccard similarity instead divides by the union size.

## Checklist

- [x] I have read the How to Contribute document.
- [x] Documentation now matches the implemented metric.
- [x] The evaluation test module passes unchanged.
- [x] Added this PR to RELEASES.rst.

## Test plan

- [x] Full evaluation test module (80 passed, 2 skipped).
- [x] Pre-commit hooks for changed files.