### PR TITLE
[Fix] Preserve NumPy random state in kmeans ARI

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -44,7 +44,6 @@ Changed
 Fixed
 ~~~~~
 
-- Preserve NumPy's global random state when computing k-means ARI `PR #283 <https://github.com/TorchDR/TorchDR/pull/283>`_.
 - Correct PACMAP mid-near pair selection to use global sample indices `PR #277 <https://github.com/TorchDR/TorchDR/pull/277>`_.
 - Fix memory leak in AffinityMatcher by freeing input data after initialization `PR #223 <https://github.com/TorchDR/TorchDR/pull/223>`_.
 - Fix PACMAP device handling `PR #215 <https://github.com/TorchDR/TorchDR/pull/215>`_.

--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -44,6 +44,7 @@ Changed
 Fixed
 ~~~~~
 
+- Preserve NumPy's global random state when computing k-means ARI `PR #283 <https://github.com/TorchDR/TorchDR/pull/283>`_.
 - Correct PACMAP mid-near pair selection to use global sample indices `PR #277 <https://github.com/TorchDR/TorchDR/pull/277>`_.
 - Fix memory leak in AffinityMatcher by freeing input data after initialization `PR #223 <https://github.com/TorchDR/TorchDR/pull/223>`_.
 - Fix PACMAP device handling `PR #215 <https://github.com/TorchDR/TorchDR/pull/215>`_.

--- a/torchdr/eval/kmeans.py
+++ b/torchdr/eval/kmeans.py
@@ -135,8 +135,11 @@ def kmeans_ari(
             f"n_clusters ({n_clusters}) cannot be greater than n_samples ({n_samples})"
         )
 
-    if random_state is not None:
-        np.random.seed(random_state)
+    seed = (
+        int(random_state)
+        if random_state is not None
+        else int(np.random.default_rng().integers(2**31))
+    )
 
     use_gpu = (device.type == "cuda") and hasattr(faiss, "StandardGpuResources")
 
@@ -147,7 +150,7 @@ def kmeans_ari(
         nredo=nredo,
         verbose=verbose,
         gpu=use_gpu,
-        seed=random_state if random_state is not None else np.random.randint(2**31),
+        seed=seed,
     )
 
     if device.type == "cuda" and not use_gpu:

--- a/torchdr/tests/test_eval.py
+++ b/torchdr/tests/test_eval.py
@@ -265,6 +265,25 @@ def test_kmeans_ari_reproducibility():
 
 
 @pytest.mark.skipif(not faiss, reason="FAISS not installed")
+@pytest.mark.parametrize("random_state", [None, 42])
+def test_kmeans_ari_preserves_numpy_random_state(random_state):
+    """Test kmeans_ari does not mutate NumPy's global random state."""
+    try:
+        import torchmetrics  # noqa: F401
+    except ImportError:
+        pytest.skip("torchmetrics not installed")
+
+    X, y = toy_dataset(100, "float32")
+    np.random.seed(1234)
+    state_before = np.random.get_state()
+
+    kmeans_ari(X, y, random_state=random_state)
+
+    state_after = np.random.get_state()
+    np.testing.assert_equal(state_after, state_before)
+
+
+@pytest.mark.skipif(not faiss, reason="FAISS not installed")
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 def test_kmeans_ari_gpu():
     """Test kmeans_ari with GPU device."""


### PR DESCRIPTION
## Summary
- use a local NumPy generator to select the FAISS seed when none is provided
- pass explicit seeds directly without reseeding NumPy globally
- cover both seeded and unseeded calls with a global-state regression test

## Test plan
- [x] Run kmeans ARI tests
- [x] Run pre-commit checks on changed files