### PR TITLE
[Chore] Require Python 3.8 or newer

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -35,7 +35,6 @@ Added
 Changed
 ~~~~~~~
 
-- Require Python 3.8 or newer in package metadata `PR #284 <https://github.com/TorchDR/TorchDR/pull/284>`_.
 - Rename SampledNeighborEmbedding to NegativeSamplingNeighborEmbedding `PR #225 <https://github.com/TorchDR/TorchDR/pull/225>`_.
 - Standardize device parameter to 'auto' default across all modules `PR #241 <https://github.com/TorchDR/TorchDR/pull/241>`_.
 - Refactor device management for consistency `PR #211 <https://github.com/TorchDR/TorchDR/pull/211>`_.

--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -35,6 +35,7 @@ Added
 Changed
 ~~~~~~~
 
+- Require Python 3.8 or newer in package metadata `PR #284 <https://github.com/TorchDR/TorchDR/pull/284>`_.
 - Rename SampledNeighborEmbedding to NegativeSamplingNeighborEmbedding `PR #225 <https://github.com/TorchDR/TorchDR/pull/225>`_.
 - Standardize device parameter to 'auto' default across all modules `PR #241 <https://github.com/TorchDR/TorchDR/pull/241>`_.
 - Refactor device management for consistency `PR #211 <https://github.com/TorchDR/TorchDR/pull/211>`_.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 ]
 license = {text = "BSD (3-Clause)"}
 readme = {file = "README.md", content-type = "text/markdown"}
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = [
     "torch",
     "scikit-learn",
@@ -39,7 +39,6 @@ classifiers=[
   "Operating System :: POSIX",
   "Operating System :: Unix",
   "Operating System :: MacOS",
-  "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
## Summary
- align the declared minimum Python version with the documented Python 3.8+ support policy
- remove the obsolete Python 3.7 package classifier

## Test plan
- [x] Run pre-commit checks on pyproject.toml