### PR TITLE
[Doc] Clarify FAISS angular distance semantics

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -64,7 +64,6 @@ Removed
 Documentation
 ~~~~~~~~~~~~~
 
-- Clarify that FAISS angular distances use unnormalized inner products `PR #285 <https://github.com/TorchDR/TorchDR/pull/285>`_.
 - Add multi-GPU distributed training documentation `PR #243 <https://github.com/TorchDR/TorchDR/pull/243>`_.
 - Add DistributedPCA documentation `PR #252 <https://github.com/TorchDR/TorchDR/pull/252>`_.
 - Add DataLoader feature documentation `PR #245 <https://github.com/TorchDR/TorchDR/pull/245>`_.

--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -64,6 +64,7 @@ Removed
 Documentation
 ~~~~~~~~~~~~~
 
+- Clarify that FAISS angular distances use unnormalized inner products `PR #285 <https://github.com/TorchDR/TorchDR/pull/285>`_.
 - Add multi-GPU distributed training documentation `PR #243 <https://github.com/TorchDR/TorchDR/pull/243>`_.
 - Add DistributedPCA documentation `PR #252 <https://github.com/TorchDR/TorchDR/pull/252>`_.
 - Add DataLoader feature documentation `PR #245 <https://github.com/TorchDR/TorchDR/pull/245>`_.

--- a/torchdr/distance/faiss.py
+++ b/torchdr/distance/faiss.py
@@ -236,7 +236,8 @@ def pairwise_distances_faiss(
     Supported metrics are:
       - "euclidean": returns the Euclidean distance (square root of the squared distance)
       - "sqeuclidean": returns the squared Euclidean distance (as computed by FAISS)
-      - "angular": returns the negative inner-product (after normalizing vectors)
+      - "angular": returns the negative inner product. Inputs are not normalized;
+        normalize them beforehand to obtain cosine-similarity neighbor ordering.
 
     If Y is not provided then we assume a self–search and, if `exclude_diag` is True,
     the self–neighbor is removed from the results.
@@ -269,7 +270,7 @@ def pairwise_distances_faiss(
         Nearest neighbor distances.
         For metric=="euclidean", distances are Euclidean (i.e. square root of L2^2).
         For metric=="sqeuclidean", distances are the squared Euclidean distances.
-        For metric=="angular", distances are the (normalized) inner product scores.
+        For metric=="angular", distances are the negative raw inner-product scores.
     indices : torch.Tensor of shape (n, k)
         Indices of the k nearest neighbors.
 


### PR DESCRIPTION
## Summary
- document that the FAISS angular metric returns negative raw inner products
- clarify that callers must normalize inputs themselves for cosine-similarity neighbor ordering
- keep FAISS behavior consistent with the Torch and KeOps backends

## Test plan
- [x] Run FAISS pairwise-distance tests
- [x] Run pre-commit checks on the changed file