### PR TITLE
[Fix] Discover all TorchDR packages explicitly

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -43,6 +43,17 @@ jobs:
       # Run Tests
       - name: Run Tests
         run: pytest torchdr/ --verbose --cov=torchdr --cov-report term --cov-report xml
+      - name: Build and smoke test wheel
+        run: |
+          python -m pip wheel . --no-deps --wheel-dir dist
+          if unzip -l dist/torchdr-*.whl | grep -q "torchdr/tests/"; then
+            echo "Wheel unexpectedly contains the test suite."
+            exit 1
+          fi
+          python -m pip uninstall --yes torchdr
+          python -m pip install --user --no-deps dist/torchdr-*.whl
+          cd "${RUNNER_TEMP}"
+          python -c "import torchdr, torchdr.affinity, torchdr.distance, torchdr.distributed, torchdr.eval, torchdr.neighbor_embedding, torchdr.spectral_embedding, torchdr.utils"
       # Codecov
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,12 @@ dynamic = ["version"]
 torchdr = "torchdr.cli:main"
 
 [tool.setuptools]
-packages = ["torchdr"]
+include-package-data = false
+
+[tool.setuptools.packages.find]
+include = ["torchdr*"]
+exclude = ["torchdr.tests*"]
+namespaces = false
 
 [tool.setuptools_scm]
 version_file = "torchdr/_version.py"


### PR DESCRIPTION
## Summary
- replace the fragile single-package declaration with explicit setuptools discovery for all TorchDR subpackages
- intentionally exclude the in-package test suite and disable accidental package-data inclusion
- add a wheel smoke check to CI that verifies tests are absent and imports every public subpackage from the installed artifact

## Test plan
- [x] targeted pre-commit hooks for TOML and workflow YAML
- [x] build the wheel with isolated package discovery
- [x] inspect the wheel for all public subpackages and absence of torchdr/tests
- [x] import every public subpackage from the wheel outside the source checkout