### PR TITLE
[Fix] Preserve distributed sparse dtypes

### DIFF
--- a/torchdr/tests/test_sparse.py
+++ b/torchdr/tests/test_sparse.py
@@ -8,6 +8,7 @@ import pytest
 import torch
 
 from torchdr.utils.sparse import (
+    distributed_symmetrize_sparse,
     flatten_sparse,
     merge_symmetry,
     pack_to_rowwise,
@@ -168,3 +169,43 @@ class TestSymmetrizeSparse:
         # With inputs in [0,1], sum_minus_prod should be in [0,1]
         assert values_out.min() >= -1e-6
         assert values_out.max() <= 2.0 + 1e-6
+
+
+def test_distributed_symmetrize_preserves_index_and_value_dtypes(monkeypatch):
+    """Collectives must not cast large indices or float64 affinity values."""
+    collective_dtypes = []
+
+    def fake_all_to_all_single(output, input):
+        output.copy_(input)
+
+    def fake_all_to_all(outputs, inputs):
+        collective_dtypes.append((outputs[0].dtype, inputs[0].dtype))
+        for output, input in zip(outputs, inputs):
+            output.copy_(input)
+
+    monkeypatch.setattr("torchdr.utils.sparse.dist.is_initialized", lambda: True)
+    monkeypatch.setattr("torchdr.utils.sparse.dist.get_world_size", lambda: 1)
+    monkeypatch.setattr(
+        "torchdr.utils.sparse.dist.all_to_all_single", fake_all_to_all_single
+    )
+    monkeypatch.setattr("torchdr.utils.sparse.dist.all_to_all", fake_all_to_all)
+
+    large_index = 2**24 + 1
+    values = torch.tensor([[0.125]], dtype=torch.float64)
+    indices = torch.tensor([[large_index]], dtype=torch.long)
+
+    values_out, indices_out = distributed_symmetrize_sparse(
+        values,
+        indices,
+        chunk_start=0,
+        chunk_size=1,
+        n_total=large_index + 1,
+        mode="sum",
+    )
+
+    assert collective_dtypes == [
+        (torch.int64, torch.int64),
+        (torch.float64, torch.float64),
+    ]
+    assert values_out.dtype == torch.float64
+    assert indices_out[0, 0].item() == large_index

--- a/torchdr/utils/sparse.py
+++ b/torchdr/utils/sparse.py
@@ -266,9 +266,11 @@ def distributed_symmetrize_sparse(
     target_sorted = target_ranks[sorted_idx]
 
     # Step 3: Vectorized packing of edges for each rank
-    send_tensors = [
-        torch.empty((3, 0), device=device, dtype=torch.float32)
-        for _ in range(world_size)
+    send_indices = [
+        torch.empty((2, 0), device=device, dtype=torch.long) for _ in range(world_size)
+    ]
+    send_values = [
+        torch.empty(0, device=device, dtype=v.dtype) for _ in range(world_size)
     ]
 
     if target_sorted.numel() > 0:
@@ -283,44 +285,43 @@ def distributed_symmetrize_sparse(
             start = offsets[idx].item()
             end = offsets[idx + 1].item()
             if end > start and r < world_size:
-                send_tensors[r] = torch.stack(
-                    [
-                        i_sorted[start:end].float(),
-                        j_sorted[start:end].float(),
-                        v_sorted[start:end],
-                    ],
-                    dim=0,
+                send_indices[r] = torch.stack(
+                    [i_sorted[start:end], j_sorted[start:end]], dim=0
                 ).contiguous()
+                send_values[r] = v_sorted[start:end].contiguous()
 
     # Step 4: Exchange sizes first to allocate correct receive buffers
     send_sizes = torch.tensor(
-        [s.shape[1] for s in send_tensors], device=device, dtype=torch.long
+        [s.shape[1] for s in send_indices], device=device, dtype=torch.long
     )
     recv_sizes = torch.zeros(world_size, device=device, dtype=torch.long)
     dist.all_to_all_single(recv_sizes, send_sizes)
 
     # Step 5: Allocate receive buffers with correct sizes
-    recv_tensors = []
+    recv_indices = []
+    recv_values = []
     for r in range(world_size):
         size = recv_sizes[r].item()
-        recv_tensors.append(torch.zeros((3, size), device=device, dtype=torch.float32))
+        recv_indices.append(torch.empty((2, size), device=device, dtype=torch.long))
+        recv_values.append(torch.empty(size, device=device, dtype=v.dtype))
 
-    # Step 6: All-to-all exchange with properly sized buffers
-    dist.all_to_all(recv_tensors, send_tensors)
+    # Step 6: Exchange indices and values without casting either dtype
+    dist.all_to_all(recv_indices, send_indices)
+    dist.all_to_all(recv_values, send_values)
 
     # Step 7: Unpack received edges (these are edges where we own the transpose)
-    if any(t.shape[1] > 0 for t in recv_tensors):
-        recv_all = torch.cat([t for t in recv_tensors if t.shape[1] > 0], dim=1)
-        recv_i = recv_all[0].long()
-        recv_j = recv_all[1].long()
-        recv_v = recv_all[2]
+    if any(t.shape[1] > 0 for t in recv_indices):
+        recv_indices_all = torch.cat([t for t in recv_indices if t.shape[1] > 0], dim=1)
+        recv_values_all = torch.cat([t for t in recv_values if t.numel() > 0], dim=0)
+        recv_i = recv_indices_all[0]
+        recv_j = recv_indices_all[1]
 
         # Combine with local edges for symmetrization
         # Local edges: (i, j) with values v
         # Received edges need to be transposed: (j, i) becomes part of our P^T
         all_i = torch.cat([i, recv_j])
         all_j = torch.cat([j, recv_i])
-        all_v = torch.cat([v, recv_v])
+        all_v = torch.cat([v, recv_values_all])
     else:
         all_i = i
         all_j = j


### PR DESCRIPTION
## Summary
- exchange sparse global indices in int64 buffers instead of packing them into float32
- exchange affinity values in their original dtype, including float64
- add regression coverage for an index above the float32 exact-integer limit and float64 affinities

## Test plan
- [x] targeted pre-commit hooks on the changed implementation and test
- [x] focused large-index and float64 regression test
- [x] complete sparse utility test file (13 passed)