### PR TITLE
[Fix] Avoid FAISS tensor host round trips

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -163,9 +163,11 @@ jobs:
       - name: Upgrade pip
         run: pip install --upgrade pip
       - name: Install FAISS
-        run: conda install -c conda-forge -c pytorch faiss-cpu=1.10.0 --yes
+        run: conda install -c pytorch -c conda-forge faiss-cpu=1.11.0 "numpy<2" --yes
       - name: Install 'torchdr' package
         run: pip install -e ".[test]"
+      - name: Verify FAISS installation
+        run: python -c "from torchdr.utils.faiss import faiss; assert faiss, 'FAISS failed to import'"
       - name: Run Tests
         run: pytest torchdr/tests/test_utils.py torchdr/tests/test_dataloader.py torchdr/tests/test_eval.py --verbose --cov=torchdr --cov-report term --cov-report xml
       - name: Upload coverage reports to Codecov

--- a/torchdr/distance/faiss.py
+++ b/torchdr/distance/faiss.py
@@ -17,7 +17,7 @@ from torch.utils.data import (
     BatchSampler,
 )
 
-from torchdr.utils.faiss import faiss
+from torchdr.utils.faiss import faiss, faiss_torch_interop
 
 LIST_METRICS_FAISS = ["euclidean", "sqeuclidean", "angular"]
 
@@ -275,6 +275,12 @@ def pairwise_distances_faiss(
     indices : torch.Tensor of shape (n, k)
         Indices of the k nearest neighbors.
 
+    Notes
+    -----
+    FAISS computes index distances in float32. Tensor inputs are passed directly
+    to FAISS on CPU or GPU when the installed FAISS build provides its PyTorch
+    interoperability wrappers; results are cast back to the input dtype.
+
     Examples
     --------
     >>> import torch
@@ -311,15 +317,21 @@ def pairwise_distances_faiss(
         k = int(k)
 
     dtype = X.dtype
-    X_np = X.detach().cpu().numpy().astype(np.float32)
-    _, d = X_np.shape
+    _, d = X.shape
 
     if Y is None or Y is X:
-        Y_np = X_np
+        Y = X
         do_exclude = exclude_diag
     else:
-        Y_np = Y.detach().cpu().numpy().astype(np.float32)
         do_exclude = False
+
+    if X.dtype != torch.float32 or Y.dtype != torch.float32:
+        warnings.warn(
+            "[TorchDR] FAISS computes distances in float32; input values will "
+            "be converted and results cast back to the input dtype.",
+            UserWarning,
+            stacklevel=2,
+        )
 
     if metric == "angular":
         flat_index = faiss.IndexFlatIP(d)
@@ -333,13 +345,13 @@ def pairwise_distances_faiss(
     if config.index_type == "Flat":
         index = flat_index
     elif config.index_type == "IVF":
-        n_vectors = len(Y_np)
+        n_vectors = len(Y)
         if config.nlist == 100 and n_vectors > 10000:
             config.nlist = min(int(4 * np.sqrt(n_vectors)), n_vectors // 40, 8192)
         index = faiss.IndexIVFFlat(flat_index, d, config.nlist, metric_type)
         index.nprobe = config.nprobe
     elif config.index_type == "IVFPQ":
-        n_vectors = len(Y_np)
+        n_vectors = len(Y)
         if config.nlist == 100 and n_vectors > 10000:
             config.nlist = min(int(4 * np.sqrt(n_vectors)), n_vectors // 40, 8192)
         if d % config.M != 0:
@@ -362,8 +374,11 @@ def pairwise_distances_faiss(
     else:
         compute_device = torch.device(device)
 
+    use_gpu_index = compute_device.type == "cuda" and hasattr(
+        faiss, "StandardGpuResources"
+    )
     if compute_device.type == "cuda":
-        if hasattr(faiss, "StandardGpuResources"):
+        if use_gpu_index:
             index = _setup_gpu_index(index, config, d)
         else:
             warnings.warn(
@@ -371,27 +386,47 @@ def pairwise_distances_faiss(
                 "This may be slow. For faster performance, install `faiss-gpu`."
             )
 
+    if use_gpu_index and faiss_torch_interop:
+        device_id = (
+            config.device if isinstance(config.device, int) else config.device[0]
+        )
+        index_device = torch.device("cuda", device_id)
+    else:
+        index_device = torch.device("cpu")
+
+    X_faiss = X.detach().to(device=index_device, dtype=torch.float32).contiguous()
+    Y_faiss = Y.detach().to(device=index_device, dtype=torch.float32).contiguous()
+
+    if not faiss_torch_interop:
+        X_faiss = X_faiss.cpu().numpy()
+        Y_faiss = Y_faiss.cpu().numpy()
+
     if needs_training and not index.is_trained:
-        train_data = Y_np
+        train_data = Y_faiss
         max_train_points = 256 * config.nlist
-        if len(Y_np) > max_train_points:
+        if len(Y_faiss) > max_train_points:
             sample_indices = np.random.choice(
-                len(Y_np), max_train_points, replace=False
+                len(Y_faiss), max_train_points, replace=False
             )
-            train_data = Y_np[sample_indices]
+            if isinstance(Y_faiss, torch.Tensor):
+                sample_indices = torch.as_tensor(sample_indices, device=Y_faiss.device)
+            train_data = Y_faiss[sample_indices]
         index.train(train_data)
 
-    index.add(Y_np)
+    index.add(Y_faiss)
 
     if do_exclude:
         k_search = k + 1
     else:
         k_search = k
 
-    D, Ind = index.search(X_np, k_search)
+    D, Ind = index.search(X_faiss, k_search)
 
     if metric == "euclidean":
-        D = np.sqrt(D)
+        if isinstance(D, torch.Tensor):
+            D = torch.sqrt(D)
+        else:
+            D = np.sqrt(D)
     elif metric == "angular":
         D = -D
 
@@ -399,8 +434,12 @@ def pairwise_distances_faiss(
         D = D[:, 1:]
         Ind = Ind[:, 1:]
 
-    distances = torch.from_numpy(D).to(compute_device).to(dtype)
-    indices = torch.from_numpy(Ind).to(compute_device).long()
+    if not isinstance(D, torch.Tensor):
+        D = torch.from_numpy(D)
+        Ind = torch.from_numpy(Ind)
+
+    distances = D.to(device=compute_device, dtype=dtype)
+    indices = Ind.to(device=compute_device, dtype=torch.long)
 
     return distances, indices
 

--- a/torchdr/tests/test_utils.py
+++ b/torchdr/tests/test_utils.py
@@ -1306,6 +1306,40 @@ def test_faiss_check_installation_success():
     assert index is not None
 
 
+@pytest.mark.skipif(not faiss, reason="faiss is not available")
+def test_enable_faiss_torch_interop_success():
+    """Test that the installed FAISS tensor wrappers can be enabled."""
+    from torchdr.utils.faiss import _enable_faiss_torch_interop
+
+    assert _enable_faiss_torch_interop() is True
+
+
+def test_enable_faiss_torch_interop_without_faiss(monkeypatch):
+    """Test that tensor interoperability stays disabled without FAISS."""
+    from importlib import import_module
+
+    faiss_utils = import_module("torchdr.utils.faiss")
+
+    monkeypatch.setattr(faiss_utils, "faiss", None)
+
+    assert faiss_utils._enable_faiss_torch_interop() is False
+
+
+@pytest.mark.skipif(not faiss, reason="faiss is not available")
+def test_enable_faiss_torch_interop_without_wrappers(monkeypatch):
+    """Test compatibility with FAISS builds lacking tensor wrappers."""
+    from importlib import import_module
+
+    faiss_utils = import_module("torchdr.utils.faiss")
+
+    def missing_wrappers(module_name):
+        raise ImportError(module_name)
+
+    monkeypatch.setattr(faiss_utils, "import_module", missing_wrappers)
+
+    assert faiss_utils._enable_faiss_torch_interop() is False
+
+
 def test_faiss_check_installation_mock_broken():
     """Test that _check_faiss_installation detects broken FAISS imports."""
     import sys

--- a/torchdr/tests/test_utils.py
+++ b/torchdr/tests/test_utils.py
@@ -174,6 +174,40 @@ def test_pairwise_distances_faiss_k_as_tensor():
 
 
 @pytest.mark.skipif(not faiss, reason="faiss is not available")
+def test_pairwise_distances_faiss_avoids_numpy_round_trip(monkeypatch):
+    """Test that FAISS consumes tensor inputs without converting to NumPy."""
+    from torchdr.utils.faiss import faiss_torch_interop
+
+    if not faiss_torch_interop:
+        pytest.skip("installed FAISS does not provide PyTorch interoperability")
+
+    x = torch.randn(20, 8, dtype=torch.float32)
+
+    def fail_numpy_conversion(self):
+        raise AssertionError("unexpected conversion to NumPy")
+
+    monkeypatch.setattr(torch.Tensor, "numpy", fail_numpy_conversion)
+
+    distances, indices = pairwise_distances(
+        x, k=5, backend="faiss", return_indices=True, device="cpu"
+    )
+
+    check_shape(distances, (20, 5))
+    check_shape(indices, (20, 5))
+
+
+@pytest.mark.skipif(not faiss, reason="faiss is not available")
+def test_pairwise_distances_faiss_warns_on_float64():
+    """Test that FAISS' float32 precision boundary is explicit."""
+    x = torch.randn(20, 8, dtype=torch.float64)
+
+    with pytest.warns(UserWarning, match="FAISS computes distances in float32"):
+        distances = pairwise_distances(x, k=5, backend="faiss", device="cpu")
+
+    assert distances.dtype == torch.float64
+
+
+@pytest.mark.skipif(not faiss, reason="faiss is not available")
 def test_faiss_config_repr():
     """Test FaissConfig __repr__ method."""
     from torchdr.distance import FaissConfig

--- a/torchdr/utils/faiss.py
+++ b/torchdr/utils/faiss.py
@@ -6,6 +6,7 @@
 
 import sys
 import warnings
+from importlib import import_module
 
 
 def _check_faiss_installation():
@@ -55,17 +56,22 @@ def _check_faiss_installation():
 # Perform the check
 faiss, _error_message = _check_faiss_installation()
 
-# Importing FAISS' official PyTorch wrappers patches index methods so they can
-# consume CPU and CUDA tensors directly. Keep a NumPy fallback for older FAISS
-# builds that do not ship the interoperability module.
-faiss_torch_interop = False
-if faiss is not None:
-    try:
-        import faiss.contrib.torch_utils  # noqa: F401
 
-        faiss_torch_interop = True
+def _enable_faiss_torch_interop():
+    """Enable FAISS' official PyTorch wrappers when they are available."""
+    if faiss is None:
+        return False
+
+    try:
+        import_module("faiss.contrib.torch_utils")
     except ImportError:
-        pass
+        return False
+    return True
+
+
+# Importing the wrappers patches index methods so they can consume CPU and CUDA
+# tensors directly. Keep a NumPy fallback for older FAISS builds without them.
+faiss_torch_interop = _enable_faiss_torch_interop()
 
 # If FAISS is not available or broken, show a helpful warning
 if faiss is None and _error_message:

--- a/torchdr/utils/faiss.py
+++ b/torchdr/utils/faiss.py
@@ -55,6 +55,18 @@ def _check_faiss_installation():
 # Perform the check
 faiss, _error_message = _check_faiss_installation()
 
+# Importing FAISS' official PyTorch wrappers patches index methods so they can
+# consume CPU and CUDA tensors directly. Keep a NumPy fallback for older FAISS
+# builds that do not ship the interoperability module.
+faiss_torch_interop = False
+if faiss is not None:
+    try:
+        import faiss.contrib.torch_utils  # noqa: F401
+
+        faiss_torch_interop = True
+    except ImportError:
+        pass
+
 # If FAISS is not available or broken, show a helpful warning
 if faiss is None and _error_message:
     _install_instructions = """


### PR DESCRIPTION
## Summary
- enable FAISS' official PyTorch interoperability wrappers when available
- pass contiguous float32 tensors directly to CPU or GPU indexes instead of routing through host NumPy
- warn explicitly when FAISS converts higher-precision input to its float32 computation dtype
- retain a NumPy fallback for older FAISS builds
- make the FAISS CI job use a compatible FAISS/NumPy pair and fail if FAISS cannot import

## Validation
- `pytest torchdr/tests/test_utils.py -k pairwise_distances_faiss -q` (18 passed)
- one-B200 end-to-end CPU/GPU tensor interoperability probe
- GitHub FAISS job: 263 passed, 14 skipped; FAISS installation smoke check passed
- `pre-commit run --all-files`
