### PR TITLE
[Fix] Keep FAISS K-means tensor input on-device

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -163,9 +163,11 @@ jobs:
       - name: Upgrade pip
         run: pip install --upgrade pip
       - name: Install FAISS
-        run: conda install -c conda-forge -c pytorch faiss-cpu=1.10.0 --yes
+        run: conda install -c pytorch -c conda-forge faiss-cpu=1.11.0 "numpy<2" --yes
       - name: Install 'torchdr' package
         run: pip install -e ".[test]"
+      - name: Verify FAISS installation
+        run: python -c "from torchdr.utils.faiss import faiss; assert faiss, 'FAISS failed to import'"
       - name: Run Tests
         run: pytest torchdr/tests/test_utils.py torchdr/tests/test_dataloader.py torchdr/tests/test_eval.py --verbose --cov=torchdr --cov-report term --cov-report xml
       - name: Upload coverage reports to Codecov

--- a/torchdr/eval/kmeans.py
+++ b/torchdr/eval/kmeans.py
@@ -7,6 +7,8 @@
 import warnings
 import numpy as np
 import torch
+from contextlib import ExitStack, redirect_stdout
+from io import StringIO
 from typing import Union, Optional
 
 from torchdr.utils import to_torch
@@ -16,6 +18,60 @@ try:
     from torchmetrics.clustering import AdjustedRandScore
 except ImportError:
     AdjustedRandScore = None
+
+
+def _fit_faiss_kmeans_tensor(
+    X,
+    n_clusters,
+    niter,
+    nredo,
+    seed,
+    use_gpu,
+    verbose,
+):
+    """Fit FAISS' tensor-native K-means implementation when available."""
+    try:
+        from faiss.contrib.torch.clustering import (
+            DatasetAssign,
+            DatasetAssignGPU,
+            kmeans,
+        )
+    except ImportError:
+        return None
+
+    if use_gpu:
+        resources = faiss.StandardGpuResources()
+        dataset = DatasetAssignGPU(resources, X)
+    else:
+        dataset = DatasetAssign(X)
+
+    best_centroids = None
+    best_objective = float("inf")
+
+    with ExitStack() as stack:
+        if use_gpu:
+            stack.enter_context(torch.cuda.device(X.device))
+        if not verbose:
+            # FAISS' contrib implementation prints one setup line unconditionally.
+            stack.enter_context(redirect_stdout(StringIO()))
+
+        for redo in range(nredo):
+            centroids, stats = kmeans(
+                n_clusters,
+                dataset,
+                niter=niter,
+                seed=seed + redo,
+                verbose=verbose,
+                return_stats=True,
+            )
+            objective = stats[-1]["obj"] if stats else float("inf")
+            if best_centroids is None or objective < best_objective:
+                best_centroids = centroids
+                best_objective = objective
+
+        _, predicted_labels = dataset.perform_search(best_centroids)
+
+    return predicted_labels.ravel()
 
 
 def kmeans_ari(
@@ -95,6 +151,8 @@ def kmeans_ari(
 
     FAISS K-means uses Lloyd's algorithm with optional multiple runs.
     GPU acceleration is automatically used if FAISS-GPU is installed and X is on GPU.
+    FAISS K-means computes in float32. Tensor inputs stay as tensors on the selected
+    CPU or GPU when the installed FAISS build provides tensor-native clustering.
     """
     if faiss is False:
         raise ImportError(
@@ -120,13 +178,10 @@ def kmeans_ari(
     else:
         device = torch.device(device)
 
-    X_np = X.detach().cpu().numpy().astype(np.float32)
-    labels_np = labels.detach().cpu().numpy()
-
-    n_samples, d = X_np.shape
+    n_samples, d = X.shape
 
     if n_clusters is None:
-        n_clusters = len(np.unique(labels_np))
+        n_clusters = int(torch.unique(labels).numel())
 
     if n_clusters < 1:
         raise ValueError(f"n_clusters must be at least 1, got {n_clusters}")
@@ -143,15 +198,16 @@ def kmeans_ari(
 
     use_gpu = (device.type == "cuda") and hasattr(faiss, "StandardGpuResources")
 
-    kmeans = faiss.Kmeans(
-        d,
-        n_clusters,
-        niter=niter,
-        nredo=nredo,
-        verbose=verbose,
-        gpu=use_gpu,
-        seed=seed,
-    )
+    if X.dtype != torch.float32:
+        warnings.warn(
+            "[TorchDR] FAISS K-means computes in float32; input values will "
+            "be converted before clustering.",
+            UserWarning,
+            stacklevel=2,
+        )
+
+    data_device = device if use_gpu else torch.device("cpu")
+    X_faiss = X.detach().to(device=data_device, dtype=torch.float32).contiguous()
 
     if device.type == "cuda" and not use_gpu:
         warnings.warn(
@@ -160,12 +216,32 @@ def kmeans_ari(
             stacklevel=2,
         )
 
-    kmeans.train(X_np)
+    predicted_labels_torch = _fit_faiss_kmeans_tensor(
+        X_faiss,
+        n_clusters=n_clusters,
+        niter=niter,
+        nredo=nredo,
+        seed=seed,
+        use_gpu=use_gpu,
+        verbose=verbose,
+    )
 
-    _, predicted_labels_np = kmeans.index.search(X_np, 1)
-    predicted_labels_np = predicted_labels_np.ravel()
+    if predicted_labels_torch is None:
+        X_np = X_faiss.cpu().numpy()
+        kmeans = faiss.Kmeans(
+            d,
+            n_clusters,
+            niter=niter,
+            nredo=nredo,
+            verbose=verbose,
+            gpu=use_gpu,
+            seed=seed,
+        )
+        kmeans.train(X_np)
+        _, predicted_labels_np = kmeans.index.search(X_np, 1)
+        predicted_labels_torch = torch.from_numpy(predicted_labels_np.ravel())
 
-    predicted_labels_torch = torch.from_numpy(predicted_labels_np).long().to(device)
+    predicted_labels_torch = predicted_labels_torch.long().to(device)
     labels_torch = labels.long().to(device)
 
     ari_metric = AdjustedRandScore().to(device)
@@ -173,7 +249,7 @@ def kmeans_ari(
 
     if input_is_numpy:
         ari_score = ari_score.detach().cpu().numpy().item()
-        predicted_labels = predicted_labels_np
+        predicted_labels = predicted_labels_torch.detach().cpu().numpy()
     else:
         predicted_labels = predicted_labels_torch
 

--- a/torchdr/tests/test_eval.py
+++ b/torchdr/tests/test_eval.py
@@ -305,6 +305,49 @@ def test_kmeans_ari_gpu():
 
 
 @pytest.mark.skipif(not faiss, reason="FAISS not installed")
+def test_kmeans_ari_tensor_input_avoids_full_numpy_round_trip(monkeypatch):
+    """Test that tensor K-means does not convert the full input to NumPy."""
+    try:
+        import torchmetrics  # noqa: F401
+        import faiss.contrib.torch.clustering  # noqa: F401
+    except ImportError:
+        pytest.skip("FAISS tensor clustering dependencies are not installed")
+
+    X = torch.randn(40, 6, dtype=torch.float32)
+    y = torch.arange(40) % 4
+    original_numpy = torch.Tensor.numpy
+
+    def guard_full_input_numpy(self):
+        if self.shape == X.shape:
+            raise AssertionError("full input was converted to NumPy")
+        return original_numpy(self)
+
+    monkeypatch.setattr(torch.Tensor, "numpy", guard_full_input_numpy)
+
+    ari_score, pred_labels = kmeans_ari(X, y, n_clusters=4, niter=2, random_state=0)
+
+    assert isinstance(ari_score, torch.Tensor)
+    assert pred_labels.shape == (40,)
+
+
+@pytest.mark.skipif(not faiss, reason="FAISS not installed")
+def test_kmeans_ari_warns_on_float64():
+    """Test that FAISS K-means' float32 precision boundary is explicit."""
+    try:
+        import torchmetrics  # noqa: F401
+    except ImportError:
+        pytest.skip("torchmetrics not installed")
+
+    X = torch.randn(40, 6, dtype=torch.float64)
+    y = torch.arange(40) % 4
+
+    with pytest.warns(UserWarning, match="FAISS K-means computes in float32"):
+        _, pred_labels = kmeans_ari(X, y, n_clusters=4, niter=2, random_state=0)
+
+    assert pred_labels.device == X.device
+
+
+@pytest.mark.skipif(not faiss, reason="FAISS not installed")
 def test_kmeans_ari_perfect_clustering():
     """Test kmeans_ari with perfect clustering."""
     try:


### PR DESCRIPTION
## Summary
- use FAISS' tensor-native clustering adapter for `kmeans_ari` when available
- keep the full training data as a Torch tensor on the selected CPU or GPU
- preserve `nredo` by selecting the best final objective across deterministic redo seeds
- warn explicitly about FAISS K-means' float32 computation boundary and retain the legacy fallback for older FAISS builds
- make the FAISS CI job use a compatible FAISS/NumPy pair and fail if FAISS cannot import

## Validation
- `pytest torchdr/tests/test_eval.py -k kmeans_ari -q` on one B200 (12 passed, including the real-GPU test)
- GitHub FAISS job: 260 passed, 14 skipped; tensor-input and installation smoke tests passed
- `pre-commit run --all-files`
