### PR TITLE
[Test] Add real-process distributed integration CI

### DIFF
--- a/.github/workflows/distributed-integration.yml
+++ b/.github/workflows/distributed-integration.yml
@@ -1,0 +1,45 @@
+name: Distributed integration
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 5 * * 1"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/distributed-integration.yml"
+      - "torchdr/affinity_matcher.py"
+      - "torchdr/distributed/**"
+      - "torchdr/spectral_embedding/pca.py"
+      - "torchdr/tests/test_distributed_integration.py"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/distributed-integration.yml"
+      - "torchdr/affinity_matcher.py"
+      - "torchdr/distributed/**"
+      - "torchdr/spectral_embedding/pca.py"
+      - "torchdr/tests/test_distributed_integration.py"
+
+jobs:
+  test-distributed-cpu:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Install TorchDR
+        run: python -m pip install --upgrade pip ".[test]"
+      - name: Run two-process integration test
+        env:
+          TORCHDR_DISTRIBUTED_TEST: "1"
+        run: >-
+          python -m torch.distributed.run --standalone --nnodes=1
+          --nproc-per-node=2 -m pytest
+          torchdr/tests/test_distributed_integration.py -q

--- a/torchdr/tests/test_distributed_integration.py
+++ b/torchdr/tests/test_distributed_integration.py
@@ -1,0 +1,75 @@
+"""Real-process integration tests for distributed collectives."""
+
+# Author: Hugues Van Assel <vanasselhugues@gmail.com>
+#
+# License: BSD 3-Clause License
+
+import os
+
+import pytest
+import torch
+import torch.distributed as dist
+
+from torchdr.distributed import DistributedContext
+from torchdr.spectral_embedding import PCA
+
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("TORCHDR_DISTRIBUTED_TEST") != "1",
+    reason="run through the dedicated multi-process integration workflow",
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def distributed_process_group():
+    """Initialize the process group created by torchrun."""
+    dist.init_process_group(backend="gloo")
+    yield
+    dist.barrier()
+    dist.destroy_process_group()
+
+
+def test_real_distributed_collectives():
+    """Exercise context discovery and PCA collectives across real processes."""
+    context = DistributedContext()
+
+    assert context.is_initialized
+    assert context.world_size == 2
+    assert context.rank in (0, 1)
+    assert context.local_rank == context.rank
+
+    full_data = torch.tensor(
+        [
+            [0.0, 1.0, 2.0, 3.0],
+            [1.0, 1.5, 2.5, 4.0],
+            [2.0, 0.5, 3.0, 5.0],
+            [3.0, 2.0, 3.5, 6.0],
+            [4.0, 3.0, 5.0, 7.0],
+            [5.0, 2.5, 6.0, 8.0],
+            [6.0, 4.0, 7.5, 9.0],
+            [7.0, 5.0, 8.0, 10.0],
+        ],
+        dtype=torch.float64,
+    )
+    local_data = full_data.chunk(context.world_size)[context.rank].contiguous()
+
+    distributed_pca = PCA(n_components=2, distributed=True, device="cpu")
+    embedding = distributed_pca.fit_transform(local_data)
+
+    assert embedding.shape == (len(local_data), 2)
+    assert distributed_pca._n_samples_total == len(full_data)
+    torch.testing.assert_close(
+        distributed_pca.mean_, full_data.mean(dim=0, keepdim=True)
+    )
+
+    gathered_components = [
+        torch.zeros_like(distributed_pca.components_) for _ in range(context.world_size)
+    ]
+    dist.all_gather(gathered_components, distributed_pca.components_)
+    torch.testing.assert_close(gathered_components[0], gathered_components[1])
+
+    reference_pca = PCA(n_components=2, distributed=False, device="cpu")
+    reference_pca.fit(full_data)
+    distributed_projector = distributed_pca.components_.T @ distributed_pca.components_
+    reference_projector = reference_pca.components_.T @ reference_pca.components_
+    torch.testing.assert_close(distributed_projector, reference_projector)


### PR DESCRIPTION
## Summary

- add a dedicated two-process distributed integration workflow
- exercise real Gloo process-group discovery and distributed PCA collectives
- compare the distributed PCA projector with a single-process reference
- run weekly and when distributed implementation or integration-test paths change

## Validation

- `python -m torch.distributed.run --standalone --nnodes=1 --nproc-per-node=2 -m pytest torchdr/tests/test_distributed_integration.py -q` (2 ranks passed on SLURM)
- pre-commit checks for the workflow and test files

## Scope

This establishes real multi-process CPU coverage. GPU-only NCCL all-to-all paths, CUDA FAISS, and synchronized GPU optimizer paths still require a provisioned GPU Actions runner.
