### PR TITLE
[Test] Cover distributed sparse symmetrization on multiple ranks

### DIFF
--- a/torchdr/tests/test_sparse.py
+++ b/torchdr/tests/test_sparse.py
@@ -4,10 +4,14 @@
 #
 # License: BSD 3-Clause License
 
+import threading
+from types import SimpleNamespace
+
 import pytest
 import torch
 
 import torchdr.utils.sparse as sparse_utils
+from torchdr.distributed import DistributedContext
 from torchdr.utils.sparse import (
     distributed_symmetrize_sparse,
     flatten_sparse,
@@ -24,6 +28,113 @@ def _rowwise_to_dense(values, indices, n_columns):
     valid = indices >= 0
     dense.scatter_add_(1, indices.clamp_min(0), values * valid)
     return dense
+
+
+class _SimulatedProcessGroup:
+    """Thread-backed stand-in for the all-to-all collectives.
+
+    Every simulated rank runs the production code path in its own thread and the
+    collectives rendezvous on a barrier, so each rank receives exactly what a
+    real process group would deliver. The barrier is bounded so a rank that
+    stops participating surfaces as a test failure instead of a hang.
+    """
+
+    def __init__(self, world_size, timeout=60.0):
+        self.world_size = world_size
+        self._barrier = threading.Barrier(world_size, timeout=timeout)
+        self._slots = [None] * world_size
+        self._state = threading.local()
+
+    def set_rank(self, rank):
+        self._state.rank = rank
+
+    def abort(self):
+        self._barrier.abort()
+
+    def all_to_all_single(self, output, input_):
+        rank = self._state.rank
+        self._slots[rank] = input_.clone()
+        self._barrier.wait()
+        received = torch.stack(
+            [self._slots[source][rank] for source in range(self.world_size)]
+        )
+        self._barrier.wait()
+        output.copy_(received)
+
+    def all_to_all(self, outputs, inputs):
+        rank = self._state.rank
+        self._slots[rank] = [tensor.clone() for tensor in inputs]
+        self._barrier.wait()
+        for source in range(self.world_size):
+            outputs[source].copy_(self._slots[source][rank])
+        self._barrier.wait()
+
+
+def _run_multi_rank_symmetrize(monkeypatch, values, indices, world_size, mode):
+    """Run the distributed path on every rank and return the per-rank outputs.
+
+    Rows are partitioned with the same helper the library uses, so the exchange
+    exercises the real agreement between ``compute_chunk_bounds`` and
+    ``get_rank_for_indices``.
+    """
+    n_total = values.shape[0]
+    group = _SimulatedProcessGroup(world_size)
+    outputs = [None] * world_size
+    failures = [None] * world_size
+
+    def worker(rank):
+        group.set_rank(rank)
+        try:
+            chunk_start, chunk_end = DistributedContext.compute_chunk_bounds(
+                SimpleNamespace(rank=rank, world_size=world_size), n_total
+            )
+            outputs[rank] = distributed_symmetrize_sparse(
+                values[chunk_start:chunk_end].clone(),
+                indices[chunk_start:chunk_end].clone(),
+                chunk_start=chunk_start,
+                chunk_size=chunk_end - chunk_start,
+                n_total=n_total,
+                mode=mode,
+            )
+        except BaseException as error:  # noqa: BLE001 - re-raised by the caller
+            failures[rank] = error
+            group.abort()
+
+    monkeypatch.setattr(sparse_utils.dist, "is_initialized", lambda: True)
+    monkeypatch.setattr(sparse_utils.dist, "get_world_size", lambda: world_size)
+    monkeypatch.setattr(sparse_utils.dist, "all_to_all_single", group.all_to_all_single)
+    monkeypatch.setattr(sparse_utils.dist, "all_to_all", group.all_to_all)
+
+    threads = [
+        threading.Thread(target=worker, args=(rank,)) for rank in range(world_size)
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=120.0)
+        assert not thread.is_alive(), "a simulated rank did not finish"
+
+    for error in failures:
+        if error is not None:
+            raise error
+    return outputs
+
+
+def _gathered_dense(outputs, n_total):
+    """Concatenate the per-rank row blocks into the full dense matrix."""
+    return torch.cat(
+        [_rowwise_to_dense(values, indices, n_total) for values, indices in outputs]
+    )
+
+
+def _random_sparse_graph(n, k, seed, dtype=torch.float32):
+    """Build a deterministic k-nearest-neighbour style sparse matrix."""
+    generator = torch.Generator().manual_seed(seed)
+    indices = torch.stack(
+        [torch.randperm(n, generator=generator)[:k] for _ in range(n)]
+    ).long()
+    values = torch.rand((n, k), generator=generator, dtype=dtype).clamp_min(1e-3)
+    return values, indices
 
 
 @pytest.fixture
@@ -270,3 +381,162 @@ class TestDistributedSymmetrizeSparse:
         ]
         assert values_out.dtype == torch.float64
         assert indices_out[0, 0].item() == large_index
+
+
+class TestDistributedSymmetrizeSparseMultiRank:
+    """Multi-rank equivalence between the distributed and centralized paths.
+
+    A single rank routes every edge back to itself, so it cannot observe whether
+    the forward and reverse contributions of a cross-rank pair stay in separate
+    streams. These cases run the production code on two or more ranks that
+    genuinely exchange edges.
+    """
+
+    def test_cross_rank_pair_keeps_the_product_term(self, monkeypatch):
+        """Reciprocal edges split across ranks must not lose ``P * Pᵀ``.
+
+        Rank 0 owns rows 0-1 and rank 1 owns rows 2-3, so the reciprocal pair
+        ``(0, 2) = 0.2`` / ``(2, 0) = 0.4`` crosses the rank boundary while the
+        one-way edge ``(1, 0) = 0.3`` stays local.
+        """
+        values = torch.tensor(
+            [[0.2, 0.0], [0.3, 0.0], [0.4, 0.0], [0.0, 0.0]], dtype=torch.float64
+        )
+        indices = torch.tensor([[2, 3], [0, 3], [0, 1], [1, 2]])
+
+        outputs = _run_multi_rank_symmetrize(
+            monkeypatch, values, indices, world_size=2, mode="sum_minus_prod"
+        )
+        actual = _gathered_dense(outputs, 4)
+
+        # Cross-rank reciprocal pair: 0.2 + 0.4 - 0.2 * 0.4.
+        assert actual[0, 2].item() == pytest.approx(0.52)
+        # Same-rank one-way edge must be counted exactly once.
+        assert actual[1, 0].item() == pytest.approx(0.30)
+
+        expected_values, expected_indices = symmetrize_sparse(
+            values, indices, mode="sum_minus_prod"
+        )
+        torch.testing.assert_close(
+            actual, _rowwise_to_dense(expected_values, expected_indices, 4)
+        )
+
+    @pytest.mark.parametrize("mode", ["sum", "sum_minus_prod"])
+    @pytest.mark.parametrize(
+        "n,k,world_size",
+        [
+            (16, 3, 2),  # even partition
+            (17, 4, 3),  # uneven partition, 6/6/5 rows
+            (23, 5, 4),  # uneven partition, 6/6/6/5 rows
+            (64, 8, 2),
+        ],
+    )
+    def test_matches_centralized_reference(self, monkeypatch, n, k, world_size, mode):
+        """Gathered multi-rank output must equal the single-process result."""
+        values, indices = _random_sparse_graph(n, k, seed=n * 10 + world_size)
+
+        outputs = _run_multi_rank_symmetrize(
+            monkeypatch, values, indices, world_size=world_size, mode=mode
+        )
+        expected_values, expected_indices = symmetrize_sparse(
+            values, indices, mode=mode
+        )
+
+        torch.testing.assert_close(
+            _gathered_dense(outputs, n),
+            _rowwise_to_dense(expected_values, expected_indices, n),
+        )
+
+    @pytest.mark.parametrize(
+        "structure", ["self_loops", "duplicate_columns", "one_way_ring"]
+    )
+    def test_degenerate_edge_structures(self, monkeypatch, structure):
+        """Self-loops, repeated columns and one-way edges must stay exact."""
+        n, world_size = 12, 3
+        if structure == "self_loops":
+            values, indices = _random_sparse_graph(n, 3, seed=101)
+            indices[:, 0] = torch.arange(n)
+        elif structure == "duplicate_columns":
+            values, indices = _random_sparse_graph(n, 4, seed=102)
+            indices[:, 1] = indices[:, 0]
+        else:
+            indices = torch.stack(
+                [torch.tensor([(row + 1) % n, (row + 2) % n]) for row in range(n)]
+            )
+            generator = torch.Generator().manual_seed(103)
+            values = torch.rand((n, 2), generator=generator) + 0.1
+
+        outputs = _run_multi_rank_symmetrize(
+            monkeypatch, values, indices, world_size=world_size, mode="sum_minus_prod"
+        )
+        expected_values, expected_indices = symmetrize_sparse(
+            values, indices, mode="sum_minus_prod"
+        )
+
+        torch.testing.assert_close(
+            _gathered_dense(outputs, n),
+            _rowwise_to_dense(expected_values, expected_indices, n),
+        )
+
+    def test_hub_heavy_graph_matches_reference(self, monkeypatch):
+        """A few hub columns concentrate the exchange on a single owner rank."""
+        n, k, world_size = 48, 7, 3
+        generator = torch.Generator().manual_seed(104)
+        weights = 1.0 / (torch.arange(n, dtype=torch.float64) + 1.0)
+        indices = torch.multinomial(
+            weights.expand(n, n), k, replacement=False, generator=generator
+        ).long()
+        values = torch.rand((n, k), generator=generator).clamp_min(1e-3)
+
+        outputs = _run_multi_rank_symmetrize(
+            monkeypatch, values, indices, world_size=world_size, mode="sum_minus_prod"
+        )
+        expected_values, expected_indices = symmetrize_sparse(
+            values, indices, mode="sum_minus_prod"
+        )
+
+        torch.testing.assert_close(
+            _gathered_dense(outputs, n),
+            _rowwise_to_dense(expected_values, expected_indices, n),
+        )
+
+    def test_preserves_dtypes_across_ranks(self, monkeypatch):
+        """float64 values and int64 indices must survive the exchange."""
+        n, world_size = 31, 3
+        values, indices = _random_sparse_graph(n, 6, seed=105, dtype=torch.float64)
+
+        outputs = _run_multi_rank_symmetrize(
+            monkeypatch, values, indices, world_size=world_size, mode="sum"
+        )
+
+        for rank_values, rank_indices in outputs:
+            assert rank_values.dtype == torch.float64
+            assert rank_indices.dtype == torch.int64
+
+        expected_values, expected_indices = symmetrize_sparse(
+            values, indices, mode="sum"
+        )
+        torch.testing.assert_close(
+            _gathered_dense(outputs, n),
+            _rowwise_to_dense(expected_values, expected_indices, n),
+        )
+
+    def test_is_deterministic_across_repetitions(self, monkeypatch):
+        """Repeated runs of the same partition must be bitwise identical."""
+        n, world_size = 40, 3
+        values, indices = _random_sparse_graph(n, 5, seed=106)
+
+        reference = None
+        for _ in range(3):
+            outputs = _run_multi_rank_symmetrize(
+                monkeypatch,
+                values,
+                indices,
+                world_size=world_size,
+                mode="sum_minus_prod",
+            )
+            gathered = _gathered_dense(outputs, n)
+            if reference is None:
+                reference = gathered
+            else:
+                assert torch.equal(reference, gathered)


### PR DESCRIPTION
## Verdict

**APPROVE** — the proposition is confirmed, and the production fix is **already
merged**. This PR contributes only the missing multi-rank regression coverage.

The direction-preserving merge landed in
[#254](https://github.com/TorchDR/TorchDR/pull/254), commit `697d7cb`. Nothing
in `torchdr/utils/sparse.py` is changed here, and the merged implementation is
not duplicated, rewritten, or reverted.

## Hypothesis

Keeping the forward (`P`) and reverse (`Pᵀ`) edge streams separate makes
distributed symmetrization exactly equivalent to single-process
`symmetrize_sparse`. The pre-fix implementation reoriented received edges,
concatenated them with the local edges, and then rebuilt both `P` and `Pᵀ` from
that single stream, which loses which stream supplied which direction:
cross-rank pairs lost the `P * Pᵀ` product term and same-rank edges could be
counted twice.

The coverage gap this PR closes: every existing test in
`TestDistributedSymmetrizeSparse` mocks the process group with `world_size=1`.
On one rank every edge is routed back to its own owner, so the forward and
reverse contributions of a cross-rank pair are never separated and the defect
is unobservable. No test exercised two or more ranks that genuinely exchange
edges.

## Benchmark design

- Baseline commit (pre-fix): `8a45d4047cb681c3f8abe8dd308d3dbd5d75fdd6`
- Production fix under test: `697d7cb2cd72c714e93d88d2ad0e1ced165d672b` (#254)
- Candidate commit (this branch): one commit on top of `697d7cb`
- Hardware: single CPU allocation, 4 CPUs / 32 GB; PyTorch 2.8.0+cu128, Python 3.11
- Simulated world sizes: 2, 3, 4
- Graphs: `n ∈ {12, 16, 17, 23, 31, 40, 48, 64}`, `k ∈ {2, …, 8}`,
  `float32` and `float64` values, `int64` indices, both `sum` and
  `sum_minus_prod` modes
- Reference: single-process `symmetrize_sparse` on the same graph
- Repetitions: correctness cases are deterministic (fixed seeds, single run);
  the determinism case runs the same partition 3× and requires bitwise equality;
  the timing figures below are the median of 3 runs

The new tests drive the **production** `distributed_symmetrize_sparse` on every
rank in its own thread. Only `torch.distributed`'s `all_to_all_single` and
`all_to_all` are replaced, by a bounded-barrier rendezvous that hands each rank
exactly the payload a real process group would deliver. Row partitioning uses
the library's own `DistributedContext.compute_chunk_bounds`, so the test also
exercises the real agreement between chunk bounds and `get_rank_for_indices`.

Exact commands:

```bash
# new coverage, this branch (697d7cb + tests)
pytest torchdr/tests/test_sparse.py::TestDistributedSymmetrizeSparseMultiRank -q

# same file checked out onto the pre-fix commit
git checkout 8a45d40 -- torchdr/utils/sparse.py
pytest torchdr/tests/test_sparse.py::TestDistributedSymmetrizeSparseMultiRank -q

# full module
pytest torchdr/tests/test_sparse.py -q
```

## Results

New cases run against the pre-fix implementation and against current `main`:

| Metric | Pre-fix `8a45d40` | Current `main` `697d7cb` |
|---|---:|---:|
| New multi-rank cases passing | 1 / 15 | **15 / 15** |
| Documented cross-rank pair `Q[0,2]` (expected `0.52`) | `0.60` | **`0.52`** |
| Documented same-rank one-way edge `Q[1,0]` (expected `0.30`) | `0.51` | **`0.30`** |
| Max abs. error on the 4×4 reproduction | `2.10e-01` | **`0.00e+00`** |
| Randomized sweep cases above tolerance (P ∈ {2,3,4}) | 32 / 32 | **0 / 32** |
| Bitwise determinism over 3 repetitions | yes | yes |

The single new case that also passes pre-fix is
`test_is_deterministic_across_repetitions`: the pre-fix merge is wrong but
stable, so determinism alone does not discriminate. It is kept because it
guards a different property (no ordering nondeterminism in the exchange).

Representative pre-fix failure, `n=31, k=6, P=3, float64, sum`:

```
Mismatched elements: 112 / 961 (11.7%)
Greatest absolute difference: 1.9692978036169217 at index (4, 4)
```

CI cost — the added tests are cheap; the module's ~19 s is dominated by
importing torch at collection:

| Metric | Value |
|---|---:|
| Added test cases | 15 |
| Slowest added case | 0.01 s |
| Total added execution time | < 0.05 s |
| `test_sparse.py` wall time, median of 3 | 19.1 s (30 tests) |

## Correctness and quality

For every configuration the gathered per-rank row blocks are compared against
the dense matrix produced by single-process `symmetrize_sparse`, with
`torch.testing.assert_close` default tolerances. Covered:

- the documented four-row case, where the reciprocal pair `(0,2)/(2,0)` crosses
  the rank boundary while the one-way edge `(1,0)` stays local;
- even partitions and uneven partitions (`17` rows over 3 ranks → 6/6/5;
  `23` rows over 4 ranks → 6/6/6/5);
- both `sum` and `sum_minus_prod` combination modes;
- self-loops on every row, duplicate column indices within a row, and purely
  one-way ring edges;
- a hub-heavy graph whose exchange concentrates on a single owner rank;
- `float64` values and `int64` indices surviving the exchange;
- bitwise determinism across repeated runs.

No production behaviour changes, so there is no quality or performance
trade-off to report for the library itself.

## Decision

Keep the merged implementation from #254 as-is and add the regression coverage
that would have caught the original defect. 14 of the 15 new cases fail on
`8a45d40` and all 15 pass on `697d7cb`, so the suite is a genuine guard rather
than a restatement of current behaviour.

## Implementation or retained benchmark artifact

`torchdr/tests/test_sparse.py` only, +270 lines, no production file touched:

- `_SimulatedProcessGroup` — thread-backed `all_to_all_single` / `all_to_all`
  with a bounded barrier, so a rank that stops participating fails the test
  instead of hanging CI;
- `_run_multi_rank_symmetrize`, `_gathered_dense`, `_random_sparse_graph` helpers;
- `TestDistributedSymmetrizeSparseMultiRank` with the 15 cases above.

## Validation

Run on the project's Conda environment (PyTorch 2.8.0+cu128, Python 3.11):

- `pytest torchdr/tests/test_sparse.py` → 30 passed
- `pytest torchdr/tests/test_sparse.py torchdr/tests/test_distributed.py
  torchdr/tests/test_distributed_pca.py torchdr/tests/test_utils.py
  torchdr/tests/test_affinity.py` → 259 passed, 11 skipped
- `pre-commit run --files torchdr/tests/test_sparse.py` → all hooks pass

## Risks and limitations

- **Simulated transport.** The collectives are threads, not NCCL. This isolates
  the merge logic from the transport, which is what the coverage gap was about,
  but it does not exercise device-to-device transfer, NCCL dtype handling, or
  real process-group lifecycle. A two-rank NCCL run of the same cases on B200
  GPUs was queued while this PR was prepared and was still waiting on a GPU
  allocation at submission time, so its result is **not** included here.
  **This PR should not be read as evidence of real-NCCL correctness.** If the
  allocation lands, the outcome will be posted as a comment on this PR whether
  it passes or fails.
- Gloo cannot back these tests: it supports `all_to_all_single` but not the
  list-based `all_to_all` the implementation uses, so a real two-process CPU
  test is not possible without changing production code.
- The tests are threaded. The barrier has a 60 s timeout and each join a 120 s
  timeout, so a deadlock surfaces as a failure, but a heavily loaded CI runner
  could in principle need more headroom.
- Chunk sizes of one row (reached when `world_size` approaches `n_samples`) are
  **not** covered. That configuration currently deadlocks the exchange in a way
  unrelated to symmetrization direction, and it is left for a separate isolated
  report rather than bundled here.
- `torch.multinomial` in the hub-heavy case materializes an `n × n` weight
  tensor; at `n = 48` this is negligible, but the case should not be scaled up
  naively.
