### PR TITLE
[Fix] Remove FAISS self-neighbors by index rather than by position

### DIFF
--- a/torchdr/distance/base.py
+++ b/torchdr/distance/base.py
@@ -185,25 +185,19 @@ def pairwise_distances(
         chunk_start, chunk_end = distributed_ctx.compute_chunk_bounds(n_samples)
         X_chunk = X[chunk_start:chunk_end]
 
-        # Compute k-NN: queries=chunk, database=full dataset
-        # Note: exclude_diag doesn't work since X_chunk is a subset of X
-        # We handle self-neighbors by searching for k+1 if needed
-        k_search = k + 1 if exclude_diag else k
-
+        # Compute k-NN: queries=chunk, database=full dataset. Query row j of the
+        # chunk is global row chunk_start + j, which is what lets exclude_diag
+        # identify the self-neighbor even though X_chunk is a subset of X.
         C, indices = pairwise_distances_faiss(
             X=X_chunk,
             Y=X,  # Full dataset as database
             metric=metric,
-            k=k_search,
-            exclude_diag=False,  # Can't use since X_chunk != X
+            k=k,
+            exclude_diag=exclude_diag,
             config=config,
             device=device,
+            query_ids=torch.arange(chunk_start, chunk_end, device=X.device),
         )
-
-        # Remove self-distances if needed
-        if exclude_diag:
-            C = C[:, 1:]
-            indices = indices[:, 1:]
 
         if return_indices:
             return C, indices

--- a/torchdr/distance/faiss.py
+++ b/torchdr/distance/faiss.py
@@ -222,6 +222,69 @@ class FaissConfig:
         return f"FaissConfig({', '.join(parts)})"
 
 
+def remove_self_neighbors(
+    distances: torch.Tensor,
+    indices: torch.Tensor,
+    query_ids: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    r"""Drop each query's own index from a ``k + 1`` neighbor search.
+
+    A self-search retrieves ``k + 1`` neighbors so that ``k`` remain once the
+    query itself is removed. The query is not reliably the first result: exact
+    ties put a duplicate observation ahead of it, the ``angular`` metric ranks
+    by raw inner product so a longer vector can outrank it, and an approximate
+    index may not return it at all. Selecting by index is therefore used rather
+    than dropping column 0.
+
+    When a row does not contain its query id, all ``k + 1`` results are valid
+    neighbors and the farthest one is dropped instead.
+
+    Parameters
+    ----------
+    distances : torch.Tensor of shape (n, k + 1)
+        Neighbor distances, sorted by increasing distance.
+    indices : torch.Tensor of shape (n, k + 1)
+        Neighbor indices in the database, aligned with ``distances``.
+    query_ids : torch.Tensor of shape (n,)
+        Database index of each query row. In distributed mode this is the
+        global index of the row, not its position within the local chunk.
+
+    Returns
+    -------
+    distances : torch.Tensor of shape (n, k)
+        Neighbor distances without the self-neighbor.
+    indices : torch.Tensor of shape (n, k)
+        Neighbor indices without the self-neighbor.
+    """
+    k_plus_one = indices.shape[1]
+    query_ids = query_ids.to(device=indices.device)
+
+    # An exact search over distinct points puts every query first. Slicing that
+    # off returns views and allocates nothing, so the common case keeps the cost
+    # of one comparison and pays no memory for the general case below.
+    if bool((indices[:, 0] == query_ids).all()):
+        return distances[:, 1:], indices[:, 1:]
+
+    is_self = indices == query_ids.unsqueeze(1)
+    # argmax gives the first match, or 0 for a row with none; such a row has
+    # k + 1 valid neighbors, so its last (farthest) column is dropped instead.
+    dropped = torch.where(
+        is_self.any(dim=1),
+        is_self.to(torch.uint8).argmax(dim=1),
+        k_plus_one - 1,
+    )
+
+    # Output column j takes input column j before the dropped position and
+    # column j + 1 after it. Both operands are views, so the only tensors
+    # materialized are the mask and the two outputs.
+    after = torch.arange(k_plus_one - 1, device=indices.device) >= dropped.unsqueeze(1)
+
+    return (
+        torch.where(after, distances[:, 1:], distances[:, :-1]),
+        torch.where(after, indices[:, 1:], indices[:, :-1]),
+    )
+
+
 @torch.compiler.disable
 def pairwise_distances_faiss(
     X: torch.Tensor,
@@ -231,6 +294,7 @@ def pairwise_distances_faiss(
     exclude_diag: bool = False,
     config: Optional[FaissConfig] = None,
     device: str = "auto",
+    query_ids: Optional[torch.Tensor] = None,
 ):
     r"""Compute the k nearest neighbors using FAISS.
 
@@ -241,7 +305,8 @@ def pairwise_distances_faiss(
         normalize them beforehand to obtain cosine-similarity neighbor ordering.
 
     If Y is not provided then we assume a self–search and, if `exclude_diag` is True,
-    the self–neighbor is removed from the results.
+    the self–neighbor is removed from the results. When X is a chunk of a larger
+    database, pass `query_ids` so that `exclude_diag` still applies.
 
     Parameters
     ----------
@@ -255,8 +320,11 @@ def pairwise_distances_faiss(
     metric : str, default "sqeuclidean"
         One of "euclidean", "sqeuclidean", or "angular".
     exclude_diag : bool, default False
-        When True and Y is not provided (i.e. self–search), the self–neighbor (index i for query i)
-        is excluded from the k results.
+        When True, the self–neighbor (the query's own database row) is excluded
+        from the k results. Requires a self–search, unless `query_ids` is given.
+        The removal matches on the index, so it is correct when duplicate
+        observations, the ``angular`` metric or an approximate index place the
+        query away from the first position.
     config : FaissConfig, optional
         Configuration object for FAISS. If None, uses default settings.
         See FaissConfig documentation for available options.
@@ -264,6 +332,10 @@ def pairwise_distances_faiss(
         Device to use for computation. If "auto", uses input device.
         If "cuda", uses FAISS GPU. If "cpu", uses FAISS CPU.
         Output remains on the specified device.
+    query_ids : torch.Tensor of shape (n,), optional
+        Row of Y that each query of X corresponds to. Only used when
+        `exclude_diag` is True, and only needed when X is a chunk of Y rather
+        than Y itself, as in distributed search. Defaults to `arange(n)`.
 
     Returns
     -------
@@ -323,7 +395,9 @@ def pairwise_distances_faiss(
         Y = X
         do_exclude = exclude_diag
     else:
-        do_exclude = False
+        # A chunk of the database can still drop its self-neighbors, but only
+        # if the caller states which database row each query came from.
+        do_exclude = exclude_diag and query_ids is not None
 
     if X.dtype != torch.float32 or Y.dtype != torch.float32:
         warnings.warn(
@@ -430,13 +504,16 @@ def pairwise_distances_faiss(
     elif metric == "angular":
         D = -D
 
-    if do_exclude:
-        D = D[:, 1:]
-        Ind = Ind[:, 1:]
-
     if not isinstance(D, torch.Tensor):
         D = torch.from_numpy(D)
         Ind = torch.from_numpy(Ind)
+
+    # Drop the self-neighbor before casting, so that only the (n, k) result is
+    # materialized in the output dtype rather than the wider (n, k + 1) search.
+    if do_exclude:
+        if query_ids is None:
+            query_ids = torch.arange(Ind.shape[0], device=Ind.device)
+        D, Ind = remove_self_neighbors(D, Ind, query_ids)
 
     distances = D.to(device=compute_device, dtype=dtype)
     indices = Ind.to(device=compute_device, dtype=torch.long)
@@ -542,7 +619,9 @@ def pairwise_distances_faiss_from_dataloader(
     metric : str, default "sqeuclidean"
         Distance metric. One of "euclidean", "sqeuclidean", or "angular".
     exclude_diag : bool, default False
-        When True, exclude self-neighbors from results.
+        When True, exclude self-neighbors from results. Rows are matched by
+        their global index, which stays correct in distributed mode where a
+        rank only queries its own chunk.
     config : FaissConfig, optional
         Configuration object for FAISS. If None, uses default settings.
     device : str, default "auto"
@@ -610,11 +689,13 @@ def pairwise_distances_faiss_from_dataloader(
 
     if distributed_ctx is not None and distributed_ctx.is_initialized:
         # Multi-GPU: each rank searches its chunk
+        chunk_start, chunk_end = distributed_ctx.compute_chunk_bounds(n_samples)
         distances, indices = _search_chunk_from_dataloader(
             dataloader, index, k_search, distributed_ctx, n_samples, compute_device
         )
     else:
         # Single GPU: search all queries
+        chunk_start, chunk_end = 0, n_samples
         distances, indices = _search_all_from_dataloader(
             dataloader, index, k_search, compute_device
         )
@@ -626,8 +707,10 @@ def pairwise_distances_faiss_from_dataloader(
         distances = -distances
 
     if exclude_diag:
-        distances = distances[:, 1:]
-        indices = indices[:, 1:]
+        # Global row index of each query, so that the self-neighbor is removed
+        # by identity rather than by position.
+        query_ids = torch.arange(chunk_start, chunk_end, device=indices.device)
+        distances, indices = remove_self_neighbors(distances, indices, query_ids)
 
     return distances.to(dtype), indices
 

--- a/torchdr/tests/test_utils.py
+++ b/torchdr/tests/test_utils.py
@@ -207,6 +207,299 @@ def test_pairwise_distances_faiss_warns_on_float64():
     assert distances.dtype == torch.float64
 
 
+def _duplicated_data(n=128, d=8, n_dup=32, seed=0):
+    """Data whose first ``n_dup`` rows exactly repeat rows ``n_dup:2*n_dup``."""
+    generator = torch.Generator().manual_seed(seed)
+    X = torch.randn(n, d, generator=generator)
+    X[:n_dup] = X[n_dup : 2 * n_dup]
+    return X
+
+
+def _varied_norm_data(n=128, d=8, seed=0):
+    """Data whose norms span two decades.
+
+    With ``metric="angular"`` FAISS ranks by the raw inner product, so the self
+    score ``||x||**2`` of a short vector is beaten by longer vectors and the
+    query is not the first result.
+    """
+    generator = torch.Generator().manual_seed(seed)
+    X = torch.randn(n, d, generator=generator)
+    return X * torch.logspace(-1, 1, n).unsqueeze(1)
+
+
+def _self_neighbor_rows(indices, query_ids):
+    """Rows that list their own index among their neighbors."""
+    return int((indices == query_ids.view(-1, 1)).any(dim=1).sum())
+
+
+def _run_distributed_knn(X, k, metric, backend, world_size):
+    """Concatenate the per-rank output of the distributed k-NN path.
+
+    The distributed branch performs no collective: a rank slices its query rows
+    and searches the full database. A context with a forced rank therefore
+    exercises the production code path without a process group.
+    """
+    from torchdr.distributed import DistributedContext
+
+    distances, indices, query_ids = [], [], []
+    for rank in range(world_size):
+        ctx = DistributedContext(force_enable=True)
+        ctx.rank = rank
+        ctx.world_size = world_size
+        start, end = ctx.compute_chunk_bounds(X.shape[0])
+        C, idx = pairwise_distances(
+            X,
+            k=k,
+            metric=metric,
+            backend=backend,
+            exclude_diag=True,
+            return_indices=True,
+            device="cpu",
+            distributed_ctx=ctx,
+        )
+        assert C.shape[0] == end - start
+        distances.append(C)
+        indices.append(idx)
+        query_ids.append(torch.arange(start, end))
+    return torch.cat(distances), torch.cat(indices), torch.cat(query_ids)
+
+
+@pytest.mark.skipif(not faiss, reason="faiss is not available")
+class TestFaissSelfNeighborRemoval:
+    """The FAISS self-search must never return the query as its own neighbor.
+
+    The torch and keops backends mask the diagonal, so they satisfy this by
+    construction and serve as the reference. FAISS searches ``k + 1`` neighbors
+    and removes the query afterwards; these tests pin the cases where the query
+    is not the first result.
+    """
+
+    def test_helper_drops_self_wherever_it_appears(self):
+        from torchdr.distance.faiss import remove_self_neighbors
+
+        indices = torch.tensor([[0, 7, 8], [4, 1, 9], [5, 6, 2]])
+        distances = torch.tensor([[0.0, 1.0, 2.0], [0.5, 1.5, 2.5], [0.25, 1.25, 2.25]])
+        query_ids = torch.tensor([0, 1, 2])
+
+        kept_distances, kept_indices = remove_self_neighbors(
+            distances, indices, query_ids
+        )
+
+        assert kept_indices.tolist() == [[7, 8], [4, 9], [5, 6]]
+        assert kept_distances.tolist() == [[1.0, 2.0], [0.5, 2.5], [0.25, 1.25]]
+
+    def test_helper_slices_when_self_is_always_first(self):
+        """The common case must stay the plain column-0 slice."""
+        from torchdr.distance.faiss import remove_self_neighbors
+
+        indices = torch.tensor([[0, 7, 8], [1, 4, 9], [2, 5, 6]])
+        distances = torch.tensor([[0.0, 1.0, 2.0], [0.0, 1.5, 2.5], [0.0, 1.25, 2.25]])
+
+        kept_distances, kept_indices = remove_self_neighbors(
+            distances, indices, torch.tensor([0, 1, 2])
+        )
+
+        assert kept_indices.tolist() == [[7, 8], [4, 9], [5, 6]]
+        assert kept_distances.tolist() == [[1.0, 2.0], [1.5, 2.5], [1.25, 2.25]]
+
+    def test_helper_drops_farthest_when_self_is_absent(self):
+        """An approximate index may not return the query at all."""
+        from torchdr.distance.faiss import remove_self_neighbors
+
+        indices = torch.tensor([[3, 4, 5]])
+        distances = torch.tensor([[1.0, 2.0, 3.0]])
+
+        kept_distances, kept_indices = remove_self_neighbors(
+            distances, indices, torch.tensor([0])
+        )
+
+        assert kept_indices.tolist() == [[3, 4]]
+        assert kept_distances.tolist() == [[1.0, 2.0]]
+
+    def test_helper_uses_global_ids(self):
+        """In distributed mode a chunk's rows keep their global index."""
+        from torchdr.distance.faiss import remove_self_neighbors
+
+        indices = torch.tensor([[9, 10, 11], [3, 11, 12]])
+        distances = torch.tensor([[0.0, 1.0, 2.0], [1.0, 2.0, 3.0]])
+
+        _, kept_indices = remove_self_neighbors(
+            distances, indices, torch.tensor([10, 11])
+        )
+
+        assert kept_indices.tolist() == [[9, 11], [3, 12]]
+
+    def test_query_ids_exclude_the_diagonal_of_a_chunk(self):
+        """``exclude_diag`` applies to a chunk of the database via query_ids."""
+        from torchdr.distance.faiss import pairwise_distances_faiss
+
+        X = _duplicated_data(seed=6)
+        start, end, k = 40, 90, 10
+
+        _, indices = pairwise_distances_faiss(
+            X=X[start:end],
+            Y=X,
+            k=k,
+            exclude_diag=True,
+            device="cpu",
+            query_ids=torch.arange(start, end),
+        )
+
+        check_shape(indices, (end - start, k))
+        assert _self_neighbor_rows(indices, torch.arange(start, end)) == 0
+
+    def test_chunk_without_query_ids_keeps_k_neighbors(self):
+        """Without query_ids a chunk search cannot tell which row is the query."""
+        from torchdr.distance.faiss import pairwise_distances_faiss
+
+        X = _duplicated_data(seed=6)
+        start, end, k = 40, 90, 10
+
+        _, indices = pairwise_distances_faiss(
+            X=X[start:end], Y=X, k=k, exclude_diag=True, device="cpu"
+        )
+
+        check_shape(indices, (end - start, k))
+        assert _self_neighbor_rows(indices, torch.arange(start, end)) > 0
+
+    @pytest.mark.parametrize("metric", ["sqeuclidean", "euclidean"])
+    def test_duplicates_do_not_produce_self_neighbors(self, metric):
+        """A duplicate observation can tie ahead of the query itself."""
+        X = _duplicated_data()
+        k = 10
+
+        _, indices = pairwise_distances(
+            X,
+            k=k,
+            metric=metric,
+            backend="faiss",
+            exclude_diag=True,
+            return_indices=True,
+            device="cpu",
+        )
+
+        check_shape(indices, (X.shape[0], k))
+        assert _self_neighbor_rows(indices, torch.arange(X.shape[0])) == 0
+
+    def test_angular_does_not_produce_self_neighbors(self):
+        """The raw inner product does not rank the query first."""
+        X = _varied_norm_data()
+        k = 10
+
+        distances, indices = pairwise_distances(
+            X,
+            k=k,
+            metric="angular",
+            backend="faiss",
+            exclude_diag=True,
+            return_indices=True,
+            device="cpu",
+        )
+        reference = pairwise_distances(
+            X, k=k, metric="angular", backend=None, exclude_diag=True
+        )
+
+        check_shape(indices, (X.shape[0], k))
+        assert _self_neighbor_rows(indices, torch.arange(X.shape[0])) == 0
+        assert_close(distances, reference, rtol=1e-5, atol=1e-5)
+
+    def test_approximate_index_returns_exactly_k_non_self_neighbors(self):
+        """IVFPQ can rank the query late or omit it entirely."""
+        from torchdr.distance import FaissConfig
+
+        generator = torch.Generator().manual_seed(0)
+        X = torch.randn(1024, 16, generator=generator)
+        k = 10
+        config = FaissConfig(index_type="IVFPQ", nlist=32, nprobe=2, M=4, nbits=4)
+
+        _, indices = pairwise_distances(
+            X,
+            k=k,
+            backend=config,
+            exclude_diag=True,
+            return_indices=True,
+            device="cpu",
+        )
+
+        check_shape(indices, (X.shape[0], k))
+        assert _self_neighbor_rows(indices, torch.arange(X.shape[0])) == 0
+
+    @pytest.mark.parametrize("world_size", [2, 3])
+    def test_distributed_chunks_remove_their_own_global_index(self, world_size):
+        """Rank r queries rows [start, end); its self-neighbor is start + j."""
+        X = _duplicated_data(n=126, n_dup=30, seed=1)
+        k = 8
+
+        distances, indices, query_ids = _run_distributed_knn(
+            X, k, "sqeuclidean", "faiss", world_size
+        )
+        reference = pairwise_distances(
+            X, k=k, metric="sqeuclidean", backend=None, exclude_diag=True
+        )
+
+        check_shape(indices, (X.shape[0], k))
+        assert _self_neighbor_rows(indices, query_ids) == 0
+        assert_close(distances, reference, rtol=1e-4, atol=1e-4)
+
+    def test_distributed_angular_matches_reference(self):
+        X = _varied_norm_data(n=126, seed=2)
+        k = 8
+
+        distances, indices, query_ids = _run_distributed_knn(
+            X, k, "angular", "faiss", world_size=3
+        )
+        reference = pairwise_distances(
+            X, k=k, metric="angular", backend=None, exclude_diag=True
+        )
+
+        assert _self_neighbor_rows(indices, query_ids) == 0
+        assert_close(distances, reference, rtol=1e-5, atol=1e-5)
+
+    def test_dataloader_removes_self_neighbors(self):
+        from torch.utils.data import DataLoader, TensorDataset
+
+        X = _duplicated_data(seed=3)
+        k = 10
+        loader = DataLoader(TensorDataset(X), batch_size=32, shuffle=False)
+
+        _, indices = pairwise_distances(
+            loader, k=k, exclude_diag=True, return_indices=True, device="cpu"
+        )
+
+        check_shape(indices, (X.shape[0], k))
+        assert _self_neighbor_rows(indices, torch.arange(X.shape[0])) == 0
+
+    def test_distinct_points_are_unaffected(self):
+        """The common case still matches the exact reference exactly."""
+        generator = torch.Generator().manual_seed(4)
+        X = torch.randn(128, 8, generator=generator)
+        k = 10
+
+        _, indices = pairwise_distances(
+            X,
+            k=k,
+            backend="faiss",
+            exclude_diag=True,
+            return_indices=True,
+            device="cpu",
+        )
+        _, reference = pairwise_distances(
+            X, k=k, backend=None, exclude_diag=True, return_indices=True
+        )
+
+        assert torch.equal(indices, reference)
+
+    def test_umap_affinity_graph_has_no_self_edges(self):
+        """Consequence downstream: a self-edge replaces a true neighbor."""
+        from torchdr.affinity import UMAPAffinity
+
+        X = _duplicated_data(seed=5)
+        affinity = UMAPAffinity(n_neighbors=10, backend="faiss", device="cpu")
+        _, indices = affinity(X, return_indices=True)
+
+        assert _self_neighbor_rows(indices, torch.arange(X.shape[0])) == 0
+
+
 @pytest.mark.skipif(not faiss, reason="faiss is not available")
 def test_faiss_config_repr():
     """Test FaissConfig __repr__ method."""


### PR DESCRIPTION
## Verdict

**APPROVE.** The FAISS k-NN path removes the self-neighbor by *position* — it
searches `k + 1` and drops column 0 — but the query is not reliably the first
result. On exact duplicates, on `angular`, and on approximate indexes, the query
survives into the neighbor list and a genuine neighbor is silently dropped in its
place. Removing by *identity* fixes every affected case at no measurable cost.

## Hypothesis

> Dropping the first FAISS result is unsafe for approximate indexes and duplicate
> observations; filtering each row by its known global query ID is correct and has
> negligible overhead.

Both halves are confirmed.

## Why position is the wrong key

Three independent reasons the query is not at column 0:

1. **Exact duplicates.** Two identical rows are both at distance 0. FAISS breaks
   the tie by internal order, so the duplicate can be ranked ahead of the query.
2. **`angular`.** The metric is the *raw* negative inner product and inputs are
   not normalized, so the query's own score `‖x‖²` is beaten by any longer vector.
   The query is frequently not in the top `k + 1` at all.
3. **Approximate indexes.** IVF/IVFPQ search a subset of cells with quantized
   codes; the query may be ranked late or missed entirely.

There is also a distributed-specific failure: `pairwise_distances` gives rank *r*
the query chunk `X[start:end]` against the full database `X`. Its query row *j* is
global row `start + j`, so even a positional rule has to know the offset. That
path already worked by accident on distinct data, and broke on all three regimes
above.

## Benchmark / correctness experiment

A standalone harness compares each FAISS entry point against the torch backend,
which masks the diagonal by construction and is therefore the reference. It runs
11 cases across the three entry points (tensor, distributed chunked, DataLoader),
three data regimes and three index types, and reports:

- `self-loop%` — rows that returned their own index (must be 0),
- `self-absent%` — rows whose `k + 1` results never contained the query,
- `rows!=oracle%` — rows whose neighbor set differs from the reference,
- `recall` against the exact reference, next to the recall the same index
  *could* achieve (`oracle`) so that index approximation is not read as a defect.

```
python evidence.py --device cpu     # from each worktree, PYTHONPATH set to it
```

### Results — correctness

`n = 128–1024`, `k = 8–10`. Before / after, same seeds:

| case | self-loop % | rows ≠ oracle % | recall | oracle recall |
|---|---|---|---|---|
| duplicates, `sqeuclidean` | **25.00 → 0.00** | 25.00 → 0.00 | 0.9621 → **0.9871** | 0.9871 |
| duplicates, `euclidean` | **25.00 → 0.00** | 25.00 → 0.00 | 0.9633 → **0.9883** | 0.9883 |
| varied norms, `angular` | **21.88 → 0.00** | 87.89 → 0.00 | 0.9121 → **1.0000** | 1.0000 |
| distinct, `sqeuclidean` (control) | 0.00 → 0.00 | 0.00 → 0.00 | 1.0000 → 1.0000 | 1.0000 |
| distinct, IVF | 0.00 → 0.00 | 0.00 → 0.00 | 0.4709 → 0.4709 | 0.4709 |
| distinct, IVFPQ | **0.20 → 0.00** | 0.20 → 0.00 | 0.2928 → **0.2930** | 0.2930 |
| distributed P=2, duplicates | **25.00 → 0.00** | 25.00 → 0.00 | 0.9590 → **0.9840** | 0.9840 |
| distributed P=3, `angular` | **22.75 → 0.00** | 87.84 → 0.00 | 0.9122 → **1.0000** | 1.0000 |
| distributed P=4, IVF | 0.00 → 0.00 | 0.00 → 0.00 | 0.4648 → 0.4648 | 0.4648 |
| DataLoader, duplicates | **25.00 → 0.00** | 25.00 → 0.00 | 0.9613 → **0.9863** | 0.9863 |
| DataLoader, IVFPQ | **0.20 → 0.00** | 0.20 → 0.00 | 0.2939 → **0.2941** | 0.2941 |

**Cases violating the self-exclusion contract: 8 / 11 → 0 / 11.** After the fix
every case matches the exact reference to the recall its own index can reach; the
distinct/IVF controls are bit-identical, and the `angular` cases become exact.

The `angular` numbers are the sharpest: 66% of rows never returned the query at
all, so the old code was throwing away a true nearest neighbor on two thirds of
the dataset while *also* keeping a self-loop on a further 22%.

### Results — downstream

The defect reaches user-visible output. `UMAPAffinity(backend="faiss")` on 256
points with 64 duplicated rows:

| backend | self-edges | rows with a self-edge |
|---|---|---|
| torch (reference) | 0 | 0 |
| faiss, before | **64** | **64** |
| faiss, after | 0 | 0 |

A self-edge is a `P_ii > 0` entry that displaces a real neighbor, so the affinity
row is both wrong and one neighbor short.

### Results — overhead

`pairwise_distances(..., backend="faiss", exclude_diag=True)`, 1× B200, `d = 64`,
`k = 15`, float32, 2 warmup + 5 timed reps, CUDA-synchronized, median of 5. The
distributed rows time rank 0's share of the work (chunked query, full database).

Distinct data — the common case, which takes the zero-copy fast path:

| config | n | before (s) | after (s) | Δ | peak MB before | peak MB after |
|---|---|---|---|---|---|---|
| single-process | 200 000 | 0.4013 | 0.4059 | +1.1% | 85.4 | 87.2 |
| distributed P=2 | 200 000 | 0.2493 | 0.2508 | +0.6% | 67.1 | 68.0 |
| distributed P=4 | 200 000 | 0.1719 | 0.1649 | −4.1% | 58.0 | 58.4 |
| single-process | 1 000 000 | 7.6600 | 7.6587 | −0.0% | 428.2 | 436.8 |
| distributed P=2 | 1 000 000 | 3.8831 | 3.8816 | −0.0% | 335.7 | 340.0 |
| distributed P=4 | 1 000 000 | 1.9940 | 1.9940 | 0.0% | 289.9 | 292.1 |

Run-to-run spread is ±0.5% at n=200 000 and ±0.1% at n=1 000 000, so every entry
above is at or inside the noise floor. Memory grows by 1–2%.

Duplicated data — a quarter of rows repeated, which forces the general path:

| config | n | before (s) | after (s) | Δ | peak MB before | peak MB after |
|---|---|---|---|---|---|---|
| single-process | 200 000 | 0.4049 | 0.4040 | −0.2% | 85.4 | **128.8** |
| distributed P=2 | 200 000 | 0.2503 | 0.2503 | 0.0% | 67.1 | **88.8** |
| distributed P=4 | 200 000 | 0.1726 | 0.1716 | −0.6% | 58.0 | **68.8** |
| single-process | 1 000 000 | 7.6586 | 7.6574 | −0.0% | 428.2 | **646.2** |
| distributed P=2 | 1 000 000 | 3.8836 | 3.8826 | −0.0% | 335.7 | **444.9** |
| distributed P=4 | 1 000 000 | 1.9944 | 1.9956 | +0.1% | 289.9 | **344.8** |

Wall time is unchanged. Peak memory rises ~50% *on this path only*, because the
old code returned non-contiguous views into the `(n, k + 1)` search buffer while
the general path has to materialize an `(n, k)` result. Two mitigations are worth
noting: the transient is the only thing that grows — once the call returns, the
candidate holds `(n, k)` and frees the wider buffer, whereas the old views kept
`(n, k + 1)` alive for the lifetime of the result — and the path is not reached
unless the data actually needs the fix.

```
python bench.py --device cuda --n 200000 --d 64 --k 15 --warmup 2 --reps 5
python bench.py --device cuda --n 200000 --d 64 --k 15 --warmup 2 --reps 5 --data duplicated
```

## Correctness

The change is `remove_self_neighbors(distances, indices, query_ids)`, called from
the three FAISS entry points:

- `pairwise_distances_faiss` — self-search, `query_ids = arange(n)`;
- `pairwise_distances` distributed branch — chunked query,
  `query_ids = arange(chunk_start, chunk_end)`;
- `pairwise_distances_faiss_from_dataloader` — both, via the chunk bounds.

Rules:

- the self-neighbor is the column whose **index equals the query's database row**,
  wherever it appears;
- if a row does not contain its query at all, all `k + 1` results are valid, so
  the **farthest** one is dropped instead — this is what keeps IVFPQ and `angular`
  returning exactly `k` real neighbors;
- when every row already has its query first — an exact search over distinct
  points, i.e. almost all real usage — the function returns `[:, 1:]` views and
  allocates nothing, so that path is the previous code exactly.

`pairwise_distances_faiss` gains an optional `query_ids` argument. It is only read
when `exclude_diag=True`, and only needed when `X` is a chunk of `Y`. This lets
the distributed branch delegate instead of re-implementing the `k + 1` search and
the removal, so the rule lives in one place. Passing `exclude_diag=True` with
`Y is not X` and no `query_ids` keeps the current behaviour of silently doing
nothing.

Tests: `torchdr/tests/test_utils.py::TestFaissSelfNeighborRemoval`, 16 cases —
the helper's three branches directly, then each entry point against the torch
reference on duplicates, `angular`, IVFPQ, and `world_size ∈ {2, 3}`, plus the
`query_ids` contract, a distinct-data control and the UMAP affinity graph.

**12 of the 16 fail on the pre-fix tree** (`697d7cb`) and all 16 pass after. The
four that pass on both are the two intended controls (distinct data is unchanged;
a chunk without `query_ids` keeps its self-neighbor) and two cases where the
pre-fix code happens to be right for that seed.

```
srun ... pytest torchdr/tests/test_utils.py -k SelfNeighbor   # 16 passed
srun ... pytest torchdr/tests                                 # 503 passed, 16 skipped, 6 xfailed
srun ... pre-commit run --all-files                           # all hooks pass
```

## Limitations

- **No multi-GPU CI.** The distributed tests set `rank`/`world_size` on a forced
  `DistributedContext` rather than launching a process group. That is exact for
  this code path, because the distributed k-NN branch performs **no collective** —
  each rank independently slices its query rows and searches the full replicated
  database — but it does not exercise NCCL.
- **Approximate-index coverage is seed-dependent.** IVFPQ produced self-loops on
  0.20% of rows at the harness scale. The in-tree IVFPQ test passes on the pre-fix
  tree for its seed, so it is coverage rather than a regression guard; the
  duplicates and `angular` tests are the ones that fail loudly.
- **One host sync.** The fast-path check reads a boolean back to the host, one per
  k-NN call. At the granularity of a FAISS search (0.4 s at n=200 000) this is not
  measurable, and it is why the distinct-data tables above are flat.
- **Peak memory on the general path.** When the fix actually engages, transient
  peak memory rises ~50% on the k-NN step (428 → 646 MB at n=1 000 000), as
  tabulated above. Wall time does not move. If that transient matters more than
  the correctness on some workload, the alternative is an in-place column shift,
  which mutates buffers FAISS returned and is not worth the risk here.
- **Ties are still resolved arbitrarily.** With duplicate rows, *which* of the tied
  neighbors is returned remains FAISS' choice. This PR only guarantees that the
  query itself is never one of them.

## Decision

Merge. This is a silent correctness bug: it produces self-edges in the affinity
graph and drops true neighbors, worst on the `angular` metric where the majority
of rows are affected, and it is invisible on the synthetic distinct-point data
most tests use. The fix is one helper, is a no-op on the common path by
construction, and measures flat on wall time and memory.
