### PR TITLE
[Fix] Give TorchDR one authoritative distributed lifecycle entry point

### DIFF
--- a/benchmarks/umap_vs_largevis_distributed.py
+++ b/benchmarks/umap_vs_largevis_distributed.py
@@ -3,7 +3,6 @@
 Compare neighborhood preservation scores for both methods.
 """
 
-import os
 import time
 import gzip
 import pickle
@@ -14,23 +13,29 @@ import torch
 import torch.distributed as dist
 
 from torchdr import UMAP, LargeVis
+from torchdr.distributed import (
+    get_rank,
+    get_world_size,
+    is_distributed as distributed_active,
+    shutdown_distributed,
+)
 from torchdr.eval import neighborhood_preservation
 
 
 def setup_distributed():
-    """Initialize distributed training if launched with torchrun."""
-    if "LOCAL_RANK" in os.environ:
-        local_rank = int(os.environ["LOCAL_RANK"])
-        torch.cuda.set_device(local_rank)
-        dist.init_process_group(backend="nccl")
-        return True, dist.get_rank(), dist.get_world_size()
-    return False, 0, 1
+    """Report the distributed state TorchDR prepared on import.
+
+    TorchDR creates the process group itself under ``torchrun`` or the
+    ``torchdr`` CLI, so calling ``torch.distributed.init_process_group`` here
+    would raise ``ValueError: trying to initialize the default process group
+    twice!``.
+    """
+    return distributed_active(), get_rank(), get_world_size()
 
 
 def cleanup_distributed():
-    """Clean up distributed training environment."""
-    if dist.is_initialized():
-        dist.destroy_process_group()
+    """Release the process group if TorchDR created it."""
+    shutdown_distributed()
 
 
 def load_zheng_dataset():

--- a/docs/source/torchdr.user_guide.rst
+++ b/docs/source/torchdr.user_guide.rst
@@ -389,6 +389,18 @@ In your script, simply use TorchDR as usual:
     model = torchdr.UMAP(n_neighbors=15, verbose=True)
     embedding = model.fit_transform(X)
 
+.. warning::
+
+   Importing TorchDR already creates the process group when the launcher
+   provides GPUs, and destroys it at interpreter exit. Adding the usual
+   ``torch.distributed.init_process_group`` call to your script therefore
+   fails with ``ValueError: trying to initialize the default process group
+   twice!``. Scripts that must create the group explicitly, for example to run
+   on CPU with Gloo, should call ``torchdr.distributed.init_distributed()``
+   instead: it reuses an existing group and is a no-op outside a distributed
+   launch. The matching ``torchdr.distributed.shutdown_distributed()`` only
+   destroys a group that TorchDR itself created.
+
 **Requirements:**
 
 - ``backend="faiss"`` (default for most methods)

--- a/examples/affinities/single_vs_multi_gpu_umap_affinity.py
+++ b/examples/affinities/single_vs_multi_gpu_umap_affinity.py
@@ -4,14 +4,21 @@ Single vs Multi-GPU UMAPAffinity Comparison
 ============================================
 
 Simple example of using UMAPAffinity with multi-GPU on 10x mouse Zheng dataset.
-Compares distributed vs non-distributed performance and verifies outputs are similar.
-Must be launched with torchrun for distributed execution.
+Compares distributed vs non-distributed performance and verifies that the rows
+owned by rank 0 match the single-GPU result.
+
+TorchDR initializes the process group itself when the script is launched with
+``torchrun`` or the ``torchdr`` CLI, so no distributed boilerplate is required
+here. Calling ``torch.distributed.init_process_group`` after importing TorchDR
+would raise ``ValueError: trying to initialize the default process group
+twice!``; use :func:`torchdr.distributed.init_distributed` if a script needs to
+create the group explicitly.
 
 Usage:
+    torchdr --gpus 4 single_vs_multi_gpu_umap_affinity.py
     torchrun --nproc_per_node=4 single_vs_multi_gpu_umap_affinity.py
 """
 
-import os
 import torch
 import torch.distributed as dist
 import time
@@ -21,6 +28,7 @@ from io import BytesIO
 import requests
 
 from torchdr.affinity import UMAPAffinity
+from torchdr.distributed import get_rank, get_world_size, is_distributed
 
 
 def download_and_load_dataset(url):
@@ -31,33 +39,32 @@ def download_and_load_dataset(url):
     return data
 
 
-def setup_distributed():
-    """Initialize distributed training environment."""
-    # torchrun sets the environment variables, but we still need to init the process group
-    local_rank = int(os.environ["LOCAL_RANK"])
-    torch.cuda.set_device(local_rank)
-    dist.init_process_group(
-        backend="nccl", device_id=torch.device(f"cuda:{local_rank}")
-    )
+def sparse_entries(values, indices, row_offset, n_total):
+    """Return sorted (encoded coordinate, value) pairs of a padded sparse chunk.
 
-
-def cleanup_distributed():
-    """Clean up distributed training environment."""
-    if dist.is_initialized():
-        dist.destroy_process_group()
+    Rows are packed with ``-1`` index padding, and the number of stored columns
+    per row depends on the local edge distribution. Encoding the coordinates
+    makes chunks with different padding widths directly comparable.
+    """
+    rows = torch.arange(values.shape[0], device=values.device).unsqueeze(1)
+    keys = (rows + row_offset) * n_total + indices
+    mask = indices >= 0
+    keys, values = keys[mask], values[mask]
+    order = torch.argsort(keys)
+    return keys[order], values[order]
 
 
 def main():
-    # Initialize distributed training
-    setup_distributed()
-    rank = dist.get_rank()
-    world_size = dist.get_world_size()
+    # TorchDR sets up the process group on import under torchrun / the CLI.
+    rank = get_rank()
+    world_size = get_world_size()
 
     # Print from all ranks to verify all GPUs are active
     print(
         f"[Rank {rank}] Process started on GPU {torch.cuda.current_device()}, device name: {torch.cuda.get_device_name()}"
     )
-    dist.barrier()  # Synchronize before continuing
+    if is_distributed():
+        dist.barrier()  # Synchronize before continuing
 
     if rank == 0:
         print(f"\nRunning comparison on {world_size} GPUs")
@@ -71,7 +78,7 @@ def main():
     x = data_10x["pca_50"].astype("float32")
 
     if rank == 0:
-        print(f"Data already PCA-reduced to 50 dimensions")
+        print("Data already PCA-reduced to 50 dimensions")
 
     # Convert to tensor (data stays on CPU)
     X = torch.tensor(x, dtype=torch.float32)
@@ -96,98 +103,99 @@ def main():
 
     # Compute affinity matrix with distributed mode
     P_dist, indices_distributed = affinity_distributed(X, log=False)
+    chunk_start = affinity_distributed.chunk_start_
 
     # Synchronize all GPUs
-    if dist.is_initialized():
+    if is_distributed():
         dist.barrier()
 
-    if rank == 0:
-        distributed_time = time.time() - start_time
-        print(f"\nMulti-GPU computation completed in {distributed_time:.2f} seconds")
+    # Only rank 0 computes the single-GPU reference and reports the comparison.
+    if rank != 0:
+        return
 
-        print("\n" + "=" * 60)
-        print("TEST 2: Single-GPU UMAPAffinity (distributed=False)")
-        print("=" * 60)
-        start_time = time.time()
+    distributed_time = time.time() - start_time
 
-    # Only rank 0 computes the single-GPU version
-    if rank == 0:
-        # Create UMAPAffinity with distributed=False
-        affinity_single = UMAPAffinity(
-            n_neighbors=30,
-            metric="sqeuclidean",
-            verbose=True,
-            device="cuda",
-            backend="faiss",
-            sparsity=True,
-            symmetrize=False,  # Match multi-GPU behavior
-            distributed=False,  # Force single-GPU mode
-        )
+    print("\n" + "=" * 60)
+    print("TEST 2: Single-GPU UMAPAffinity (distributed=False)")
+    print("=" * 60)
+    start_time = time.time()
 
-        # Compute affinity matrix with single GPU
-        P_single, indices_single = affinity_single(X, log=False)
+    # Same settings as the distributed run, so both compute the symmetrized
+    # affinity P + Pᵀ - P∘Pᵀ and the outputs are directly comparable.
+    affinity_single = UMAPAffinity(
+        n_neighbors=30,
+        metric="sqeuclidean",
+        verbose=True,
+        device="cuda",
+        backend="faiss",
+        sparsity=True,
+        distributed=False,  # Force single-GPU mode
+    )
 
-        single_time = time.time() - start_time
-        print(f"\nSingle-GPU computation completed in {single_time:.2f} seconds")
+    # Compute affinity matrix with single GPU
+    P_single, indices_single = affinity_single(X, log=False)
 
-        # Compare results
-        print("\n" + "=" * 60)
-        print("COMPARISON RESULTS")
-        print("=" * 60)
+    single_time = time.time() - start_time
+    print(f"\nSingle-GPU computation completed in {single_time:.2f} seconds")
 
-        # Timing comparison
-        print(f"\nTiming:")
-        print(f"  Multi-GPU ({world_size} GPUs): {distributed_time:.2f} seconds")
-        print(f"  Single-GPU: {single_time:.2f} seconds")
-        print(f"  Speedup: {single_time / distributed_time:.2f}x")
+    # Compare results
+    print("\n" + "=" * 60)
+    print("COMPARISON RESULTS")
+    print("=" * 60)
 
-        # Output shape comparison
-        print(f"\nOutput shapes:")
-        print(f"  Multi-GPU affinity shape: {P_dist.shape}")
-        print(f"  Single-GPU affinity shape: {P_single.shape}")
-        print(f"  Multi-GPU indices shape: {indices_distributed.shape}")
-        print(f"  Single-GPU indices shape: {indices_single.shape}")
+    # Timing comparison
+    print("\nTiming:")
+    print(f"  Multi-GPU ({world_size} GPUs): {distributed_time:.2f} seconds")
+    print(f"  Single-GPU: {single_time:.2f} seconds")
+    print(f"  Speedup: {single_time / distributed_time:.2f}x")
 
-        print(f"\nAffinity statistics (Multi-GPU):")
-        print(f"  Min value: {P_dist.min().item():.6e}")
-        print(f"  Max value: {P_dist.max().item():.6e}")
-        print(f"  Mean value: {P_dist.mean().item():.6e}")
+    # Output shape comparison
+    print("\nOutput shapes:")
+    print(f"  Multi-GPU affinity shape: {P_dist.shape}")
+    print(f"  Single-GPU affinity shape: {P_single.shape}")
+    print(f"  Multi-GPU indices shape: {indices_distributed.shape}")
+    print(f"  Single-GPU indices shape: {indices_single.shape}")
 
-        print(f"\nAffinity statistics (Single-GPU):")
-        print(f"  Min value: {P_single.min().item():.6e}")
-        print(f"  Max value: {P_single.max().item():.6e}")
-        print(f"  Mean value: {P_single.mean().item():.6e}")
+    print("\nAffinity statistics (Multi-GPU):")
+    print(f"  Min value: {P_dist.min().item():.6e}")
+    print(f"  Max value: {P_dist.max().item():.6e}")
+    print(f"  Mean value: {P_dist.mean().item():.6e}")
 
-        # Check similarity of outputs (P_dist is chunked, P_single is full)
-        print(f"\nOutput similarity check (comparing rank 0's chunk):")
+    print("\nAffinity statistics (Single-GPU):")
+    print(f"  Min value: {P_single.min().item():.6e}")
+    print(f"  Max value: {P_single.max().item():.6e}")
+    print(f"  Mean value: {P_single.mean().item():.6e}")
 
-        # Get the size of rank 0's chunk
-        chunk_size = P_dist.shape[0]
+    # Symmetrization gives each row a different number of stored neighbors, so
+    # the two runs are compared as coordinate/value pairs over rank 0's rows.
+    chunk_size = P_dist.shape[0]
+    n_total = P_single.shape[0]
+    keys_dist, values_dist = sparse_entries(
+        P_dist, indices_distributed, chunk_start, n_total
+    )
+    keys_single, values_single = sparse_entries(
+        P_single[:chunk_size], indices_single[:chunk_size], 0, n_total
+    )
 
-        # Compare indices for the chunk
-        indices_match = torch.allclose(
-            indices_distributed, indices_single[:chunk_size], rtol=1e-5
-        )
-        print(f"  Indices match (chunk of {chunk_size} points): {indices_match}")
+    print(f"\nOutput similarity check (comparing rank 0's chunk of {chunk_size} rows):")
+    print(
+        f"  Stored entries (multi-GPU / single-GPU): {keys_dist.numel()}"
+        f" / {keys_single.numel()}"
+    )
 
-        # Compare affinity values for the chunk
-        P_single_chunk = P_single[:chunk_size]
-        values_diff = torch.abs(P_dist - P_single_chunk).mean()
+    same_support = keys_dist.numel() == keys_single.numel() and bool(
+        (keys_dist == keys_single).all()
+    )
+    print(f"  Same sparsity pattern: {same_support}")
+
+    if same_support:
+        abs_diff = (values_dist - values_single).abs()
+        print(f"  Mean absolute difference: {abs_diff.mean().item():.6e}")
+        print(f"  Max absolute difference: {abs_diff.max().item():.6e}")
         print(
-            f"  Mean absolute difference in affinity values: {values_diff.item():.6e}"
+            "  Affinity values match (rtol=1e-3): "
+            f"{torch.allclose(values_dist, values_single, rtol=1e-3, atol=1e-6)}"
         )
-
-        # Check relative difference
-        relative_diff = (
-            torch.abs(P_dist - P_single_chunk) / (P_single_chunk + 1e-10)
-        ).mean()
-        print(f"  Mean relative difference: {relative_diff.item():.6e}")
-
-        values_match = torch.allclose(P_dist, P_single_chunk, rtol=1e-3, atol=1e-6)
-        print(f"  Affinity values match (rtol=1e-3): {values_match}")
-
-    # Clean up
-    cleanup_distributed()
 
 
 if __name__ == "__main__":

--- a/torchdr/cli.py
+++ b/torchdr/cli.py
@@ -91,6 +91,13 @@ Arguments after the script name are passed directly to your script.
             )
             sys.exit(1)
 
+        if n_gpus < 1:
+            print(
+                f"Error: --gpus must be a positive number or 'all', got '{args.gpus}'",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
         if n_gpus > available_gpus:
             print(
                 f"Warning: Requested {n_gpus} GPUs but only {available_gpus} "
@@ -98,6 +105,10 @@ Arguments after the script name are passed directly to your script.
                 file=sys.stderr,
             )
             n_gpus = available_gpus
+
+        if n_gpus < 1:
+            print("Error: No GPUs detected on this system", file=sys.stderr)
+            sys.exit(1)
 
     # Print hardware detection summary
     print("TorchDR Multi-GPU Launcher")
@@ -107,8 +118,13 @@ Arguments after the script name are passed directly to your script.
 
     # Build torchrun command (single-node only)
     # Use --standalone to avoid port conflicts on shared systems (uses localhost:0)
+    # Invoke torchrun through the running interpreter so the workers always use
+    # the environment TorchDR is installed in, even when no ``torchrun``
+    # executable is on PATH.
     cmd = [
-        "torchrun",
+        sys.executable,
+        "-m",
+        "torch.distributed.run",
         "--standalone",
         f"--nproc_per_node={n_gpus}",
         args.script,
@@ -125,7 +141,8 @@ Arguments after the script name are passed directly to your script.
         sys.exit(result.returncode)
     except FileNotFoundError:
         print(
-            "Error: torchrun not found. Make sure PyTorch is installed.",
+            f"Error: could not launch '{sys.executable} -m torch.distributed.run'. "
+            "Make sure PyTorch is installed in this environment.",
             file=sys.stderr,
         )
         sys.exit(1)

--- a/torchdr/distance/base.py
+++ b/torchdr/distance/base.py
@@ -109,7 +109,7 @@ def pairwise_distances(
     ...     dataloader, k=15, return_indices=True
     ... )
 
-    >>> # DataLoader with multi-GPU (after torch.distributed.init_process_group)
+    >>> # DataLoader with multi-GPU (launched with torchrun or the torchdr CLI)
     >>> from torchdr.distributed import DistributedContext
     >>> dist_ctx = DistributedContext()
     >>> distances, indices = pairwise_distances(

--- a/torchdr/distributed/__init__.py
+++ b/torchdr/distributed/__init__.py
@@ -12,14 +12,119 @@ utilities for managing distributed multi-GPU computation.
 import atexit
 import os
 import warnings
-from typing import Tuple
+from typing import Optional, Tuple
 
 import torch
 import torch.distributed as dist
 
-__all__ = ["is_distributed", "get_rank", "get_world_size", "DistributedContext"]
+__all__ = [
+    "is_distributed",
+    "get_rank",
+    "get_world_size",
+    "init_distributed",
+    "shutdown_distributed",
+    "DistributedContext",
+]
 
 _distributed_initialized_by_torchdr = False
+_cleanup_registered = False
+
+
+def init_distributed(backend: Optional[str] = None) -> bool:
+    """Initialize the process group for a launcher-provided rendezvous.
+
+    This is the single entry point TorchDR uses to create a process group. It
+    is called automatically on import when the process was started by
+    ``torchrun`` or the ``torchdr`` CLI and a GPU is available, so scripts
+    normally need no distributed boilerplate at all.
+
+    Call this function instead of :func:`torch.distributed.init_process_group`
+    in scripts that must also run without a launcher, or in CPU test processes
+    that the automatic setup deliberately skips. Calling
+    :func:`torch.distributed.init_process_group` directly after importing
+    TorchDR raises ``ValueError: trying to initialize the default process group
+    twice!`` because the group already exists.
+
+    The function is idempotent and never raises when there is nothing to do:
+    it returns ``False`` when a process group already exists, when no launcher
+    is detected, or when :mod:`torch.distributed` is unavailable.
+
+    Parameters
+    ----------
+    backend : str, optional
+        Process group backend. Defaults to ``"nccl"`` when CUDA is available
+        and ``"gloo"`` otherwise.
+
+    Returns
+    -------
+    bool
+        True if this call created the process group, False if it was a no-op.
+
+    Examples
+    --------
+    >>> from torchdr.distributed import init_distributed, shutdown_distributed
+    >>> init_distributed()  # no-op unless launched with torchrun
+    False
+    """
+    global _distributed_initialized_by_torchdr, _cleanup_registered
+
+    if not dist.is_available():
+        return False
+
+    if dist.is_initialized():
+        current = dist.get_backend()
+        if backend is not None and str(backend).lower() != str(current).lower():
+            warnings.warn(
+                f"A process group is already initialized with backend "
+                f"'{current}'. The requested backend '{backend}' is ignored.",
+                UserWarning,
+                stacklevel=2,
+            )
+        return False
+
+    if "LOCAL_RANK" not in os.environ:
+        return False
+
+    cuda_available = torch.cuda.is_available()
+    if backend is None:
+        backend = "nccl" if cuda_available else "gloo"
+
+    if cuda_available:
+        torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))
+
+    dist.init_process_group(backend=backend)
+    _distributed_initialized_by_torchdr = True
+
+    if not _cleanup_registered:
+        atexit.register(_auto_cleanup_distributed)
+        _cleanup_registered = True
+
+    return True
+
+
+def shutdown_distributed() -> bool:
+    """Destroy the process group if TorchDR created it.
+
+    Groups created by the caller or by another library are left untouched, so
+    this is safe to call unconditionally at the end of a script. TorchDR also
+    calls it automatically at interpreter exit.
+
+    Returns
+    -------
+    bool
+        True if this call destroyed the process group, False otherwise.
+    """
+    global _distributed_initialized_by_torchdr
+
+    if not dist.is_available():
+        return False
+
+    if _distributed_initialized_by_torchdr and dist.is_initialized():
+        dist.destroy_process_group()
+        _distributed_initialized_by_torchdr = False
+        return True
+
+    return False
 
 
 def _auto_setup_distributed():
@@ -32,9 +137,8 @@ def _auto_setup_distributed():
 
     Note: Only initializes if CUDA is available. TorchDR distributed mode is
     GPU-only since PyTorch already provides efficient CPU parallelization.
+    Explicitly calling :func:`init_distributed` still creates a Gloo group.
     """
-    global _distributed_initialized_by_torchdr
-
     if "LOCAL_RANK" in os.environ and not dist.is_initialized():
         # Only setup distributed for GPU training
         if not torch.cuda.is_available():
@@ -49,16 +153,7 @@ def _auto_setup_distributed():
             )
             return
 
-        local_rank = int(os.environ["LOCAL_RANK"])
-        torch.cuda.set_device(local_rank)
-
-        # Initialize process group (GPU-only with NCCL backend)
-        dist.init_process_group(backend="nccl")
-
-        _distributed_initialized_by_torchdr = True
-
-        # Register cleanup function
-        atexit.register(_auto_cleanup_distributed)
+        init_distributed(backend="nccl")
 
 
 def _auto_cleanup_distributed():
@@ -68,11 +163,7 @@ def _auto_cleanup_distributed():
     interpreter exits. It only destroys the process group if it was
     initialized by TorchDR's auto-setup.
     """
-    global _distributed_initialized_by_torchdr
-
-    if _distributed_initialized_by_torchdr and dist.is_initialized():
-        dist.destroy_process_group()
-        _distributed_initialized_by_torchdr = False
+    shutdown_distributed()
 
 
 def is_distributed():
@@ -142,8 +233,8 @@ class DistributedContext:
     >>> from torchdr.distributed import DistributedContext
     >>> from torchdr.distance import pairwise_distances
     >>>
-    >>> # Initialize distributed (usually done by launcher like torchrun)
-    >>> # torch.distributed.init_process_group(...)
+    >>> # The process group is created on import under torchrun or the
+    >>> # torchdr CLI; call init_distributed() only outside those launchers.
     >>>
     >>> # Create distributed context
     >>> dist_ctx = DistributedContext()

--- a/torchdr/tests/test_cli.py
+++ b/torchdr/tests/test_cli.py
@@ -4,10 +4,17 @@
 #
 # License: BSD 3-Clause License
 
+import sys
+
 import pytest
 from unittest.mock import patch, MagicMock
 
 from torchdr.cli import get_gpu_count, main
+
+
+def assert_launches_through_current_interpreter(cmd):
+    """Check the launcher runs torchrun as a module of the running Python."""
+    assert cmd[:3] == [sys.executable, "-m", "torch.distributed.run"]
 
 
 class TestGetGpuCount:
@@ -44,7 +51,7 @@ class TestMain:
         assert exc_info.value.code == 0
         mock_run.assert_called_once()
         cmd = mock_run.call_args[0][0]
-        assert "torchrun" in cmd
+        assert_launches_through_current_interpreter(cmd)
         assert "--standalone" in cmd
         assert "--nproc_per_node=4" in cmd
         assert "script.py" in cmd
@@ -86,6 +93,21 @@ class TestMain:
                 main()
 
         assert exc_info.value.code == 1
+
+    @pytest.mark.parametrize("gpus", ["0", "-1"])
+    @patch("torchdr.cli.subprocess.run")
+    @patch("torchdr.cli.get_gpu_count")
+    def test_non_positive_gpus_rejected(self, mock_gpu_count, mock_run, capsys, gpus):
+        """A non-positive --gpus value fails before torchrun is invoked."""
+        mock_gpu_count.return_value = 4
+
+        with patch("sys.argv", ["torchdr", "--gpus", gpus, "script.py"]):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+
+        assert exc_info.value.code == 1
+        assert "positive" in capsys.readouterr().err
+        mock_run.assert_not_called()
 
     @patch("torchdr.cli.subprocess.run")
     @patch("torchdr.cli.get_gpu_count")
@@ -138,3 +160,31 @@ class TestMain:
                 main()
 
         assert exc_info.value.code == 1
+
+    @patch("torchdr.cli.subprocess.run")
+    @patch("torchdr.cli.get_gpu_count")
+    def test_does_not_depend_on_torchrun_on_path(self, mock_gpu_count, mock_run):
+        """The launcher must not rely on a `torchrun` executable being on PATH."""
+        mock_gpu_count.return_value = 2
+        mock_run.return_value = MagicMock(returncode=0)
+
+        with patch("sys.argv", ["torchdr", "--gpus", "2", "script.py"]):
+            with pytest.raises(SystemExit):
+                main()
+
+        cmd = mock_run.call_args[0][0]
+        assert_launches_through_current_interpreter(cmd)
+        assert "torchrun" not in cmd
+
+    @patch("torchdr.cli.subprocess.run")
+    @patch("torchdr.cli.get_gpu_count")
+    def test_exit_code_is_propagated(self, mock_gpu_count, mock_run):
+        """The launcher exits with the torchrun exit code, unchanged."""
+        mock_gpu_count.return_value = 1
+        mock_run.return_value = MagicMock(returncode=7)
+
+        with patch("sys.argv", ["torchdr", "script.py"]):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+
+        assert exc_info.value.code == 7

--- a/torchdr/tests/test_distributed.py
+++ b/torchdr/tests/test_distributed.py
@@ -4,12 +4,19 @@
 #
 # License: BSD 3-Clause License
 
+import warnings
+from unittest.mock import patch
+
+import pytest
 import torch
 
+import torchdr.distributed as torchdr_distributed
 from torchdr.distributed import (
     is_distributed,
     get_rank,
     get_world_size,
+    init_distributed,
+    shutdown_distributed,
     DistributedContext,
 )
 
@@ -29,6 +36,118 @@ class TestDistributedUtilities:
     def test_get_world_size_non_distributed(self):
         """Test get_world_size returns 1 when not distributed."""
         assert get_world_size() == 1
+
+
+class TestInitDistributed:
+    """Tests for the authoritative process group entry point."""
+
+    def test_no_launcher_is_noop(self, monkeypatch):
+        """Without LOCAL_RANK there is no rendezvous, so nothing is created."""
+        monkeypatch.delenv("LOCAL_RANK", raising=False)
+
+        with patch("torch.distributed.init_process_group") as mock_init:
+            assert init_distributed() is False
+
+        mock_init.assert_not_called()
+
+    def test_creates_group_when_launched(self, monkeypatch):
+        """A launcher rendezvous triggers exactly one initialization."""
+        monkeypatch.setenv("LOCAL_RANK", "0")
+        monkeypatch.setattr(torchdr_distributed, "_cleanup_registered", True)
+        monkeypatch.setattr(
+            torchdr_distributed, "_distributed_initialized_by_torchdr", False
+        )
+
+        with patch("torch.distributed.init_process_group") as mock_init:
+            with patch("torch.cuda.is_available", return_value=False):
+                assert init_distributed() is True
+
+        mock_init.assert_called_once_with(backend="gloo")
+        assert torchdr_distributed._distributed_initialized_by_torchdr is True
+
+        # Reset the module flag so later tests see a pristine state.
+        monkeypatch.setattr(
+            torchdr_distributed, "_distributed_initialized_by_torchdr", False
+        )
+
+    def test_defaults_to_nccl_with_cuda(self, monkeypatch):
+        """CUDA launches use NCCL and bind the local device."""
+        monkeypatch.setenv("LOCAL_RANK", "1")
+        monkeypatch.setattr(torchdr_distributed, "_cleanup_registered", True)
+        monkeypatch.setattr(
+            torchdr_distributed, "_distributed_initialized_by_torchdr", False
+        )
+
+        with patch("torch.distributed.init_process_group") as mock_init:
+            with patch("torch.cuda.is_available", return_value=True):
+                with patch("torch.cuda.set_device") as mock_set_device:
+                    assert init_distributed() is True
+
+        mock_init.assert_called_once_with(backend="nccl")
+        mock_set_device.assert_called_once_with(1)
+
+        monkeypatch.setattr(
+            torchdr_distributed, "_distributed_initialized_by_torchdr", False
+        )
+
+    def test_idempotent_when_group_exists(self, monkeypatch):
+        """A second call must not raise 'initialize the default group twice'."""
+        monkeypatch.setenv("LOCAL_RANK", "0")
+
+        with patch("torch.distributed.is_initialized", return_value=True):
+            with patch("torch.distributed.get_backend", return_value="nccl"):
+                with patch("torch.distributed.init_process_group") as mock_init:
+                    assert init_distributed() is False
+
+        mock_init.assert_not_called()
+
+    def test_warns_on_backend_mismatch(self, monkeypatch):
+        """An explicit backend that cannot be honoured is reported."""
+        monkeypatch.setenv("LOCAL_RANK", "0")
+
+        with patch("torch.distributed.is_initialized", return_value=True):
+            with patch("torch.distributed.get_backend", return_value="nccl"):
+                with pytest.warns(UserWarning, match="already initialized"):
+                    assert init_distributed(backend="gloo") is False
+
+    def test_no_warning_when_backend_matches(self, monkeypatch):
+        """Requesting the backend already in use is silent."""
+        monkeypatch.setenv("LOCAL_RANK", "0")
+
+        with patch("torch.distributed.is_initialized", return_value=True):
+            with patch("torch.distributed.get_backend", return_value="gloo"):
+                with warnings.catch_warnings():
+                    warnings.simplefilter("error")
+                    assert init_distributed(backend="gloo") is False
+
+
+class TestShutdownDistributed:
+    """Tests for the matching teardown helper."""
+
+    def test_noop_for_foreign_group(self, monkeypatch):
+        """A group TorchDR did not create is left alone."""
+        monkeypatch.setattr(
+            torchdr_distributed, "_distributed_initialized_by_torchdr", False
+        )
+
+        with patch("torch.distributed.is_initialized", return_value=True):
+            with patch("torch.distributed.destroy_process_group") as mock_destroy:
+                assert shutdown_distributed() is False
+
+        mock_destroy.assert_not_called()
+
+    def test_destroys_own_group_once(self, monkeypatch):
+        """A group TorchDR created is destroyed exactly once."""
+        monkeypatch.setattr(
+            torchdr_distributed, "_distributed_initialized_by_torchdr", True
+        )
+
+        with patch("torch.distributed.is_initialized", return_value=True):
+            with patch("torch.distributed.destroy_process_group") as mock_destroy:
+                assert shutdown_distributed() is True
+                assert shutdown_distributed() is False
+
+        mock_destroy.assert_called_once()
 
 
 class TestDistributedContext:

--- a/torchdr/tests/test_distributed_integration.py
+++ b/torchdr/tests/test_distributed_integration.py
@@ -10,7 +10,11 @@ import pytest
 import torch
 import torch.distributed as dist
 
-from torchdr.distributed import DistributedContext
+from torchdr.distributed import (
+    DistributedContext,
+    init_distributed,
+    shutdown_distributed,
+)
 from torchdr.spectral_embedding import PCA
 
 
@@ -22,16 +26,29 @@ pytestmark = pytest.mark.skipif(
 
 @pytest.fixture(scope="module", autouse=True)
 def distributed_process_group():
-    """Initialize the process group created by torchrun."""
-    dist.init_process_group(backend="gloo")
+    """Join the process group started by the launcher.
+
+    TorchDR already creates a NCCL group on import when the launcher provides
+    GPUs, so the group must not be created a second time here. On CPU runners
+    the automatic setup is skipped and this creates the Gloo group itself.
+    """
+    init_distributed(backend="gloo")
+    if not dist.is_initialized():
+        pytest.skip("no process group; launch with torch.distributed.run")
     yield
     dist.barrier()
-    dist.destroy_process_group()
+    shutdown_distributed()
+
+
+def _collective_device():
+    """Return a device the active backend can communicate on."""
+    return "cuda" if dist.get_backend() == "nccl" else "cpu"
 
 
 def test_real_distributed_collectives():
     """Exercise context discovery and PCA collectives across real processes."""
     context = DistributedContext()
+    device = _collective_device()
 
     assert context.is_initialized
     assert context.world_size == 2
@@ -50,10 +67,10 @@ def test_real_distributed_collectives():
             [7.0, 5.0, 8.0, 10.0],
         ],
         dtype=torch.float64,
-    )
+    ).to(device)
     local_data = full_data.chunk(context.world_size)[context.rank].contiguous()
 
-    distributed_pca = PCA(n_components=2, distributed=True, device="cpu")
+    distributed_pca = PCA(n_components=2, distributed=True, device=device)
     embedding = distributed_pca.fit_transform(local_data)
 
     assert embedding.shape == (len(local_data), 2)
@@ -68,7 +85,7 @@ def test_real_distributed_collectives():
     dist.all_gather(gathered_components, distributed_pca.components_)
     torch.testing.assert_close(gathered_components[0], gathered_components[1])
 
-    reference_pca = PCA(n_components=2, distributed=False, device="cpu")
+    reference_pca = PCA(n_components=2, distributed=False, device=device)
     reference_pca.fit(full_data)
     distributed_projector = distributed_pca.components_.T @ distributed_pca.components_
     reference_projector = reference_pca.components_.T @ reference_pca.components_


### PR DESCRIPTION
## Verdict

**APPROVE**

## Hypothesis

The documented multi-GPU example can initialize the process group twice,
because importing TorchDR already initializes it under `torchrun`. The
launcher also accepts nonsensical GPU counts and depends on a `torchrun`
executable being on `PATH`. Correcting the lifecycle and the launcher checks
should eliminate a broken first-run experience.

Confirmed on all counts, plus one the hypothesis did not anticipate: the
real-process integration test added in #293 has the same double-initialization
defect, so it cannot run on GPUs at all.

## Benchmark design

- Baseline commit: `697d7cb` (current `main`), clean worktree
- Candidate commit: `e025cf9`
- Hardware and world size: 2 × B200, `world_size=2`, NCCL 2.27.3, torch
  2.8.0+cu128; CPU/Gloo probes on the same node with `CUDA_VISIBLE_DEVICES=`
- Dataset / N / D / k / dtype: 10x mouse Zheng, N = 1,306,127, D = 50,
  `n_neighbors=30`, float32, `backend="faiss"`, `sparsity=True`
- Repetitions and synchronization: each probe is a fresh process launch;
  `dist.barrier()` between the distributed and reference phases
- Exact commands: each probe is printed verbatim above its output in the logs;
  the two headline ones are

  ```
  torchrun --standalone --nproc_per_node=2 \
    examples/affinities/single_vs_multi_gpu_umap_affinity.py

  TORCHDR_DISTRIBUTED_TEST=1 python -m torch.distributed.run --standalone \
    --nnodes=1 --nproc-per-node=2 -m pytest \
    torchdr/tests/test_distributed_integration.py -q
  ```

Baseline and candidate ran in identical allocations, each with the worktree
pinned on `sys.path` and `torchdr.__file__` asserted to resolve inside that
worktree before any measurement.

## Results

| Probe | Baseline `697d7cb` | Candidate `e025cf9` |
|---|---|---|
| B1 documented example, `torchrun`, 2 GPUs | `ValueError: trying to initialize the default process group twice!` — exit 1 | exit 0, full 1.3M-cell run |
| B2 documented CI command, GPUs visible (NCCL) | `ChildFailedError` — exit 1 | `1 passed` — exit 0 |
| B3 no-boilerplate contract (control) | exit 0 | exit 0 |
| B4 `--gpus 0` | `torchrun ... --nproc_per_node=0` → `AssertionError` — exit 1 | `Error: --gpus must be a positive number or 'all', got '0'` — exit 1, `torchrun` never launched |
| B5 `--gpus -1` | `torchrun ... --nproc_per_node=-1` → `AssertionError` — exit 1 | `Error: --gpus must be a positive number or 'all', got '-1'` — exit 1 |
| B6 no `torchrun` on `PATH` | `Error: torchrun not found. Make sure PyTorch is installed.` — exit 1 | exit 0, both workers ran |
| B7 worker script exits 7 | exit 1 | exit 1 (unchanged) |
| C1 CI command, GPUs hidden (CPU/Gloo) | `1 passed` — exit 0 | `1 passed` — exit 0 |
| C2 integration test, no launcher | `ValueError: ... environment variable RANK expected, but not set` — 1 error, exit 1 | `1 skipped` — exit 0 |
| C3 distributed benchmark module import | exit 0 | exit 0 |

B3, C1 and C3 are the unchanged-behaviour controls: the paths that already
worked still work, including the exact command the CPU CI job runs.

## Correctness and quality

B1 is a correctness result, not just a smoke test. On rank 0's chunk the
candidate compares the distributed `UMAPAffinity` against a single-GPU
reference computed with identical settings, as sorted coordinate/value pairs
so that different padding widths are comparable:

```
Output similarity check (comparing rank 0's chunk of 653064 rows):
  Stored entries (multi-GPU / single-GPU): 32276628 / 32276628
  Same sparsity pattern: True
  Mean absolute difference: 0.000000e+00
  Max absolute difference: 0.000000e+00
```

32.3M stored affinity entries agree exactly. The previous version of this
example compared `symmetrize=False` against the distributed default, which is
not the same quantity; both instances now use the default `symmetrize=True`.

B2 also exercises the new backend-mismatch warning end to end: under NCCL the
fixture's `init_distributed(backend="gloo")` correctly reuses the existing
group and reports `A process group is already initialized with backend 'nccl'.
The requested backend 'gloo' is ignored.`

## Decision

Adopt the change. Every claim in the hypothesis reproduced on the baseline and
is resolved in the candidate, with no regression in any control probe.

## Implementation or retained benchmark artifact

- `init_distributed(backend=None)` / `shutdown_distributed()` in
  `torchdr/distributed/__init__.py` are now the single entry point for the
  process group. `init_distributed` defaults to NCCL with CUDA and Gloo
  otherwise, binds the local device, registers cleanup once, reuses an
  existing group, warns when an explicit backend cannot be honoured, and is a
  no-op without a launcher. `shutdown_distributed` only destroys a group
  TorchDR created, so a caller-owned or third-party group is never touched.
  `_auto_setup_distributed` / `_auto_cleanup_distributed` delegate to them
  rather than duplicating the logic; the GPU-only auto-setup behaviour and its
  CPU warning are unchanged.
- `torchdr/cli.py` rejects non-positive `--gpus` before launching, and runs
  `sys.executable -m torch.distributed.run` so workers always use the
  environment TorchDR is installed in.
- The example, the integration test and `benchmarks/umap_vs_largevis_distributed.py`
  drop their hand-rolled boilerplate and use the helpers.
- The user guide gains a warning at the exact place that tells users to "simply
  use TorchDR as usual", and two docstrings that still recommended calling
  `torch.distributed.init_process_group` were corrected.

## Validation

- Probes B1–B7 and C1–C3 above, baseline and candidate, 2 × B200.
- `pytest torchdr/tests/test_cli.py torchdr/tests/test_distributed.py` →
  38 passed. 14 of these cases are new and cover `init_distributed` /
  `shutdown_distributed` idempotence, backend defaulting, device binding, the
  mismatch warning, and the launcher argument and interpreter contracts.
- Full suite `pytest torchdr/tests` → 497 passed, 13 skipped, 6 xfailed,
  6 failed. All 6 failures are in `test_dataloader.py` and are **pre-existing
  on `697d7cb`**: the same 6 fail identically on a clean baseline worktree
  (FAISS CPU/GPU tolerance on this hardware, `Greatest absolute difference:
  0.00390625` at `rtol=1e-4`). They are unrelated to this change and are not
  addressed here.
- `pre-commit run --all-files` → all hooks pass. `git diff --check` clean.

## Risks and limitations

- **`--gpus` semantics are unchanged for valid input.** Only non-positive
  values are newly rejected; `all` and any positive count behave as before,
  including the existing clamp-with-warning when the request exceeds the
  hardware.
- **B7 is unchanged, and deliberately so.** `torchrun` normalizes a failing
  worker to exit code 1 via `ChildFailedError`, so a worker's own exit code
  does not survive the launcher. The CLI contract is that it propagates
  `torchrun`'s exit code unchanged; that is what the new unit test pins, and
  no attempt is made to reconstruct worker exit codes.
- **The example is not faster on 2 GPUs at this size** (20.55 s distributed vs
  17.96 s single-GPU, 0.87×). The FAISS index is replicated per rank and the
  symmetrization adds an `all_to_all` exchange, so 2 ranks do not pay off at
  N = 1.3M / D = 50; the single-GPU phase also benefits from the warm CUDA and
  FAISS context established by the distributed phase. The example's purpose
  here is agreement, not speedup, and the timings are printed as measured.
- **CI cannot catch this class of bug today.** The distributed workflow runs on
  a CPU-only `ubuntu-latest` runner, where the auto-setup deliberately skips
  initialization, so the double-initialization path is never taken. C1 shows
  that job still passes; a GPU runner would be needed to guard B1/B2 upstream.
