### PR TITLE
[Chore] Add benchmark for the UMAP negative-sampling branch

### DIFF
--- a/benchmarks/umap_negative_sampling.py
+++ b/benchmarks/umap_negative_sampling.py
@@ -1,0 +1,535 @@
+"""Benchmark the UMAP repulsive (negative-sampling) branch.
+
+``UMAP`` draws ``n_negatives = negative_sample_rate * n_neighbors`` negatives for
+every row of the local chunk, evaluates the full ``(chunk, n_negatives)``
+rectangle, and then zeroes the columns beyond each row's per-iteration budget
+``min(active_positive_edges * negative_sample_rate, n_negatives)``.  Only a
+minority of the rectangle therefore contributes to the gradient.
+
+This script measures how much is actually left on the table.  It compares three
+implementations of ``_compute_repulsive_gradients`` under identical conditions:
+
+``baseline``
+    The shipped kernel.  ``pairwise_distances_indexed`` builds the
+    ``(chunk, n_negatives, n_components)`` difference tensor to produce the
+    squared distances, and the gradient block then rebuilds the same tensor.
+
+``fused``
+    Control arm.  Still fully rectangular and still consumes the same eager
+    draw, but materializes the difference tensor once and derives the distances
+    from it.  Same arithmetic in the same order, so it is *bitwise* identical to
+    the baseline; it isolates how much of any speed-up comes from removing the
+    redundant materialization rather than from packing.
+
+``packed``
+    Evaluates only ``sum_i min(active_i * negative_sample_rate, n_negatives)``
+    negative pairs in a flat layout, draws them with a single ``searchsorted``
+    over a globally offset exclusion table, and scatters the result back with
+    ``index_add_``.
+
+Reported per arm: end-to-end ``fit_transform`` wall time (median and range over
+``--reps`` runs), CUDA-event time for the attractive branch, the repulsive
+branch and the whole training step, peak allocated bytes per phase, the negative
+pairs actually evaluated, and K-ary neighborhood preservation.
+
+``--check`` additionally replays every arm against one identical model state and
+reports the gradient difference against the baseline, plus a uniformity and
+exclusion audit of the packed draw.
+
+Example
+-------
+python benchmarks/umap_negative_sampling.py --dataset zheng --n-samples 200000 \
+    --n-neighbors 30 --max-iter 500 --reps 3 --check
+"""
+
+import argparse
+import gzip
+import json
+import os
+import pickle
+import statistics
+import time
+from io import BytesIO
+
+import numpy as np
+import torch
+
+from torchdr import UMAP
+from torchdr.distance import pairwise_distances_indexed
+from torchdr.eval import neighborhood_preservation
+from torchdr.neighbor_embedding.base import NeighborEmbedding
+
+DATASETS = {
+    "macosko": "http://file.biolab.si/opentsne/benchmark/macosko_2015.pkl.gz",
+    "zheng": "http://file.biolab.si/opentsne/benchmark/10x_mouse_zheng.pkl.gz",
+}
+
+
+# --- Repulsive-branch arms -------------------------------------------------
+#
+# Written as plain functions of a fitted model so that the --check probe can
+# evaluate every arm against one identical state.
+
+
+def negative_counts(model):
+    """Per-row number of negatives the baseline actually uses this iteration."""
+    active = model.mask_affinity_in_.sum(dim=1)
+    return (active * model.negative_sample_rate).clamp(max=model.n_negatives).long()
+
+
+def _coefficients(D, model):
+    """In-place ``-2 b / ((eps + d) (1 + a d^b))`` used by all arms."""
+    D_ = 1 + model._a * D**model._b
+    D.add_(model._eps)
+    D.mul_(D_)
+    D.reciprocal_().mul_(-2 * model._b)
+    return D
+
+
+def repulsive_baseline(model):
+    """Verbatim copy of the shipped kernel, kept so --check can audit the copy."""
+    D = pairwise_distances_indexed(
+        model.embedding_,
+        query_indices=model.chunk_indices_,
+        key_indices=model.neg_indices_,
+        metric="sqeuclidean",
+    )
+    _coefficients(D, model)
+
+    neg_counts = (model.mask_affinity_in_.sum(dim=1) * model.negative_sample_rate).to(
+        torch.long
+    )
+    col_idx = torch.arange(model.n_negatives, device=model.embedding_.device)
+    D.masked_fill_(col_idx[None, :].ge(neg_counts[:, None]), 0)
+
+    diff = (
+        model.embedding_[model.chunk_indices_].unsqueeze(1)
+        - model.embedding_[model.neg_indices_]
+    )
+    grad = torch.einsum("ijk,ij->ik", diff, D)
+    grad.clamp_(-4, 4)
+    return grad
+
+
+def repulsive_fused(model):
+    """Rectangular, but the difference tensor is materialized only once."""
+    diff = (
+        model.embedding_[model.chunk_indices_].unsqueeze(1)
+        - model.embedding_[model.neg_indices_]
+    )
+    D = _coefficients((diff**2).sum(dim=-1), model)
+
+    neg_counts = (model.mask_affinity_in_.sum(dim=1) * model.negative_sample_rate).to(
+        torch.long
+    )
+    col_idx = torch.arange(model.n_negatives, device=model.embedding_.device)
+    D.masked_fill_(col_idx[None, :].ge(neg_counts[:, None]), 0)
+
+    grad = torch.einsum("ijk,ij->ik", diff, D)
+    grad.clamp_(-4, 4)
+    return grad
+
+
+def _flat_exclusion_table(model):
+    """Flatten the per-row exclusion table into one globally sorted array.
+
+    Row ``r`` is offset by ``r * big`` with ``big = n_candidates + 1``, so the
+    per-row blocks are disjoint and ordered.  A single ``searchsorted`` over the
+    flat array then returns ``r * width + shift_r``, reproducing the row-wise
+    search of ``_draw_with_exclusions`` without an ``(n_pairs, width)`` temporary.
+    """
+    cached = getattr(model, "_flat_exclusion", None)
+    if cached is not None:
+        return cached
+    adjusted = model.negative_adjusted_exclusion_
+    rows, width = adjusted.shape
+    big = int(model.n_samples_in_) + 1
+    offsets = torch.arange(rows, device=adjusted.device, dtype=torch.long) * big
+    flat = (adjusted + offsets.unsqueeze(1)).reshape(-1).contiguous()
+    model._flat_exclusion = (flat, width, big)
+    return model._flat_exclusion
+
+
+def packed_draw(model, row_ids):
+    """Draw one negative per entry of ``row_ids``, respecting row exclusions."""
+    flat, width, big = _flat_exclusion_table(model)
+    compressed = (
+        torch.rand(row_ids.numel(), device=row_ids.device)
+        * model.negative_available_counts_[row_ids]
+    ).long()
+    pos = torch.searchsorted(flat, compressed + row_ids * big, right=True)
+    return compressed + (pos - row_ids * width)
+
+
+def _replay_draw(model, row_ids, counts):
+    """Reuse the baseline's own negatives, to isolate the packing itself."""
+    starts = torch.cumsum(counts, 0) - counts
+    within = torch.arange(row_ids.numel(), device=row_ids.device) - starts[row_ids]
+    return model.neg_indices_[row_ids, within]
+
+
+def repulsive_packed(model, replay=False):
+    """Evaluate only the negative pairs that survive the per-row budget."""
+    device = model.embedding_.device
+    counts = negative_counts(model)
+    chunk = model.chunk_indices_.numel()
+    grad = torch.zeros(
+        (chunk, model.n_components), device=device, dtype=model.embedding_.dtype
+    )
+
+    row_ids = torch.repeat_interleave(
+        torch.arange(chunk, device=device, dtype=torch.long), counts
+    )
+    if row_ids.numel() == 0:
+        return grad
+    neg_ids = (
+        _replay_draw(model, row_ids, counts) if replay else packed_draw(model, row_ids)
+    )
+
+    diff = model.embedding_[model.chunk_indices_[row_ids]] - model.embedding_[neg_ids]
+    D = _coefficients((diff**2).sum(dim=-1), model)
+
+    grad.index_add_(0, row_ids, diff * D.unsqueeze(1))
+    grad.clamp_(-4, 4)
+    return grad
+
+
+class FusedUMAP(UMAP):
+    def _compute_repulsive_gradients(self):
+        return repulsive_fused(self)
+
+
+class PackedUMAP(UMAP):
+    def on_training_step_start(self):
+        # Skip the eager rectangular draw: the packed budget is only known once
+        # the attractive branch has refreshed ``mask_affinity_in_``.
+        NeighborEmbedding.on_training_step_start(self)
+
+    def _compute_repulsive_gradients(self):
+        return repulsive_packed(self)
+
+
+ARMS = {"baseline": UMAP, "fused": FusedUMAP, "packed": PackedUMAP}
+
+
+# --- Instrumentation -------------------------------------------------------
+
+
+def make_timed(cls):
+    """Wrap an arm with CUDA-event timing and per-phase peak-memory tracking."""
+
+    class Timed(cls):
+        def _init_embedding(self, X):
+            embedding = super()._init_embedding(X)
+            cap = self.max_iter + 1
+            self._i = 0
+            self._events = {
+                key: [
+                    (
+                        torch.cuda.Event(enable_timing=True),
+                        torch.cuda.Event(enable_timing=True),
+                    )
+                    for _ in range(cap)
+                ]
+                for key in ("attractive", "repulsive", "step")
+            }
+            self._peak = {key: [] for key in ("attractive", "repulsive")}
+            self._pairs = torch.zeros(cap, dtype=torch.long, device=self.device_)
+            self._row_max = torch.zeros(cap, dtype=torch.long, device=self.device_)
+            return embedding
+
+        def _compute_attractive_gradients(self):
+            # ``reset_peak_memory_stats`` sets the peak to the currently
+            # allocated bytes, so the per-phase maxima below are comparable and
+            # their maximum is the exact peak of the whole step.
+            torch.cuda.reset_peak_memory_stats()
+            self._events["attractive"][self._i][0].record()
+            grad = super()._compute_attractive_gradients()
+            self._events["attractive"][self._i][1].record()
+            self._peak["attractive"].append(torch.cuda.max_memory_allocated())
+            return grad
+
+        def _compute_repulsive_gradients(self):
+            torch.cuda.reset_peak_memory_stats()
+            self._events["repulsive"][self._i][0].record()
+            grad = super()._compute_repulsive_gradients()
+            self._events["repulsive"][self._i][1].record()
+            self._peak["repulsive"].append(torch.cuda.max_memory_allocated())
+            counts = negative_counts(self)
+            self._pairs[self._i] = counts.sum()
+            # Unclamped, to show whether a per-step maximum-width truncation of
+            # the rectangle would save anything.
+            self._row_max[self._i] = (
+                self.mask_affinity_in_.sum(dim=1) * self.negative_sample_rate
+            ).max()
+            # Captured here: clear_memory() drops chunk_indices_ before
+            # fit_transform returns.
+            self._rect = self.chunk_indices_.numel() * self.n_negatives
+            self._n_negatives = self.n_negatives
+            return grad
+
+        def _training_step(self):
+            self._events["step"][self._i][0].record()
+            out = super()._training_step()
+            self._events["step"][self._i][1].record()
+            self._i += 1
+            return out
+
+        def report(self):
+            torch.cuda.synchronize()
+            n = self._i
+            times = {
+                key: [ev[i][0].elapsed_time(ev[i][1]) for i in range(n)]
+                for key, ev in self._events.items()
+            }
+            peak = {k: int(np.median(v[:n])) for k, v in self._peak.items()}
+            peak["step"] = max(peak["attractive"], peak["repulsive"])
+            row_max = self._row_max[:n].cpu().numpy()
+            return {
+                "n_iter": n,
+                "ms": {k: float(np.median(v)) for k, v in times.items()},
+                "peak_bytes": peak,
+                "neg_pairs": int(np.median(self._pairs[:n].cpu().numpy())),
+                "neg_pairs_rect": int(self._rect),
+                "row_max_median": int(np.median(row_max)),
+                "saturated_iters": float(np.mean(row_max >= self._n_negatives)),
+            }
+
+    Timed.__name__ = f"Timed{cls.__name__}"
+    return Timed
+
+
+# --- Correctness probe -----------------------------------------------------
+
+
+def make_probe(iters):
+    """UMAP that compares every arm against the shipped kernel at ``iters``."""
+
+    class Probe(UMAP):
+        records = []
+
+        def _compute_repulsive_gradients(self):
+            grad = super()._compute_repulsive_gradients()
+            step = int(self.n_iter_.item())
+            if step in iters:
+                self.records.append(self._probe(grad, step))
+            return grad
+
+        def _probe(self, reference, step):
+            counts = negative_counts(self)
+            packed = repulsive_packed(self, replay=True)
+            fused = repulsive_fused(self)
+            record = {
+                "iter": step,
+                "neg_pairs_packed": int(counts.sum().item()),
+                "neg_pairs_rect": int(self.chunk_indices_.numel() * self.n_negatives),
+                "copy_bitwise_equal": bool(
+                    torch.equal(repulsive_baseline(self), reference)
+                ),
+                "fused_bitwise_equal": bool(torch.equal(fused, reference)),
+                "packed_replay_max_abs_err": float(
+                    (packed - reference).abs().max().item()
+                ),
+                "packed_replay_repeat_max_abs_diff": float(
+                    (repulsive_packed(self, replay=True) - packed).abs().max().item()
+                ),
+            }
+            record.update(self._audit_draw())
+            return record
+
+        def _audit_draw(self, rows=256, draws=512):
+            """Check the packed draw never returns an excluded index."""
+            device = self.embedding_.device
+            chunk = self.chunk_indices_.numel()
+            probe_rows = torch.arange(min(rows, chunk), device=device)
+            row_ids = probe_rows.repeat_interleave(draws)
+            drawn = packed_draw(self, row_ids)
+            excluded = self.negative_exclusion_indices_[row_ids]
+            hits = int((drawn.unsqueeze(1) == excluded).any(dim=1).sum().item())
+            in_range = int(
+                ((drawn >= 0) & (drawn < int(self.n_samples_in_))).sum().item()
+            )
+            return {
+                "draw_samples": int(drawn.numel()),
+                "draw_excluded_hits": hits,
+                "draw_out_of_range": int(drawn.numel()) - in_range,
+            }
+
+    Probe.records = []
+    return Probe
+
+
+# --- Data ------------------------------------------------------------------
+
+
+def load_dataset(name, cache_dir, n_samples, seed):
+    os.makedirs(cache_dir, exist_ok=True)
+    cached = os.path.join(cache_dir, f"{name}_pca50.npy")
+    if os.path.exists(cached):
+        X = np.load(cached)
+    else:
+        import requests
+
+        response = requests.get(DATASETS[name], stream=True)
+        response.raise_for_status()
+        with gzip.open(BytesIO(response.content), "rb") as handle:
+            X = pickle.load(handle)["pca_50"].astype("float32")
+        np.save(cached, X)
+    if 0 < n_samples < X.shape[0]:
+        rng = np.random.default_rng(seed)
+        idx = np.sort(rng.choice(X.shape[0], size=n_samples, replace=False))
+        X = np.ascontiguousarray(X[idx])
+    return X
+
+
+# --- Driver ----------------------------------------------------------------
+
+
+def build(cls, args):
+    return cls(
+        n_neighbors=args.n_neighbors,
+        max_iter=args.max_iter,
+        device="cuda",
+        backend="faiss",
+        random_state=args.seed,
+        verbose=False,
+    )
+
+
+def run_arm(name, args, X):
+    cls = make_timed(ARMS[name])
+    walls, reports, embedding = [], [], None
+    for rep in range(args.reps):
+        torch.cuda.empty_cache()
+        model = build(cls, args)
+        torch.cuda.synchronize()
+        start = time.perf_counter()
+        out = model.fit_transform(X)
+        torch.cuda.synchronize()
+        walls.append(time.perf_counter() - start)
+        reports.append(model.report())
+        if rep == 0:
+            embedding = out.detach().clone()
+        del model
+        print(f"  [{name}] rep {rep}: {walls[-1]:.4f} s", flush=True)
+    median = sorted(range(len(walls)), key=lambda i: walls[i])[len(walls) // 2]
+    return {
+        "wall_s": walls,
+        "wall_median_s": statistics.median(walls),
+        "wall_min_s": min(walls),
+        "wall_max_s": max(walls),
+        "timing": reports[median],
+    }, embedding
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dataset", choices=sorted(DATASETS), default="macosko")
+    parser.add_argument("--cache-dir", default="benchmark_data")
+    parser.add_argument("--n-samples", type=int, default=0, help="0 keeps all rows")
+    parser.add_argument("--n-neighbors", type=int, default=30)
+    parser.add_argument("--max-iter", type=int, default=500)
+    parser.add_argument("--reps", type=int, default=3)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--quality-k", type=int, default=15)
+    parser.add_argument("--arms", default="baseline,fused,packed")
+    parser.add_argument("--check", action="store_true", help="run the gradient probe")
+    parser.add_argument("--json", default=None, help="write full results here")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    if not torch.cuda.is_available():
+        raise SystemExit("This benchmark requires a CUDA device.")
+
+    X = torch.from_numpy(
+        load_dataset(args.dataset, args.cache_dir, args.n_samples, args.seed)
+    ).cuda()
+    print(f"{args.dataset}: {tuple(X.shape)} on {torch.cuda.get_device_name(0)}")
+
+    if args.check:
+        iters = {0, 1, args.max_iter // 2, args.max_iter - 1}
+        probe = build(make_probe(iters), args)
+        probe.fit_transform(X)
+        print("\n=== gradient probe ===")
+        for record in probe.records:
+            print(json.dumps(record))
+        del probe
+        torch.cuda.empty_cache()
+
+    # Warm up FAISS and cuBLAS so the first timed arm is not penalized.
+    warmup = build(make_timed(UMAP), args)
+    warmup.max_iter = 20
+    warmup.fit_transform(X)
+    torch.cuda.synchronize()
+    del warmup
+    torch.cuda.empty_cache()
+
+    results, quality = {}, {}
+    for name in args.arms.split(","):
+        print(f"[arm] {name}", flush=True)
+        results[name], embedding = run_arm(name, args, X)
+        quality[name] = float(
+            neighborhood_preservation(
+                X, embedding, K=args.quality_k, backend="faiss", device="cuda"
+            )
+        )
+        print(f"  [{name}] preservation@{args.quality_k} = {quality[name]:.6f}")
+        del embedding
+        torch.cuda.empty_cache()
+
+    base = results.get(args.arms.split(",")[0])
+    header = (
+        f"| arm | wall (s) | vs base | step (ms) | repulsive (ms) | "
+        f"peak step (MB) | peak repulsive (MB) | preservation@{args.quality_k} |"
+    )
+    print("\n" + header)
+    print("|" + "---|" * 8)
+    for name, result in results.items():
+        timing = result["timing"]
+        delta = 100 * (result["wall_median_s"] / base["wall_median_s"] - 1)
+        print(
+            f"| {name} "
+            f"| {result['wall_median_s']:.3f} "
+            f"[{result['wall_min_s']:.3f}, {result['wall_max_s']:.3f}] "
+            f"| {delta:+.2f}% "
+            f"| {timing['ms']['step']:.3f} "
+            f"| {timing['ms']['repulsive']:.3f} "
+            f"| {timing['peak_bytes']['step'] / 1e6:.0f} "
+            f"| {timing['peak_bytes']['repulsive'] / 1e6:.0f} "
+            f"| {quality[name]:.6f} |"
+        )
+    timing = base["timing"]
+    rect, packed = timing["neg_pairs_rect"], timing["neg_pairs"]
+    print(
+        f"\nnegative pairs per iteration (median): packed {packed:,} of "
+        f"rectangular {rect:,} ({100 * packed / rect:.1f}%)"
+    )
+    # A cheaper alternative to packing is to truncate the rectangle to the
+    # widest per-row budget of the step.  It only helps when that width is
+    # below n_negatives, which hub rows in the symmetrized graph rarely allow.
+    print(
+        f"widest per-row budget (median): {timing['row_max_median']:,}; "
+        f"saturates n_negatives in {100 * timing['saturated_iters']:.2f}% of "
+        f"iterations"
+    )
+
+    if args.json:
+        with open(args.json, "w") as handle:
+            json.dump(
+                {
+                    "config": vars(args),
+                    "device": torch.cuda.get_device_name(0),
+                    "torch": torch.__version__,
+                    "n_samples": int(X.shape[0]),
+                    "results": results,
+                    "quality": quality,
+                },
+                handle,
+                indent=2,
+            )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Verdict

**REFUTE** — packing the UMAP negative pairs down to the per-row active budget
is a real but scale-dependent saving that clears neither campaign threshold
across the target range, and it costs reproducibility. No production change is
proposed. This PR adds the benchmark that produced the evidence so the decision
stays re-checkable.

## Hypothesis

`UMAP._compute_repulsive_gradients` draws `n_negatives = negative_sample_rate *
n_neighbors` negatives for every row of the local chunk, evaluates the full
`(chunk, n_negatives)` rectangle, and then zeroes every column past that row's
per-iteration budget `min(active_positive_edges * negative_sample_rate,
n_negatives)`. Computing only the surviving pairs should cut repulsive kernel
time and peak memory, especially later in optimization when the edge schedule
has thinned out.

The campaign also asked to test a cheaper alternative first: truncating the
rectangle to the widest per-row budget of the step, instead of a packed kernel.

## Benchmark design

- Baseline commit: `697d7cb` (`upstream/main`), also the base of this branch.
- Candidate commits: none in `torchdr/`. The two candidate kernels live in the
  added benchmark only.
- Hardware and world size: 1 × NVIDIA B200 (183 GB), driver 580.126.20,
  torch 2.8.0+cu128, `backend="faiss"`, float32, world size 1.
- Datasets: Macosko 2015 (44,808 × 50) and 10x mouse Zheng (1,306,127 × 50 and a
  200,000-row subsample), both the PCA-50 matrices used by
  `benchmarks/benchmark_umap_single_cell.py`.
- `n_neighbors=30` (so `n_negatives=150`), `max_iter=500`, `random_state=0`.
- Repetitions: 3 measured `fit_transform` runs per arm after a 20-iteration
  warm-up; median reported with `[min, max]`. Kernel times come from
  preallocated CUDA events with no host synchronization inside the loop; wall
  times are bracketed by `torch.cuda.synchronize()`.
- Three arms in the same process, on the same device-resident data, same seed,
  same iteration count, so the only difference is the repulsive kernel:
  `baseline` (shipped), `fused` (control: rectangular, but the difference tensor
  is materialized once instead of twice — bitwise identical), `packed`
  (candidate).
- Exact command (per configuration; SLURM jobs `20736835`, `20736277`):

  ```
  python benchmarks/umap_negative_sampling.py \
      --dataset zheng --n-samples 200000 --n-neighbors 30 \
      --max-iter 500 --reps 3 --quality-k 15 \
      --arms baseline,fused,packed --check
  ```

## Results

`step` and `repulsive` are per-iteration CUDA-event medians. `peak step` is the
exact peak allocated bytes of a training step (max of the two phase peaks, each
measured from its own `reset_peak_memory_stats`).

**Macosko, n = 44,808, k = 30** (job `20736835`)

| arm | wall s | Δ wall | step ms | repulsive ms | peak step MB | peak repulsive MB | preservation@15 |
|---|---:|---:|---:|---:|---:|---:|---:|
| baseline | 1.553 [1.547, 1.555] | — | 2.599 | 0.654 | 815 | 574 | 0.147044 |
| fused | 1.484 [1.484, 1.485] | −4.4% | 2.465 | 0.519 | 814 | 600 | 0.147044 |
| packed | 1.518 [1.517, 1.522] | −2.3% | 2.625 | 0.526 | 761 | 466 | 0.148612 |

**Zheng subsample, n = 200,000, k = 30** (job `20736277`)

| arm | wall s | Δ wall | step ms | repulsive ms | peak step MB | peak repulsive MB | preservation@15 |
|---|---:|---:|---:|---:|---:|---:|---:|
| baseline | 7.662 [7.659, 7.665] | — | 13.800 | 2.885 | 5279 | 3524 | 0.078048 |
| fused | 7.398 [7.386, 7.403] | −3.4% | 13.267 | 2.351 | 5279 | 3644 | 0.078048 |
| packed | 6.891 [6.890, 6.898] | **−10.1%** | 12.816 | 1.821 | 5035 | 3041 | 0.078351 |

**Zheng full, n = 1,306,127, k = 30** (job `20736277`)

| arm | wall s | Δ wall | step ms | repulsive ms | peak step MB | peak repulsive MB | preservation@15 |
|---|---:|---:|---:|---:|---:|---:|---:|
| baseline | 77.774 [77.735, 82.805] | — | 125.369 | 19.728 | 51722 | 33250 | 0.029727 |
| fused | 78.173 [76.109, 79.014] | +0.5% | 121.982 | 16.329 | 51753 | 34065 | 0.029727 |
| packed | 72.488 [72.447, 72.512] | −6.8% | 118.217 | 12.467 | 50165 | 30125 | 0.029310 |

An independent earlier job (`20734878`, same measurement code) reproduces the
candidate deltas: macosko −1.3%, Zheng-200k −10.5%, Zheng-1.3M −6.9% wall;
repulsive-branch −20.8% / −37.0% / −36.8%.

**Density, and the cheaper alternative**

| dataset | packed pairs / iter | rectangular pairs / iter | ratio | widest per-row budget (median) | iterations saturating `n_negatives` |
|---|---:|---:|---:|---:|---:|
| macosko 44,808 | 1,998,860 | 6,721,200 | 29.7% | 400 | 99.80% |
| zheng 200,000 | 8,846,277 | 30,000,000 | 29.5% | 525 | 99.80% |
| zheng 1,306,127 | 58,170,182 | 195,919,050 | 29.7% | 825 | 100.00% |

The density is stable at ~30% from the first hundred iterations onward — there
is no "late training gets sparser" effect to exploit. And the widest per-row
budget is 400–825 against `n_negatives = 150`, so **truncating the rectangle to
the step maximum saves nothing in 99.8–100% of iterations**. Hub rows in the
symmetrized k-NN graph accumulate far more than `n_neighbors` active positive
edges and always saturate the cap. The cheap alternative is a dead end; only a
genuinely packed kernel can capture the 70%.

## Correctness and quality

The `--check` probe replays every arm against one identical model state
(embedding, `mask_affinity_in_`, `neg_indices_`, exclusion tables) at iterations
0, 1, 250 and 499. Over the 16 probes taken across all three configurations:

| property | result |
|---|---|
| benchmark's copy of the shipped kernel vs. the real one | bitwise equal, 16/16 |
| `fused` vs. baseline | **bitwise equal, 16/16** |
| `packed` (baseline's own negatives replayed) vs. baseline | ≤ 1.12e-05 max abs |
| `packed` repeated twice on identical state | up to 1.48e-05 max abs |
| packed draw hitting an excluded index | 0 / 2,097,152 draws |
| packed draw out of `[0, n_samples)` | 0 / 2,097,152 draws |

The replay error and the repeat-to-repeat difference are the same order of
magnitude, so the packed arm has no systematic bias — the discrepancy is
`index_add_` reassociation, not different math. That is also the problem: the
scatter is non-deterministic on CUDA, so a packed kernel would make
`random_state` stop producing reproducible embeddings.

Quality is unaffected. Neighborhood preservation @15 moves by −1.4% to +1.1%
relative with no consistent sign, which is the noise floor for a different
negative-sampling stream (one embedding per arm per configuration; see
limitations).

## Decision

Measured against the campaign thresholds:

- **Speed (≥10% median wall).** Met at exactly one of three scales: −10.1% at
  n=200k (−10.5% on replication). Missed at n=44.8k (−2.3%) and at n=1.31M
  (−6.8%). The repulsive branch itself is 20% faster at n=44.8k and ~37% faster
  at both larger sizes, but it is only 16–25% of the training step, and the step
  is 81–90% of the wall clock.
- **Memory (≥15% peak).** Missed everywhere: −6.6% / −4.6% / −3.0% of the
  training-step peak. The repulsive phase does shrink 9–19%, but **the attractive
  branch sets the step peak at every scale measured** (5279 vs 3524 MB at 200k;
  51722 vs 33250 MB at 1.3M), so shrinking the negatives cannot move the process
  peak. Most of the small step-peak gain that does appear is not the packed
  kernel at all — it is the `chunk × n_negatives` int64 `neg_indices_` buffer
  (1.57 GB at n=1.3M) that the packed arm never allocates.
- **Quality.** No loss.

Against that, a packed kernel costs: a changed random stream, a
non-deterministic `index_add_` scatter, a dynamic per-iteration shape that forces
a device→host synchronization (`repeat_interleave` with device-resident counts
must read the total), and roughly 45 lines of index machinery in the hot path.

So: REFUTE the packed kernel as a default. This is not a null result — the
n=200k point is a genuine 10%, and a maintainer may still want it — but it does
not clear the bar consistently, and the reproducibility regression is a user-
contract change that a 7% median win does not buy.

Two findings from this work are worth separate consideration and are **not**
proposed here:

1. The repulsive branch builds the `(chunk, n_negatives, n_components)`
   difference tensor twice — once inside `pairwise_distances_indexed` to get the
   distances, once again for the gradient. The `fused` arm removes the second
   build, is **bitwise identical** to the current output, and is 17–21% faster in
   the repulsive branch at every scale. It is not free: holding `diff` and `D`
   simultaneously raises the repulsive-phase peak by 3–5%, and the end-to-end
   effect (−4.4% / −3.4% / +0.5%) is within wall-clock noise at the largest size.
   A decision on that trade-off belongs in its own PR.
2. `PCA` initialization hard-failed once with
   `torch._C._LinAlgError: linalg.svd: The algorithm failed to converge` on the
   already-decorrelated Macosko PCA-50 matrix (job `20736277`), while the same
   input only emitted the cuSOLVER fallback warning on other runs. Flaky, and
   orthogonal to this point.

## Retained benchmark artifact

`benchmarks/umap_negative_sampling.py` — one file, no changes anywhere else.

- Three arms behind `--arms`, written as plain functions of a fitted model so
  they can be compared against one identical state.
- CUDA-event timing for the attractive branch, the repulsive branch and the
  whole step, plus exact per-phase peak allocated bytes.
- Negative-pair density and the widest-per-row-budget statistic, so the
  "truncate to the step maximum" alternative can be re-refuted on other data.
- `--check` runs the gradient probe and the exclusion/range audit of the packed
  draw.
- Downloads the same two single-cell datasets as the existing UMAP benchmark and
  caches them under `--cache-dir`; `--json` writes the full record.

## Validation

- Pre-commit clean on the added file (`ruff`, `ruff-format`, codespell and the
  rest), SLURM job `20736190`.
- Full test suite on 1 × B200: **485 passed, 13 skipped, 6 xfailed, 6 failed**.
  All six failures are the pre-existing `torchdr/tests/test_dataloader.py`
  FAISS CPU-vs-GPU tolerance failures on this hardware (`Greatest absolute
  difference: 0.00390625`), present on `697d7cb` before this branch. This PR adds
  no importable package code, so it cannot affect them.
  - One unrelated flake was seen once and did not reproduce:
    `test_affinity.py::test_normalized_gibbs_affinity[0-sqeuclidean-float32]`
    failed a `tol=1e-5` float32 marginal check in one run, then passed 3/3 in
    isolation and again in the full suite.
- The committed file was re-run end to end after formatting (jobs `20736835`,
  `20736277`); the numbers above come from that exact revision.
- `git diff --check` clean.

## Risks and limitations

- **Single GPU only.** Everything here is world size 1. The repulsive branch is
  chunk-local and per-rank identical, so distributed results should follow the
  same shape — but note the direction: at world size *w* each rank owns *n/w*
  rows, which moves the workload toward the small-*n* regime where packing gives
  nothing, and the packed kernel adds a per-iteration host synchronization that
  would interleave with the gradient all-reduce. Both push the verdict more
  negative, not less, which is why a multi-GPU run was not required to settle it.
- **One seed per configuration.** The quality column is a single embedding per
  arm, not a distribution. It is reported to show the packed arm does not damage
  the embedding, not to resolve sub-percent quality differences.
- At n=1.3M the wall-clock delta (−5.3 s) exceeds the summed step-time delta
  (500 × 7.15 ms = 3.6 s). The residual is outside the timed windows and is
  consistent with allocator pressure from the 1.57 GB `neg_indices_` buffer the
  packed arm never allocates; it was not isolated further.
- The benchmark is 535 lines, larger than the other files in `benchmarks/`,
  because it carries two alternative kernels and a correctness probe alongside
  the measurement. It is standalone and imports nothing new.
- `--dataset zheng` downloads and unpickles a 1.3M-row file from
  `file.biolab.si`, the same source and mechanism as the existing
  `benchmarks/benchmark_umap_single_cell.py`.
- Results are B200-specific. The density and saturation statistics are
  hardware-independent; the timing ratios are not.
