### PR TITLE
[Fix] Exchange sparse edges with flat all_to_all_single

### DIFF
--- a/.github/workflows/distributed-integration.yml
+++ b/.github/workflows/distributed-integration.yml
@@ -13,6 +13,8 @@ on:
       - "torchdr/distributed/**"
       - "torchdr/spectral_embedding/pca.py"
       - "torchdr/tests/test_distributed_integration.py"
+      - "torchdr/tests/test_distributed_sparse.py"
+      - "torchdr/utils/sparse.py"
   push:
     branches:
       - main
@@ -22,6 +24,8 @@ on:
       - "torchdr/distributed/**"
       - "torchdr/spectral_embedding/pca.py"
       - "torchdr/tests/test_distributed_integration.py"
+      - "torchdr/tests/test_distributed_sparse.py"
+      - "torchdr/utils/sparse.py"
 
 jobs:
   test-distributed-cpu:
@@ -43,3 +47,10 @@ jobs:
           python -m torch.distributed.run --standalone --nnodes=1
           --nproc-per-node=2 -m pytest
           torchdr/tests/test_distributed_integration.py -q
+      - name: Run two-process sparse symmetrization test
+        env:
+          TORCHDR_DISTRIBUTED_TEST: "1"
+        run: >-
+          python -m torch.distributed.run --standalone --nnodes=1
+          --nproc-per-node=2 -m pytest
+          torchdr/tests/test_distributed_sparse.py -q

--- a/torchdr/tests/test_distributed_sparse.py
+++ b/torchdr/tests/test_distributed_sparse.py
@@ -1,0 +1,170 @@
+"""Real-process tests for the distributed sparse symmetrization exchange.
+
+These run on the Gloo CPU backend, which only supports the flat
+``all_to_all_single`` collective. They therefore cover the edge exchange of
+:func:`torchdr.utils.sparse.distributed_symmetrize_sparse` on ordinary CI
+runners, without a GPU or an NCCL process group.
+"""
+
+# Author: Hugues Van Assel <vanasselhugues@gmail.com>
+#
+# License: BSD 3-Clause License
+
+import os
+
+import pytest
+import torch
+import torch.distributed as dist
+
+from torchdr.distributed import DistributedContext
+from torchdr.utils.sparse import distributed_symmetrize_sparse, symmetrize_sparse
+
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("TORCHDR_DISTRIBUTED_TEST") != "1",
+    reason="run through the dedicated multi-process integration workflow",
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def distributed_process_group():
+    """Initialize the process group created by torchrun.
+
+    Fails loudly on a single process: these tests are meaningless unless the
+    edges really cross a rank boundary, and a silent one-rank run would report
+    green while exercising none of the exchange.
+    """
+    dist.init_process_group(backend="gloo")
+    world_size = dist.get_world_size()
+    if world_size < 2:
+        dist.destroy_process_group()
+        pytest.fail(f"launch this module with at least two processes, got {world_size}")
+    yield
+    dist.barrier()
+    dist.destroy_process_group()
+
+
+def _build_graph(n_samples, n_neighbors, seed, dtype):
+    """Deterministic asymmetric sparse graph, identical on every rank."""
+    generator = torch.Generator().manual_seed(seed)
+    indices = torch.randint(
+        0, n_samples, (n_samples, n_neighbors), generator=generator, dtype=torch.long
+    )
+    values = torch.rand(
+        (n_samples, n_neighbors), generator=generator, dtype=torch.float64
+    )
+    return values.to(dtype), indices
+
+
+def _rowwise_to_dense(values, indices, n_columns):
+    """Padded row-wise representation to dense, summing duplicate slots."""
+    dense = torch.zeros((values.shape[0], n_columns), dtype=values.dtype)
+    valid = indices >= 0
+    dense.scatter_add_(1, indices.clamp_min(0), values * valid)
+    return dense
+
+
+def _symmetrize_local_chunk(values, indices, n_samples, mode):
+    """Run the distributed path on this rank's row chunk."""
+    context = DistributedContext()
+    chunk_start, chunk_end = context.compute_chunk_bounds(n_samples)
+    chunk_size = chunk_end - chunk_start
+    assert chunk_size < n_samples, "the rows must be split across ranks"
+
+    out_values, out_indices = distributed_symmetrize_sparse(
+        values[chunk_start:chunk_end].contiguous(),
+        indices[chunk_start:chunk_end].contiguous(),
+        chunk_start=chunk_start,
+        chunk_size=chunk_size,
+        n_total=n_samples,
+        mode=mode,
+    )
+    return chunk_start, chunk_end, out_values, out_indices
+
+
+@pytest.mark.parametrize("mode", ["sum", "sum_minus_prod"])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+@pytest.mark.parametrize(
+    "n_samples, n_neighbors", [(64, 4), (101, 7)], ids=["even", "uneven"]
+)
+def test_chunk_matches_single_process_reference(n_samples, n_neighbors, dtype, mode):
+    """Each rank's rows must equal the single-process symmetrization."""
+    values, indices = _build_graph(n_samples, n_neighbors, seed=n_samples, dtype=dtype)
+
+    chunk_start, chunk_end, out_values, out_indices = _symmetrize_local_chunk(
+        values, indices, n_samples, mode
+    )
+
+    assert out_values.dtype == dtype
+    assert out_indices.dtype == torch.int64
+    assert out_values.shape[0] == chunk_end - chunk_start
+
+    reference_values, reference_indices = symmetrize_sparse(values, indices, mode=mode)
+    torch.testing.assert_close(
+        _rowwise_to_dense(out_values, out_indices, n_samples),
+        _rowwise_to_dense(reference_values, reference_indices, n_samples)[
+            chunk_start:chunk_end
+        ],
+    )
+
+
+def test_gathered_ranks_reconstruct_the_full_matrix():
+    """Concatenating every rank's rows must rebuild the reference matrix."""
+    n_samples, n_neighbors = 101, 7
+    values, indices = _build_graph(n_samples, n_neighbors, seed=7, dtype=torch.float32)
+
+    _, _, out_values, out_indices = _symmetrize_local_chunk(
+        values, indices, n_samples, "sum_minus_prod"
+    )
+    local_dense = _rowwise_to_dense(out_values, out_indices, n_samples)
+
+    gathered = [None] * dist.get_world_size()
+    dist.all_gather_object(gathered, local_dense)
+
+    reference_values, reference_indices = symmetrize_sparse(
+        values, indices, mode="sum_minus_prod"
+    )
+    full = torch.cat(gathered)
+    assert full.shape == (n_samples, n_samples)
+    torch.testing.assert_close(
+        full, _rowwise_to_dense(reference_values, reference_indices, n_samples)
+    )
+    torch.testing.assert_close(full, full.T)
+
+
+def test_skewed_payload_matches_reference():
+    """Very unequal per-rank payloads must exchange correctly.
+
+    Every edge points into the rows owned by the last rank, so all other ranks
+    send their whole edge list to a single peer and receive almost nothing.
+    This is the uneven split-size case of the flat exchange.
+    """
+    n_samples, n_neighbors = 96, 5
+    world_size = dist.get_world_size()
+    last_chunk_start = (n_samples // world_size) * (world_size - 1)
+
+    generator = torch.Generator().manual_seed(11)
+    indices = torch.randint(
+        last_chunk_start,
+        n_samples,
+        (n_samples, n_neighbors),
+        generator=generator,
+        dtype=torch.long,
+    )
+    values = torch.rand(
+        (n_samples, n_neighbors), generator=generator, dtype=torch.float32
+    )
+
+    chunk_start, chunk_end, out_values, out_indices = _symmetrize_local_chunk(
+        values, indices, n_samples, "sum_minus_prod"
+    )
+
+    reference_values, reference_indices = symmetrize_sparse(
+        values, indices, mode="sum_minus_prod"
+    )
+    torch.testing.assert_close(
+        _rowwise_to_dense(out_values, out_indices, n_samples),
+        _rowwise_to_dense(reference_values, reference_indices, n_samples)[
+            chunk_start:chunk_end
+        ],
+    )

--- a/torchdr/tests/test_sparse.py
+++ b/torchdr/tests/test_sparse.py
@@ -28,21 +28,31 @@ def _rowwise_to_dense(values, indices, n_columns):
 
 @pytest.fixture
 def mock_single_rank_collectives(monkeypatch):
-    """Replace distributed collectives with one-rank copies."""
+    """Replace distributed collectives with one-rank copies.
+
+    Returns the dtypes of the payload exchanges, i.e. the calls carrying
+    explicit split sizes, so tests can assert that coordinates and values keep
+    their native dtypes on the wire.
+    """
     exchanged_dtypes = []
 
-    def fake_all_to_all_single(output, input_):
+    def fake_all_to_all_single(
+        output, input_, output_split_sizes=None, input_split_sizes=None
+    ):
+        if input_split_sizes is not None:
+            exchanged_dtypes.append((input_.dtype,))
         output.copy_(input_)
-
-    def fake_all_to_all(outputs, inputs):
-        exchanged_dtypes.append(tuple(tensor.dtype for tensor in inputs))
-        for output, input_ in zip(outputs, inputs):
-            output.copy_(input_)
 
     monkeypatch.setattr(sparse_utils.dist, "is_initialized", lambda: True)
     monkeypatch.setattr(sparse_utils.dist, "get_world_size", lambda: 1)
     monkeypatch.setattr(sparse_utils.dist, "all_to_all_single", fake_all_to_all_single)
-    monkeypatch.setattr(sparse_utils.dist, "all_to_all", fake_all_to_all)
+    monkeypatch.setattr(
+        sparse_utils.dist,
+        "all_to_all",
+        lambda *args, **kwargs: pytest.fail(
+            "the sparse exchange must not use the list-based all_to_all"
+        ),
+    )
     return exchanged_dtypes
 
 

--- a/torchdr/utils/sparse.py
+++ b/torchdr/utils/sparse.py
@@ -251,9 +251,10 @@ def distributed_symmetrize_sparse(
 
     Notes
     -----
-    Edge exchange is performed on the input device. Coalescing and row-wise
-    packing are then performed on CPU to reduce peak accelerator memory. The
-    returned tensors are moved back to the input device.
+    Edge exchange is performed on the input device with ``all_to_all_single``
+    over flat buffers, which both NCCL and the Gloo CPU backend support.
+    Coalescing and row-wise packing are then performed on CPU to reduce peak
+    accelerator memory. The returned tensors are moved back to the input device.
     """
     if not dist.is_initialized():
         raise RuntimeError(
@@ -276,66 +277,36 @@ def distributed_symmetrize_sparse(
     target_sorted = target_ranks[sorted_idx]
     del i, j, target_ranks
 
-    # Step 3: Build separate index/value buffers. Keeping encoded coordinates
-    # as int64 avoids the precision loss caused by packing indices as float32.
-    send_keys = [
-        torch.empty(0, device=device, dtype=torch.long) for _ in range(world_size)
-    ]
-    send_values = [
-        torch.empty(0, device=device, dtype=v.dtype) for _ in range(world_size)
-    ]
+    # Step 3: Derive the per-rank split sizes. The edges are already ordered by
+    # owning rank, so the boundaries are just the insertion points of the rank
+    # labels and the sorted buffers double as flat send buffers.
+    boundaries = torch.arange(world_size + 1, device=device)
+    send_offsets = torch.searchsorted(target_sorted, boundaries)
+    send_counts = send_offsets[1:] - send_offsets[:-1]
+    recv_counts = torch.empty_like(send_counts)
+    dist.all_to_all_single(recv_counts, send_counts)
+    send_splits = send_counts.tolist()
+    recv_splits = recv_counts.tolist()
+    del boundaries, send_offsets, send_counts, recv_counts, target_sorted, sorted_idx
 
-    if target_sorted.numel() > 0:
-        unique_targets, counts = torch.unique_consecutive(
-            target_sorted, return_counts=True
-        )
-        offsets = torch.cat([torch.tensor([0], device=device), counts.cumsum(0)])
+    # Step 4: Exchange exact integer coordinates and values without dtype casts.
+    # Keeping encoded coordinates as int64 avoids the precision loss caused by
+    # packing indices as float32. One contiguous buffer per payload keeps the
+    # allocation and host-synchronization count independent of the world size
+    # and, unlike the list-based all_to_all, is supported by the Gloo backend.
+    n_received = sum(recv_splits)
+    transpose_keys = torch.empty(n_received, device=device, dtype=torch.long)
+    transpose_values = torch.empty(n_received, device=device, dtype=v.dtype)
+    dist.all_to_all_single(transpose_keys, keys_sorted, recv_splits, send_splits)
+    dist.all_to_all_single(transpose_values, values_sorted, recv_splits, send_splits)
+    del keys_sorted, values_sorted, send_splits, recv_splits
 
-        for idx, r in enumerate(unique_targets.tolist()):
-            start = offsets[idx].item()
-            end = offsets[idx + 1].item()
-            if end > start and r < world_size:
-                send_keys[r] = keys_sorted[start:end]
-                send_values[r] = values_sorted[start:end]
-
-    # Step 4: Exchange sizes and allocate exact receive buffers.
-    send_sizes = torch.tensor(
-        [tensor.numel() for tensor in send_keys], device=device, dtype=torch.long
-    )
-    recv_sizes = torch.zeros(world_size, device=device, dtype=torch.long)
-    dist.all_to_all_single(recv_sizes, send_sizes)
-
-    recv_keys = [
-        torch.empty(size.item(), device=device, dtype=torch.long) for size in recv_sizes
-    ]
-    recv_values = [
-        torch.empty(size.item(), device=device, dtype=v.dtype) for size in recv_sizes
-    ]
-
-    # Step 5: Exchange exact integer coordinates and values without dtype casts.
-    dist.all_to_all(recv_keys, send_keys)
-    dist.all_to_all(recv_values, send_values)
-    del (
-        send_keys,
-        send_values,
-        send_sizes,
-        recv_sizes,
-        keys_sorted,
-        values_sorted,
-        target_sorted,
-        sorted_idx,
-    )
-
-    # Step 6: Offload local and received edges before the memory-heavy unique.
+    # Step 5: Offload local and received edges before the memory-heavy unique.
     local_keys = keys.cpu()
     local_values = v.cpu()
     del keys, v
-    for rank in range(world_size):
-        recv_keys[rank] = recv_keys[rank].cpu()
-        recv_values[rank] = recv_values[rank].cpu()
-    transpose_keys = torch.cat(recv_keys)
-    transpose_values = torch.cat(recv_values)
-    del recv_keys, recv_values
+    transpose_keys = transpose_keys.cpu()
+    transpose_values = transpose_values.cpu()
 
     # Received keys encode original (i, j) entries. Rewrite them in place as
     # (j, i), retaining their provenance as Pᵀ rather than treating them as P.
@@ -343,7 +314,7 @@ def distributed_symmetrize_sparse(
     transpose_keys.remainder_(n_total).mul_(n_total).add_(received_rows)
     del received_rows
 
-    # Step 7: Coalesce P and Pᵀ separately. This is both correct for reciprocal
+    # Step 6: Coalesce P and Pᵀ separately. This is both correct for reciprocal
     # edges and avoids duplicating the already combined edge list a second time.
     i_sym, j_sym, vP, vPT = _merge_sparse_keys(
         local_keys,
@@ -354,7 +325,7 @@ def distributed_symmetrize_sparse(
     )
     del local_keys, local_values, transpose_keys, transpose_values
 
-    # Step 8: Combine components on CPU and pack the rows owned by this rank.
+    # Step 7: Combine components on CPU and pack the rows owned by this rank.
     v_sym = _combine_P_PT(vP, vPT, mode)
     del vP, vPT
     local_mask = (i_sym >= chunk_start) & (i_sym < chunk_start + chunk_size)
@@ -363,5 +334,5 @@ def distributed_symmetrize_sparse(
     v_local = v_sym[local_mask]
     values_out, indices_out = pack_to_rowwise(i_local, j_local, v_local, chunk_size)
 
-    # Step 9: Restore the caller's device contract.
+    # Step 8: Restore the caller's device contract.
     return values_out.to(device), indices_out.to(device)


### PR DESCRIPTION
## Verdict

**APPROVE.** The list-based `all_to_all` is replaced by flat `all_to_all_single` over contiguous buffers. This turns a hard `RuntimeError` on the Gloo CPU backend into exact correctness, makes the exchange region 1.6–3.9x faster, cuts CUDA synchronization points from `O(world_size)` to a constant 4, and deletes 30 net lines.

The approval rests on **capability and correctness coverage**, not on end-to-end speed. End-to-end runtime of `distributed_symmetrize_sparse` is unchanged within noise, because the CPU coalescing step dominates. That is stated explicitly below rather than buried.

## Hypothesis

Concatenated payload buffers plus split sizes reduce Python and allocation overhead while enabling a Gloo CPU integration path.

## Problem

`distributed_symmetrize_sparse` built one send tensor per rank and shipped them with `dist.all_to_all`. That collective is implemented for NCCL only. On any CPU process group the function failed outright:

```
RuntimeError: Backend gloo does not support alltoall
```

Measured on the unmodified `main` (`697d7cb`) with a 6-case correctness harness: **0/6 cases pass under Gloo**, 6/6 under NCCL. The consequence is that the whole distributed symmetrization path was untestable on GPU-less CI runners.

## Change

The edges are already sorted by owning rank, so the split sizes are just the insertion points of the rank labels, and the sorted buffers are usable directly as flat send buffers:

- `torch.searchsorted` over the sorted rank labels derives `send_counts` deterministically. No `bincount` (CUDA-atomics nondeterminism), no `unique_consecutive` + per-rank `.item()` loop.
- Two `all_to_all_single` calls exchange the encoded int64 coordinates and the values, each in one contiguous buffer, keeping their native dtypes on the wire.
- The per-rank send slicing, the per-rank receive allocations, and the final `torch.cat` of the received chunks are all removed.

Net effect on `torchdr/utils/sparse.py`: **+26 / -56**.

## Benchmark design

`bench_exchange.py` runs two arms over identical sorted inputs inside one process, so the arms differ only in transport and their outputs must be bitwise identical:

- `list` — the pre-change path: per-rank lists, `all_to_all`, per-rank D2H copies, `torch.cat`.
- `flat` — this PR: split sizes, two `all_to_all_single`, one D2H copy per payload.

Real B200 GPUs, NCCL, `k=30`, float32, median of 5 reps after 1 warmup, barrier- and CUDA-synchronized. Sync points counted with `torch.cuda.set_sync_debug_mode("warn")`; host RSS peak sampled from `/proc/self/statm`. The shipped function is also timed end to end against a separate checkout of unmodified `main`, in the same allocation, so the hardware is identical.

## Results

Exchange region, per-rank median ms (range over all ranks and both checkouts):

| world | n | local edges | payload | `all_to_all` | `all_to_all_single` | speedup |
|---|---|---|---|---|---|---|
| 2 | 50 000 | 750 k | 8.6 MB | 3.65–3.85 | 0.93–0.96 | **3.9x** |
| 2 | 200 000 | 3.0 M | 34 MB | 6.75–8.02 | 2.81–3.04 | **2.4x** |
| 2 | 1 000 000 | 15.0 M | 172 MB | 138.9–178.1 | 102.4–104.4 | **1.6x** |
| 4 | 50 000 | 375 k | 4.3 MB | 1.89–2.04 | 0.64–0.74 | **2.9x** |
| 4 | 200 000 | 1.5 M | 17 MB | 4.27–4.73 | 1.62–1.82 | **2.6x** |
| 4 | 1 000 000 | 7.5 M | 86 MB | 17.8–20.0 | 6.8–7.4 | **2.7x** |

CUDA synchronization points inside the region, identical at every size:

| world | `all_to_all` | `all_to_all_single` |
|---|---|---|
| 2 | 16 | **4** |
| 4 | 28 | **4** |

The list path costs `6 * world_size + 4` synchronizations; the flat path is constant, which is the main reason the advantage does not decay as ranks are added.

Host RSS peak inside the region at 15 M edges drops from 2232–2311 MB to 2091–2197 MB, consistent with eliminating the `torch.cat` duplicate of the 172 MB received payload.

End-to-end `distributed_symmetrize_sparse`, median of 3, world 2:

| n | main | this PR | delta |
|---|---|---|---|
| 50 000 | 136.7 / 158.4 ms | 145.3 / 166.6 ms | +5% (noise) |
| 200 000 | 1022.4 / 1063.3 ms | 1066.0 / 1028.6 ms | mixed sign (noise) |
| 1 000 000 | 6702.2 / 6711.4 ms | 6672.2 / 6557.5 ms | -0.4% / -2.3% |

GPU peak allocated is **byte-identical** (70.0 / 275.9 / 1377.3 MB), as is peak reserved. Host RSS peak end to end is a wash.

**Read this honestly:** the exchange is only ~1.5–2.5% of the end-to-end call, which is dominated by the CPU `torch.unique` coalescing over 30 M keys. A 37–74% saving on 2% of the runtime is invisible against run-to-run variance. This PR does not claim an end-to-end speedup. The coalescing cost is a separate question.

## Correctness

- **Transport equivalence:** the two arms produced bitwise-identical keys and values in **all 24 benchmark records** (12 at world 2, 12 at world 4). Both layouts group received data by source rank in the same order.
- **NCCL:** 6/6 correctness cases pass at `max_abs_err = 0.0` against a single-process reference, unchanged from `main`.
- **Gloo:** **0/6 before → 6/6 after** at world 2 and 6/6 at world 4, all at `max_abs_err = 0.0`.
- Cases cover even and uneven row splits, `sum` and `sum_minus_prod`, float32 and float64, and n up to 1024 with k up to 16.

## Test coverage added

`torchdr/tests/test_distributed_sparse.py` — real two-process Gloo tests, which only become possible because of this change. 10 tests per rank:

- each rank's rows equal the single-process `symmetrize_sparse` reference, parametrized over 2 modes x 2 dtypes x even/uneven splits;
- the gathered ranks reconstruct the full matrix, and it is symmetric;
- a fully skewed payload where every edge targets the last rank's rows, exercising the extreme uneven split-size path.

The module fails loudly if launched on a single process, so it can never go green while silently exercising nothing. The existing `test_sparse.py` fixture now asserts the exchange does **not** fall back to the list-based `all_to_all`.

The workflow runs the new module as a separate torchrun step, deliberately not appended to the existing pytest target, so two module-scoped `init_process_group` fixtures never collide in one pytest run.

## Limitations

- End-to-end runtime and peak memory are unchanged; only the exchange region improves. See above.
- Benchmarked at world 2 and 4 on a single node. Multi-node interconnect behaviour is not measured.
- `all_to_all_single` requires the payload to be contiguous per destination rank. That holds here because the edges are sorted by owning rank in the preceding step; it is not a general property.
- The Gloo tests use small graphs (n <= 101) to stay inside a CPU runner's budget. Large-index integrity remains covered by the existing single-rank `test_large_indices_are_not_rounded`, which now exercises `all_to_all_single`.

## Interaction with #294 — please read before merging

This is the one place these branches genuinely collide, and it needs a follow-up whichever way you merge.

#294 adds `_SimulatedProcessGroup.all_to_all_single(self, output, input_)` — a two-argument signature with no split-size support — plus an `all_to_all` method. This PR calls `all_to_all_single` with four positional arguments and never calls `all_to_all`.

Git will merge the two diffs textually, since #294 is a pure insertion and this PR edits a different hunk. But **the result will not run**: the simulated group would raise `TypeError` on the split-size arguments. Whichever of the two merges second needs `_SimulatedProcessGroup.all_to_all_single` taught to honour `output_split_sizes` / `input_split_sizes`; its `all_to_all` can then be dropped.

Both branches are independently based on `697d7cb` and neither is stacked on the other. Tell me the merge order you want and I will push the reconciling change to the second one.

## Reproduce

```bash
# correctness, both backends, 6 cases
torchrun --standalone --nnodes=1 --nproc-per-node=2 exchange_case.py --backend gloo
torchrun --standalone --nnodes=1 --nproc-per-node=2 exchange_case.py --backend nccl

# the two transport arms, same allocation, both checkouts
torchrun --standalone --nnodes=1 --nproc-per-node=4 bench_exchange.py \
    --sizes 50000,200000,1000000 --k 30 --reps 5

# the new CI step, exactly as the workflow runs it
TORCHDR_DISTRIBUTED_TEST=1 python -m torch.distributed.run --standalone \
    --nnodes=1 --nproc-per-node=2 -m pytest torchdr/tests/test_distributed_sparse.py -q
```

## Validation

- `pytest torchdr/tests/test_sparse.py` — 15 passed
- `pytest torchdr/tests/test_distributed.py torchdr/tests/test_distributed_pca.py` — 32 passed
- new module under torchrun, Gloo, CPU-only — 10 passed per rank at both 2 and 4 processes
- existing `test_distributed_integration.py` under torchrun — 1 passed per rank, unaffected
- `pre-commit run --all-files` — all hooks pass
