### PR TITLE
[Fix] Reuse FAISS GPU resources with correct device streams

### DIFF
--- a/benchmarks/faiss/.gitignore
+++ b/benchmarks/faiss/.gitignore
@@ -1,4 +1,5 @@
 # Benchmark outputs
 *.csv
+*.json
 *.png
 *.pdf

--- a/benchmarks/faiss/gpu_resource_lifecycle.py
+++ b/benchmarks/faiss/gpu_resource_lifecycle.py
@@ -1,0 +1,196 @@
+"""Benchmark repeated exact k-NN searches on one GPU.
+
+Measures what FAISS GPU resource ownership costs: the first-call initialization,
+the steady-state search time of the calls that follow, the peak memory the
+device holds while they run, and how much stays resident afterwards. FAISS
+allocates its temporary pool outside the PyTorch caching allocator, so device
+occupancy is read from ``torch.cuda.mem_get_info`` rather than from
+``max_memory_allocated``.
+
+Three modes cover how TorchDR reaches FAISS in practice:
+
+- ``fresh-config``: a new ``FaissConfig`` per call, which is what every
+  ``backend="faiss"`` estimator does.
+- ``shared-config``: one ``FaissConfig`` reused across calls.
+- ``affinity``: repeated ``UMAPAffinity`` fits, an end-to-end path that adds
+  normalization and symmetrization on top of the search.
+
+Run the same command on the base commit and on the branch to compare. Each mode
+prints and persists its row as soon as it finishes, so a failure in a later mode
+does not discard earlier results. The run also prints the resolved ``torchdr``
+package path, because an editable install can shadow the checkout under test.
+
+Usage:
+    PYTHONPATH=$(git rev-parse --show-toplevel) python gpu_resource_lifecycle.py \
+        --n 200000 --d 128 --k 15 --repeats 20 --output results.json
+"""
+
+import argparse
+import json
+import resource
+import statistics
+import time
+
+import torch
+
+import torchdr
+from torchdr.affinity import UMAPAffinity
+from torchdr.distance import FaissConfig, pairwise_distances
+
+MODES = ("fresh-config", "shared-config", "affinity")
+ROW = "{:<14}{:>10}{:>10}{:>10}{:>10}{:>9}{:>9}{:>9}"
+
+
+def device_used_mb() -> float:
+    """Megabytes occupied on the current CUDA device, including FAISS' own pools."""
+    free, total = torch.cuda.mem_get_info()
+    return (total - free) / 1024**2
+
+
+def host_peak_mb() -> float:
+    """Peak resident set size of this process, in megabytes."""
+    return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
+
+
+def run_mode(name, call, repeats):
+    """Time ``call`` ``repeats`` times and return its summary and last result.
+
+    Occupancy is sampled after every call, then once more with the result
+    dropped and the PyTorch cache released, which leaves only what FAISS still
+    holds on the device.
+    """
+    torch.cuda.synchronize()
+    durations = []
+    peak_mb = 0.0
+    result = None
+
+    for _ in range(repeats):
+        start = time.perf_counter()
+        result = call()
+        torch.cuda.synchronize()
+        durations.append(time.perf_counter() - start)
+        peak_mb = max(peak_mb, device_used_mb())
+
+    scratch, result = result, None
+    torch.cuda.empty_cache()
+    torch.cuda.synchronize()
+
+    steady = durations[1:] or durations
+    return {
+        "mode": name,
+        "calls": len(durations),
+        "first_call_s": durations[0],
+        "steady_median_s": statistics.median(steady),
+        "steady_mean_s": statistics.fmean(steady),
+        "steady_max_s": max(steady),
+        "total_s": sum(durations),
+        "peak_device_mb": peak_mb,
+        "resident_device_mb": device_used_mb(),
+        "peak_host_mb": host_peak_mb(),
+    }, scratch
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--n", type=int, default=200_000, help="database size")
+    parser.add_argument("--d", type=int, default=128, help="dimension")
+    parser.add_argument("--k", type=int, default=15, help="neighbors per query")
+    parser.add_argument("--repeats", type=int, default=20, help="calls per mode")
+    parser.add_argument(
+        "--affinity-repeats", type=int, default=5, help="UMAPAffinity fits"
+    )
+    parser.add_argument("--modes", nargs="+", choices=MODES, default=list(MODES))
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--label", type=str, default="", help="provenance label")
+    parser.add_argument("--output", type=str, default=None, help="JSON output path")
+    args = parser.parse_args()
+
+    if not torch.cuda.is_available():
+        raise SystemExit("This benchmark requires a CUDA device.")
+
+    torch.manual_seed(args.seed)
+    X = torch.randn(args.n, args.d, device="cuda")
+    torch.cuda.synchronize()
+
+    report = {
+        "n": args.n,
+        "d": args.d,
+        "k": args.k,
+        "repeats": args.repeats,
+        "seed": args.seed,
+        "label": args.label,
+        "gpu": torch.cuda.get_device_name(0),
+        "torchdr_path": torchdr.__file__,
+        "data_only_device_mb": device_used_mb(),
+        "modes": [],
+    }
+
+    print(f"n={args.n} d={args.d} k={args.k} repeats={args.repeats} seed={args.seed}")
+    print(f"label={args.label or '-'} gpu={report['gpu']}")
+    print(f"torchdr={report['torchdr_path']}")
+    print(f"data_only_device_mb={report['data_only_device_mb']:.0f}")
+    print(
+        ROW.format(
+            "mode", "first", "median", "mean", "total", "peakMB", "residMB", "hostMB"
+        )
+    )
+
+    calls = {
+        "fresh-config": (
+            lambda: pairwise_distances(
+                X,
+                k=args.k,
+                backend=FaissConfig(),
+                return_indices=True,
+                exclude_diag=True,
+            ),
+            args.repeats,
+        ),
+        "shared-config": (
+            lambda config=FaissConfig(): pairwise_distances(
+                X, k=args.k, backend=config, return_indices=True, exclude_diag=True
+            ),
+            args.repeats,
+        ),
+        "affinity": (
+            lambda: UMAPAffinity(n_neighbors=args.k, backend="faiss", verbose=False)(X),
+            args.affinity_repeats,
+        ),
+    }
+
+    neighbors = {}
+    for name in args.modes:
+        call, repeats = calls[name]
+        summary, result = run_mode(name, call, repeats)
+        report["modes"].append(summary)
+        print(
+            ROW.format(
+                summary["mode"],
+                f"{summary['first_call_s']:.4f}",
+                f"{summary['steady_median_s']:.4f}",
+                f"{summary['steady_mean_s']:.4f}",
+                f"{summary['total_s']:.4f}",
+                f"{summary['peak_device_mb']:.0f}",
+                f"{summary['resident_device_mb']:.0f}",
+                f"{summary['peak_host_mb']:.0f}",
+            )
+        )
+        if name in ("fresh-config", "shared-config"):
+            neighbors[name] = result[1]
+        if args.output:
+            with open(args.output, "w") as handle:
+                json.dump(report, handle, indent=2)
+
+    if len(neighbors) == 2:
+        agree = torch.equal(*neighbors.values())
+        report["indices_agree_across_modes"] = agree
+        print(f"indices agree across modes: {agree}")
+
+    if args.output:
+        with open(args.output, "w") as handle:
+            json.dump(report, handle, indent=2)
+        print(f"wrote {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/torchdr/distance/faiss.py
+++ b/torchdr/distance/faiss.py
@@ -8,7 +8,7 @@ import torch
 import numpy as np
 import warnings
 from weakref import WeakKeyDictionary
-from typing import Union, Optional, Dict, Any, Tuple, List
+from typing import Union, Optional, Any, Tuple, List
 
 from torch.utils.data import (
     DataLoader,
@@ -18,6 +18,11 @@ from torch.utils.data import (
 )
 
 from torchdr.utils.faiss import faiss, faiss_torch_interop
+from torchdr.utils.faiss_runtime import (
+    faiss_device_scope,
+    faiss_gpu_available,
+    get_gpu_resources,
+)
 
 LIST_METRICS_FAISS = ["euclidean", "sqeuclidean", "angular"]
 
@@ -121,7 +126,10 @@ class FaissConfig:
         - 'auto': Use FAISS default temporary memory pool (typically a fixed size)
         - float/int: Explicit size in GB (e.g., 2.0 for 2GB)
         - 0: Disable pre-allocation (use cudaMalloc on demand)
-        Only applies to GPU mode.
+        Only applies to GPU mode. The pool belongs to the process rather than to
+        this config: the first search on a device sizes it and it stays resident
+        until the process exits, so a later config asking for a different
+        explicit size resizes the shared pool for every subsequent search.
     device : int, default=0
         GPU device ID to use.
         Only applies when input is on CUDA.
@@ -151,11 +159,6 @@ class FaissConfig:
         index config objects (e.g., for advanced memory management).
         Use at your own risk - some options may degrade result quality.
 
-    Attributes
-    ----------
-    gpu_resources : Dict[int, Any]
-        Dictionary mapping device IDs to their GPU resources (created on demand).
-
     Examples
     --------
     >>> # Basic configuration
@@ -179,11 +182,16 @@ class FaissConfig:
     Notes
     -----
     - Increasing temp_memory helps with large batch operations but reduces memory
-      available for data storage
+      available for data storage. FAISS defaults to a pool of roughly 1.5GB per
+      device, which the first GPU search allocates and the process then keeps.
+      Set temp_memory explicitly to bound it on a shared device.
     - IVF indexes trade accuracy for speed and are recommended for datasets > 10M vectors
     - IVFPQ provides significant memory savings (e.g., 128D float32 vectors: 512 bytes
       -> ~32 bytes with M=16, nbits=8) at the cost of some accuracy
     - For IVFPQ, ensure the vector dimension is divisible by M
+    - The configuration is plain data. FAISS GPU resources are owned by the
+      process, not by the configuration, so a config stays copyable and
+      picklable after it has been used on a GPU.
     """
 
     def __init__(
@@ -205,7 +213,6 @@ class FaissConfig:
         self.M = M
         self.nbits = nbits
         self.faiss_kwargs = kwargs
-        self.gpu_resources: Dict[int, Any] = {}
 
     def __repr__(self):
         parts = [
@@ -220,6 +227,12 @@ class FaissConfig:
         if self.faiss_kwargs:
             parts.append(f"**{self.faiss_kwargs}")
         return f"FaissConfig({', '.join(parts)})"
+
+
+def _index_device_id(config: FaissConfig) -> int:
+    """CUDA ordinal the FAISS index runs on. A sequence selects its first device."""
+    device = config.device
+    return int(device) if isinstance(device, int) else int(device[0])
 
 
 def remove_self_neighbors(
@@ -448,23 +461,21 @@ def pairwise_distances_faiss(
     else:
         compute_device = torch.device(device)
 
-    use_gpu_index = compute_device.type == "cuda" and hasattr(
-        faiss, "StandardGpuResources"
-    )
+    use_gpu_index = compute_device.type == "cuda" and faiss_gpu_available()
+    # Device the index lives on, or None when FAISS stays on the host.
+    faiss_device = None
     if compute_device.type == "cuda":
         if use_gpu_index:
             index = _setup_gpu_index(index, config, d)
+            faiss_device = torch.device("cuda", _index_device_id(config))
         else:
             warnings.warn(
                 "[TorchDR] WARNING: `faiss-gpu` not installed, using CPU for Faiss computations. "
                 "This may be slow. For faster performance, install `faiss-gpu`."
             )
 
-    if use_gpu_index and faiss_torch_interop:
-        device_id = (
-            config.device if isinstance(config.device, int) else config.device[0]
-        )
-        index_device = torch.device("cuda", device_id)
+    if faiss_device is not None and faiss_torch_interop:
+        index_device = faiss_device
     else:
         index_device = torch.device("cpu")
 
@@ -475,26 +486,31 @@ def pairwise_distances_faiss(
         X_faiss = X_faiss.cpu().numpy()
         Y_faiss = Y_faiss.cpu().numpy()
 
-    if needs_training and not index.is_trained:
-        train_data = Y_faiss
-        max_train_points = 256 * config.nlist
-        if len(Y_faiss) > max_train_points:
-            sample_indices = np.random.choice(
-                len(Y_faiss), max_train_points, replace=False
-            )
-            if isinstance(Y_faiss, torch.Tensor):
-                sample_indices = torch.as_tensor(sample_indices, device=Y_faiss.device)
-            train_data = Y_faiss[sample_indices]
-        index.train(train_data)
-
-    index.add(Y_faiss)
-
     if do_exclude:
         k_search = k + 1
     else:
         k_search = k
 
-    D, Ind = index.search(X_faiss, k_search)
+    # Every FAISS call runs with the index device current, which is what makes
+    # FAISS adopt the PyTorch stream holding the writes to X_faiss and Y_faiss.
+    with faiss_device_scope(faiss_device):
+        if needs_training and not index.is_trained:
+            train_data = Y_faiss
+            max_train_points = 256 * config.nlist
+            if len(Y_faiss) > max_train_points:
+                sample_indices = np.random.choice(
+                    len(Y_faiss), max_train_points, replace=False
+                )
+                if isinstance(Y_faiss, torch.Tensor):
+                    sample_indices = torch.as_tensor(
+                        sample_indices, device=Y_faiss.device
+                    )
+                train_data = Y_faiss[sample_indices]
+            index.train(train_data)
+
+        index.add(Y_faiss)
+
+        D, Ind = index.search(X_faiss, k_search)
 
     if metric == "euclidean":
         if isinstance(D, torch.Tensor):
@@ -537,19 +553,15 @@ def _setup_gpu_index(index, config: FaissConfig, d: int):
     -------
     gpu_index : faiss.GpuIndex
         Configured GPU index.
+
+    Notes
+    -----
+    The resource is owned by the process rather than by ``config``, so repeated
+    calls on the same device reuse one temporary memory pool and a config stays
+    free of live FAISS objects.
     """
-    device_id = config.device if isinstance(config.device, int) else config.device[0]
-
-    if device_id not in config.gpu_resources:
-        res = faiss.StandardGpuResources()
-
-        if config.temp_memory != "auto":
-            temp_memory_bytes = int(config.temp_memory * 1024**3)
-            res.setTempMemory(temp_memory_bytes)
-
-        config.gpu_resources[device_id] = res
-    else:
-        res = config.gpu_resources[device_id]
+    device_id = _index_device_id(config)
+    res = get_gpu_resources(device_id, config.temp_memory)
 
     if isinstance(index, faiss.IndexFlatL2) or isinstance(index, faiss.IndexFlatIP):
         flat_config = faiss.GpuIndexFlatConfig()
@@ -794,7 +806,7 @@ def _build_index_from_dataloader(
 
                 # Move to GPU if needed
                 if compute_device.type == "cuda":
-                    if hasattr(faiss, "StandardGpuResources"):
+                    if faiss_gpu_available():
                         index = _setup_gpu_index(index, config, d)
                     else:
                         warnings.warn(
@@ -840,7 +852,7 @@ def _build_index_from_dataloader(
 
             # Move to GPU if needed
             if compute_device.type == "cuda":
-                if hasattr(faiss, "StandardGpuResources"):
+                if faiss_gpu_available():
                     index = _setup_gpu_index(index, config, d)
                 else:
                     warnings.warn(

--- a/torchdr/distance/faiss.py
+++ b/torchdr/distance/faiss.py
@@ -126,10 +126,8 @@ class FaissConfig:
         - 'auto': Use FAISS default temporary memory pool (typically a fixed size)
         - float/int: Explicit size in GB (e.g., 2.0 for 2GB)
         - 0: Disable pre-allocation (use cudaMalloc on demand)
-        Only applies to GPU mode. The pool belongs to the process rather than to
-        this config: the first search on a device sizes it and it stays resident
-        until the process exits, so a later config asking for a different
-        explicit size resizes the shared pool for every subsequent search.
+        Only applies to GPU mode. The pool belongs to the calling thread rather
+        than to this config: searches on the same thread and device reuse it.
     device : int, default=0
         GPU device ID to use.
         Only applies when input is on CUDA.
@@ -183,15 +181,18 @@ class FaissConfig:
     -----
     - Increasing temp_memory helps with large batch operations but reduces memory
       available for data storage. FAISS defaults to a pool of roughly 1.5GB per
-      device, which the first GPU search allocates and the process then keeps.
-      Set temp_memory explicitly to bound it on a shared device.
+      device, which the first GPU search allocates and the calling thread keeps.
+      Set temp_memory explicitly to bound it.
     - IVF indexes trade accuracy for speed and are recommended for datasets > 10M vectors
     - IVFPQ provides significant memory savings (e.g., 128D float32 vectors: 512 bytes
       -> ~32 bytes with M=16, nbits=8) at the cost of some accuracy
     - For IVFPQ, ensure the vector dimension is divisible by M
     - The configuration is plain data. FAISS GPU resources are owned by the
-      process, not by the configuration, so a config stays copyable and
-      picklable after it has been used on a GPU.
+      calling thread, not by the configuration, so a config stays copyable and
+      picklable after it has been used on a GPU. Resources are not shared across
+      threads because FAISS does not make ``StandardGpuResources`` thread-safe.
+      Consequently, concurrent CPU threads targeting the same GPU each keep a
+      separate temporary pool.
     """
 
     def __init__(
@@ -556,9 +557,9 @@ def _setup_gpu_index(index, config: FaissConfig, d: int):
 
     Notes
     -----
-    The resource is owned by the process rather than by ``config``, so repeated
-    calls on the same device reuse one temporary memory pool and a config stays
-    free of live FAISS objects.
+    The resource is owned by the calling thread rather than by ``config``, so
+    repeated calls on the same thread and device reuse one temporary memory pool
+    while a config stays free of live FAISS objects.
     """
     device_id = _index_device_id(config)
     res = get_gpu_resources(device_id, config.temp_memory)

--- a/torchdr/eval/kmeans.py
+++ b/torchdr/eval/kmeans.py
@@ -13,6 +13,7 @@ from typing import Union, Optional
 
 from torchdr.utils import to_torch
 from torchdr.utils.faiss import faiss
+from torchdr.utils.faiss_runtime import faiss_gpu_available, get_gpu_resources
 
 try:
     from torchmetrics.clustering import AdjustedRandScore
@@ -40,7 +41,10 @@ def _fit_faiss_kmeans_tensor(
         return None
 
     if use_gpu:
-        resources = faiss.StandardGpuResources()
+        device_id = X.device.index
+        if device_id is None:
+            device_id = torch.cuda.current_device()
+        resources = get_gpu_resources(device_id)
         dataset = DatasetAssignGPU(resources, X)
     else:
         dataset = DatasetAssign(X)
@@ -196,7 +200,7 @@ def kmeans_ari(
         else int(np.random.default_rng().integers(2**31))
     )
 
-    use_gpu = (device.type == "cuda") and hasattr(faiss, "StandardGpuResources")
+    use_gpu = (device.type == "cuda") and faiss_gpu_available()
 
     if X.dtype != torch.float32:
         warnings.warn(

--- a/torchdr/tests/test_faiss_runtime.py
+++ b/torchdr/tests/test_faiss_runtime.py
@@ -1,0 +1,241 @@
+"""Tests for the process-level FAISS GPU runtime and its stream contract."""
+
+# Author: Hugues Van Assel <vanasselhugues@gmail.com>
+#
+# License: BSD 3-Clause License
+
+import copy
+import pickle
+
+import pytest
+import torch
+from torch.testing import assert_close
+
+from torchdr.distance import FaissConfig, pairwise_distances
+from torchdr.distance.faiss import pairwise_distances_faiss
+from torchdr.utils import faiss
+from torchdr.utils.faiss_runtime import (
+    faiss_device_scope,
+    faiss_gpu_available,
+    get_gpu_resources,
+    reset_gpu_resources,
+)
+
+requires_faiss = pytest.mark.skipif(not faiss, reason="faiss is not available")
+requires_faiss_gpu = pytest.mark.skipif(
+    not faiss or not torch.cuda.is_available() or not faiss_gpu_available(),
+    reason="requires CUDA and a faiss-gpu build",
+)
+requires_two_gpus = pytest.mark.skipif(
+    not faiss
+    or not faiss_gpu_available()
+    or not torch.cuda.is_available()
+    or torch.cuda.device_count() < 2,
+    reason="requires two CUDA devices and a faiss-gpu build",
+)
+
+
+@pytest.fixture(autouse=True)
+def clean_runtime():
+    """No test may observe or leak another test's FAISS resources."""
+    reset_gpu_resources()
+    yield
+    reset_gpu_resources()
+
+
+class _FakeResources:
+    """Stand-in for ``StandardGpuResources`` recording temp-memory requests."""
+
+    def __init__(self):
+        self.temp_memory_calls = []
+
+    def setTempMemory(self, size):  # noqa: N802 - mirrors the FAISS spelling
+        self.temp_memory_calls.append(size)
+
+
+class _FakeFaiss:
+    StandardGpuResources = _FakeResources
+
+
+@pytest.fixture
+def fake_faiss(monkeypatch):
+    """Drive the runtime with a fake FAISS module, so it is testable on CPU."""
+    monkeypatch.setattr("torchdr.utils.faiss_runtime.faiss", _FakeFaiss)
+
+
+# ====== resource ownership ======
+
+
+def test_missing_gpu_support_raises_an_actionable_error(monkeypatch):
+    monkeypatch.setattr("torchdr.utils.faiss_runtime.faiss", object())
+
+    assert not faiss_gpu_available()
+    with pytest.raises(RuntimeError, match="no GPU support"):
+        get_gpu_resources(0)
+
+
+def test_one_resource_per_device_never_shared_across_devices(fake_faiss):
+    assert get_gpu_resources(0) is get_gpu_resources(0)
+    assert get_gpu_resources(0) is not get_gpu_resources(1)
+
+
+def test_explicit_temp_memory_is_applied_once_and_auto_keeps_the_pool(fake_faiss):
+    res = get_gpu_resources(0, temp_memory=2.0)
+    get_gpu_resources(0, temp_memory=2.0)
+    assert res.temp_memory_calls == [int(2.0 * 1024**3)]
+
+    # 'auto' must not shrink a pool an earlier caller sized.
+    get_gpu_resources(0, temp_memory="auto")
+    assert res.temp_memory_calls == [int(2.0 * 1024**3)]
+
+    get_gpu_resources(0, temp_memory=1.0)
+    assert res.temp_memory_calls[-1] == 1024**3
+
+
+def test_reset_releases_every_resource(fake_faiss):
+    first = get_gpu_resources(0)
+    reset_gpu_resources()
+
+    assert get_gpu_resources(0) is not first
+
+
+# ====== configuration holds no runtime state ======
+
+
+@requires_faiss
+def test_config_stays_plain_data_after_a_search():
+    config = FaissConfig()
+    X = torch.randn(64, 8)
+
+    pairwise_distances(X, k=5, backend=config, device="cpu")
+
+    assert not any(
+        type(value).__module__.startswith("faiss") for value in vars(config).values()
+    )
+    assert repr(config) == repr(FaissConfig())
+    for clone in (copy.deepcopy(config), pickle.loads(pickle.dumps(config))):
+        assert vars(clone) == vars(config)
+
+
+@requires_faiss_gpu
+def test_config_holds_no_gpu_resources_after_a_gpu_search():
+    config = FaissConfig()
+    X = torch.randn(256, 16, device="cuda")
+
+    pairwise_distances(X, k=5, backend=config)
+
+    assert vars(config) == vars(FaissConfig())
+    assert pickle.loads(pickle.dumps(config)).index_type == "Flat"
+
+
+@requires_faiss_gpu
+def test_repeated_searches_share_one_resource():
+    X = torch.randn(512, 16, device="cuda")
+
+    pairwise_distances(X, k=5, backend="faiss")
+    resources = get_gpu_resources(0)
+    pairwise_distances(X, k=5, backend=FaissConfig())
+
+    assert get_gpu_resources(0) is resources
+
+
+# ====== same-device tensors reach FAISS without a host copy ======
+
+
+@requires_faiss_gpu
+def test_gpu_search_makes_no_host_copy(monkeypatch):
+    from torchdr.utils.faiss import faiss_torch_interop
+
+    if not faiss_torch_interop:
+        pytest.skip("installed FAISS does not provide PyTorch interoperability")
+
+    host_copies = []
+    original_cpu = torch.Tensor.cpu
+
+    def counting_cpu(self, *args, **kwargs):
+        host_copies.append(tuple(self.shape))
+        return original_cpu(self, *args, **kwargs)
+
+    X = torch.randn(512, 16, device="cuda")
+    monkeypatch.setattr(torch.Tensor, "cpu", counting_cpu)
+    distances, indices = pairwise_distances_faiss(X, k=5)
+
+    assert host_copies == []
+    assert distances.device.type == "cuda"
+    assert indices.device.type == "cuda"
+
+
+# ====== stream and device scoping ======
+
+
+@pytest.mark.parametrize("device", [None, torch.device("cpu")])
+def test_device_scope_is_a_no_op_off_cuda(device):
+    with faiss_device_scope(device):
+        pass
+
+
+@requires_two_gpus
+def test_device_scope_enters_the_index_device_and_restores_the_previous_one():
+    with torch.cuda.device(0):
+        with faiss_device_scope(torch.device("cuda", 1)):
+            assert torch.cuda.current_device() == 1
+        assert torch.cuda.current_device() == 0
+
+
+def _queued_work(base, rotation, n_steps=32):
+    """Enough asynchronous work that a racing read would observe stale memory."""
+    out = base
+    for _ in range(n_steps):
+        out = torch.tanh(out @ rotation)
+    return out
+
+
+@requires_faiss_gpu
+def test_search_consumes_writes_issued_on_a_non_default_stream():
+    """add/search must be ordered behind tensor writes on the caller's stream."""
+    generator = torch.Generator(device="cuda").manual_seed(0)
+    base = torch.randn(20000, 64, device="cuda", generator=generator)
+    rotation = torch.randn(64, 64, device="cuda", generator=generator) / 8.0
+
+    torch.cuda.synchronize()
+    reference = _queued_work(base, rotation)
+    expected_distances, expected_indices = pairwise_distances_faiss(reference, k=10)
+    torch.cuda.synchronize()
+
+    stream = torch.cuda.Stream()
+    with torch.cuda.stream(stream):
+        X = _queued_work(base, rotation)
+        distances, indices = pairwise_distances_faiss(X, k=10)
+        # Consuming the outputs on the same stream must also be ordered.
+        checksum = distances.sum()
+    torch.cuda.synchronize()
+
+    assert torch.isfinite(checksum)
+    assert torch.equal(indices, expected_indices)
+    assert_close(distances, expected_distances)
+
+
+@requires_two_gpus
+def test_search_on_a_secondary_device_uses_that_device_stream():
+    """The index device drives the stream even when another device is current."""
+    generator = torch.Generator(device="cuda:1").manual_seed(0)
+    base = torch.randn(20000, 64, device="cuda:1", generator=generator)
+    rotation = torch.randn(64, 64, device="cuda:1", generator=generator) / 8.0
+    config = FaissConfig(device=1)
+
+    torch.cuda.synchronize()
+    reference = _queued_work(base, rotation)
+    expected_distances, expected_indices = pairwise_distances_faiss(
+        reference, k=10, config=config
+    )
+    torch.cuda.synchronize()
+
+    stream = torch.cuda.Stream(device="cuda:1")
+    with torch.cuda.device(0), torch.cuda.stream(stream):
+        X = _queued_work(base, rotation)
+        distances, indices = pairwise_distances_faiss(X, k=10, config=config)
+    torch.cuda.synchronize()
+
+    assert distances.device == torch.device("cuda", 1)
+    assert torch.equal(indices, expected_indices)
+    assert_close(distances, expected_distances)

--- a/torchdr/tests/test_faiss_runtime.py
+++ b/torchdr/tests/test_faiss_runtime.py
@@ -1,4 +1,4 @@
-"""Tests for the process-level FAISS GPU runtime and its stream contract."""
+"""Tests for the thread-local FAISS GPU runtime and its stream contract."""
 
 # Author: Hugues Van Assel <vanasselhugues@gmail.com>
 #
@@ -6,6 +6,7 @@
 
 import copy
 import pickle
+import threading
 
 import pytest
 import torch
@@ -79,20 +80,36 @@ def test_one_resource_per_device_never_shared_across_devices(fake_faiss):
     assert get_gpu_resources(0) is not get_gpu_resources(1)
 
 
-def test_explicit_temp_memory_is_applied_once_and_auto_keeps_the_pool(fake_faiss):
+def test_resources_are_not_shared_across_threads(fake_faiss):
+    main_resource = get_gpu_resources(0)
+    worker_resources = []
+
+    def get_twice():
+        worker_resources.extend([get_gpu_resources(0), get_gpu_resources(0)])
+
+    worker = threading.Thread(target=get_twice)
+    worker.start()
+    worker.join()
+
+    assert worker_resources[0] is worker_resources[1]
+    assert worker_resources[0] is not main_resource
+
+
+def test_explicit_temp_memory_is_applied_once_and_auto_restores_default(fake_faiss):
     res = get_gpu_resources(0, temp_memory=2.0)
     get_gpu_resources(0, temp_memory=2.0)
     assert res.temp_memory_calls == [int(2.0 * 1024**3)]
 
-    # 'auto' must not shrink a pool an earlier caller sized.
-    get_gpu_resources(0, temp_memory="auto")
-    assert res.temp_memory_calls == [int(2.0 * 1024**3)]
+    auto_res = get_gpu_resources(0, temp_memory="auto")
+    assert auto_res is not res
+    assert auto_res.temp_memory_calls == []
 
-    get_gpu_resources(0, temp_memory=1.0)
-    assert res.temp_memory_calls[-1] == 1024**3
+    res = get_gpu_resources(0, temp_memory=1.0)
+    assert res is auto_res
+    assert res.temp_memory_calls == [1024**3]
 
 
-def test_reset_releases_every_resource(fake_faiss):
+def test_reset_releases_calling_thread_resources(fake_faiss):
     first = get_gpu_resources(0)
     reset_gpu_resources()
 

--- a/torchdr/utils/faiss_runtime.py
+++ b/torchdr/utils/faiss_runtime.py
@@ -1,0 +1,105 @@
+"""Process-level ownership of FAISS GPU resources."""
+
+# Author: Hugues Van Assel <vanasselhugues@gmail.com>
+#
+# License: BSD 3-Clause License
+
+import contextlib
+import threading
+from typing import Any, Dict, Optional, Union
+
+import torch
+
+from torchdr.utils.faiss import faiss
+
+# One FAISS resource per CUDA device, owned by the process for its lifetime.
+# ``StandardGpuResources`` holds a temporary memory pool, a pinned host buffer
+# and per-device CUDA state, so building one per search costs both time and
+# device memory. This is runtime state, never user configuration: it is not
+# copied, pickled, or reachable from an estimator's parameters.
+_LOCK = threading.Lock()
+_RESOURCES: Dict[int, Any] = {}
+_TEMP_MEMORY: Dict[int, Union[str, float]] = {}
+
+
+def faiss_gpu_available() -> bool:
+    """Whether the installed FAISS build can create GPU indexes."""
+    return bool(faiss) and hasattr(faiss, "StandardGpuResources")
+
+
+def get_gpu_resources(device_id: int, temp_memory: Union[str, float] = "auto") -> Any:
+    """Return this process' FAISS GPU resource for ``device_id``.
+
+    Parameters
+    ----------
+    device_id : int
+        CUDA device ordinal the resource serves.
+    temp_memory : str or float, default='auto'
+        Size in GB of the FAISS temporary memory pool, or ``'auto'`` to keep
+        whatever pool FAISS already sized. An explicit size is applied only when
+        it differs from the size in force for that device. ``'auto'`` never
+        resizes an existing pool: FAISS exposes no call that restores its own
+        default, so honouring it would shrink a pool an earlier caller asked for.
+
+    Returns
+    -------
+    resources : faiss.StandardGpuResources
+        The resource owned by this process for ``device_id``.
+    """
+    if not faiss_gpu_available():
+        raise RuntimeError(
+            "[TorchDR] The installed FAISS build has no GPU support. "
+            "Install `faiss-gpu` to run FAISS on CUDA devices."
+        )
+
+    device_id = int(device_id)
+
+    with _LOCK:
+        res = _RESOURCES.get(device_id)
+        if res is None:
+            res = faiss.StandardGpuResources()
+            _RESOURCES[device_id] = res
+            _TEMP_MEMORY[device_id] = "auto"
+
+        if temp_memory != "auto" and temp_memory != _TEMP_MEMORY[device_id]:
+            res.setTempMemory(int(float(temp_memory) * 1024**3))
+            _TEMP_MEMORY[device_id] = temp_memory
+
+        return res
+
+
+def reset_gpu_resources() -> None:
+    """Release every FAISS GPU resource held by this process.
+
+    Frees the temporary memory pools without waiting for interpreter shutdown.
+    Intended for tests, which must not leak resources across cases.
+    """
+    with _LOCK:
+        _RESOURCES.clear()
+        _TEMP_MEMORY.clear()
+
+
+@contextlib.contextmanager
+def faiss_device_scope(device: Optional[torch.device]):
+    """Make ``device`` current so FAISS and PyTorch agree on the CUDA stream.
+
+    ``faiss.contrib.torch_utils`` wraps every ``train``/``add``/``search`` call
+    in ``using_stream``, which binds the resource to ``torch.cuda.current_stream()``
+    of ``torch.cuda.current_device()``. That binding is what orders FAISS behind
+    the writes PyTorch made to the input tensors, but it targets the current
+    device, so an index living on another device keeps its own FAISS stream and
+    can read writes that have not completed. Entering the index device first
+    keeps both libraries on one stream, which is the only synchronization the
+    tensor interoperability path needs.
+
+    Parameters
+    ----------
+    device : torch.device or None
+        Device the FAISS index lives on. ``None`` and CPU devices are no-ops.
+    """
+    if device is None or device.type != "cuda":
+        yield
+        return
+
+    with torch.cuda.device(device):
+        yield

--- a/torchdr/utils/faiss_runtime.py
+++ b/torchdr/utils/faiss_runtime.py
@@ -1,4 +1,4 @@
-"""Process-level ownership of FAISS GPU resources."""
+"""Thread-local ownership of FAISS GPU resources."""
 
 # Author: Hugues Van Assel <vanasselhugues@gmail.com>
 #
@@ -6,20 +6,30 @@
 
 import contextlib
 import threading
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional, Tuple, Union
 
 import torch
 
 from torchdr.utils.faiss import faiss
 
-# One FAISS resource per CUDA device, owned by the process for its lifetime.
+# One FAISS resource per CUDA device and calling CPU thread. FAISS documents
+# ``StandardGpuResources`` as not thread-safe because its temporary memory can
+# only have one user at a time. A thread may, and should, share its resource
+# between the GPU indexes it creates on the same device.
 # ``StandardGpuResources`` holds a temporary memory pool, a pinned host buffer
 # and per-device CUDA state, so building one per search costs both time and
-# device memory. This is runtime state, never user configuration: it is not
-# copied, pickled, or reachable from an estimator's parameters.
-_LOCK = threading.Lock()
-_RESOURCES: Dict[int, Any] = {}
-_TEMP_MEMORY: Dict[int, Union[str, float]] = {}
+# device memory. This runtime state is never user configuration: it is not
+# copied, pickled, or reachable from an estimator's parameters. Thread-local
+# ownership also releases a worker's resources when that thread exits.
+_STATE = threading.local()
+
+
+def _thread_state() -> Tuple[Dict[int, Any], Dict[int, Union[str, float]]]:
+    """Return the resource and temp-memory maps for the calling thread."""
+    if not hasattr(_STATE, "resources"):
+        _STATE.resources = {}
+        _STATE.temp_memory = {}
+    return _STATE.resources, _STATE.temp_memory
 
 
 def faiss_gpu_available() -> bool:
@@ -28,7 +38,7 @@ def faiss_gpu_available() -> bool:
 
 
 def get_gpu_resources(device_id: int, temp_memory: Union[str, float] = "auto") -> Any:
-    """Return this process' FAISS GPU resource for ``device_id``.
+    """Return this thread's FAISS GPU resource for ``device_id``.
 
     Parameters
     ----------
@@ -36,15 +46,15 @@ def get_gpu_resources(device_id: int, temp_memory: Union[str, float] = "auto") -
         CUDA device ordinal the resource serves.
     temp_memory : str or float, default='auto'
         Size in GB of the FAISS temporary memory pool, or ``'auto'`` to keep
-        whatever pool FAISS already sized. An explicit size is applied only when
-        it differs from the size in force for that device. ``'auto'`` never
-        resizes an existing pool: FAISS exposes no call that restores its own
-        default, so honouring it would shrink a pool an earlier caller asked for.
+        FAISS' default pool. An explicit size is applied only when it differs
+        from the size in force for that device. Returning to ``'auto'`` after an
+        explicit size recreates the resource because FAISS exposes no method to
+        restore its version- and device-dependent default.
 
     Returns
     -------
     resources : faiss.StandardGpuResources
-        The resource owned by this process for ``device_id``.
+        The resource owned by the calling thread for ``device_id``.
     """
     if not faiss_gpu_available():
         raise RuntimeError(
@@ -54,29 +64,31 @@ def get_gpu_resources(device_id: int, temp_memory: Union[str, float] = "auto") -
 
     device_id = int(device_id)
 
-    with _LOCK:
-        res = _RESOURCES.get(device_id)
-        if res is None:
-            res = faiss.StandardGpuResources()
-            _RESOURCES[device_id] = res
-            _TEMP_MEMORY[device_id] = "auto"
+    resources, temp_memory_by_device = _thread_state()
+    res = resources.get(device_id)
+    current_temp_memory = temp_memory_by_device.get(device_id)
 
-        if temp_memory != "auto" and temp_memory != _TEMP_MEMORY[device_id]:
-            res.setTempMemory(int(float(temp_memory) * 1024**3))
-            _TEMP_MEMORY[device_id] = temp_memory
+    if res is None or (temp_memory == "auto" and current_temp_memory != "auto"):
+        res = faiss.StandardGpuResources()
+        resources[device_id] = res
+        temp_memory_by_device[device_id] = "auto"
 
-        return res
+    if temp_memory != "auto" and temp_memory != temp_memory_by_device[device_id]:
+        res.setTempMemory(int(float(temp_memory) * 1024**3))
+        temp_memory_by_device[device_id] = temp_memory
+
+    return res
 
 
 def reset_gpu_resources() -> None:
-    """Release every FAISS GPU resource held by this process.
+    """Release FAISS GPU resources held by the calling thread.
 
     Frees the temporary memory pools without waiting for interpreter shutdown.
     Intended for tests, which must not leak resources across cases.
     """
-    with _LOCK:
-        _RESOURCES.clear()
-        _TEMP_MEMORY.clear()
+    resources, temp_memory_by_device = _thread_state()
+    resources.clear()
+    temp_memory_by_device.clear()
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
## Summary

- Reuse one FAISS GPU resource per calling CPU thread and CUDA device instead of constructing one for every search.
- Keep live FAISS handles out of `FaissConfig`, preserving copy and pickle behavior.
- Run FAISS train, add, and search operations with the index device current so FAISS's PyTorch wrappers select the correct CUDA stream.
- Route GPU K-means through the same resource accessor.

## Motivation

TorchDR commonly creates a fresh `FaissConfig` for each affinity or neighbor search. Constructing `StandardGpuResources` each time repeatedly creates temporary GPU and pinned-host buffers. The benchmark isolates roughly 95 ms of setup per call on one B200.

FAISS GPU resources cannot be shared safely between concurrent CPU threads. The cache is therefore thread-local, following FAISS's documented threading contract, while still reusing resources across repeated indexes created by the same thread. A configuration remains plain data rather than becoming an owner of runtime handles.

The stream correction addresses searches on a configured CUDA device that differs from the process's current device. FAISS's PyTorch interoperability wrapper chooses the current PyTorch stream of the current CUDA device; entering the index device before each operation makes that choice unambiguous.

## Benchmark

`benchmarks/faiss/gpu_resource_lifecycle.py` compares new and reused configurations plus repeated `UMAPAffinity` fits. Baseline and candidate were staged on node-local storage and run on the same NVIDIA B200 with FAISS 1.11.0.

Steady-state median seconds per call:

| Workload | main | this PR |
| --- | ---: | ---: |
| 50k × 64 exact search, fresh config | 0.1098 | 0.0206 |
| 50k × 64 `UMAPAffinity` fit | 0.1260 | 0.0336 |
| 200k × 128 exact search, fresh config | 0.4694 | 0.3713 |
| 200k × 128 `UMAPAffinity` fit | 0.4874 | 0.3867 |
| 1M × 128 exact search, fresh config | 9.3372 | 9.2291 |

Neighbor indices agreed across all measured call patterns and arm orders. The benefit is largest for repeated small and medium searches; at one million rows, search time dominates resource setup.

## Memory trade-off

The default FAISS temporary pool remains resident for the lifetime of the calling thread. In the benchmark this was about 1.6 GB on the B200. Concurrent CPU threads targeting the same GPU each require a separate pool because `StandardGpuResources` is not thread-safe. `FaissConfig.temp_memory` can bound the pool. Returning from an explicit size to `"auto"` recreates the resource so configuration behavior does not depend on an earlier call.

## Validation

- Added coverage for same-thread reuse, cross-thread isolation, independent devices, memory-pool configuration and reset, config copy/pickle behavior, host-copy avoidance, CUDA device restoration, and non-default-stream ordering.
- Two-B200 validation of the original device/stream implementation: 13 passed.
- Validation after the thread-safety correction: affected CPU suite 289 passed, 20 skipped.
- `pre-commit run --all-files` and `git diff --check` pass.
- GitHub CI validates CPU, minimal-dependency, FAISS, Windows, macOS, documentation, and coverage configurations.

## Limitations

- This PR does not add reusable FAISS indexes, multi-GPU replication/sharding, or automatic batching; those are tracked independently.
- Process-resident memory becomes thread-resident memory to satisfy FAISS's concurrency requirements. Applications using many CPU threads against one GPU should set `temp_memory` deliberately.

Closes #303
