### PR TITLE
[Fix] Stream DataLoader batches into FAISS without a NumPy round trip

### DIFF
--- a/benchmarks/faiss/BENCHMARK_RESULTS.md
+++ b/benchmarks/faiss/BENCHMARK_RESULTS.md
@@ -103,5 +103,6 @@ sample now being staged on the device rather than on the host.
 
 **Key insight**: tensor staging pays off most on the IVF build, where the
 training and add passes dominate, and regrouping pays off most when the loader
-batch is small. Setting `pin_memory=True` on the DataLoader did not help, since
-the streaming path already uploads through a pinned buffer of its own.
+batch is small. A follow-up comparison found no benefit from managing a second
+pinned buffer and CUDA event inside TorchDR, so the implementation leaves
+pinning to the DataLoader and uses PyTorch's direct transfer otherwise.

--- a/benchmarks/faiss/BENCHMARK_RESULTS.md
+++ b/benchmarks/faiss/BENCHMARK_RESULTS.md
@@ -72,3 +72,36 @@ Benchmarks run on NVIDIA B200 GPU with 128-dimensional vectors, k=15 neighbors.
 3. **IVFPQ**: Best for memory-constrained scenarios. Recall is limited by PQ compression (~20-30% on clustered data).
 
 4. **nlist selection**: Follow FAISS guidelines: `4*sqrt(n)` to `16*sqrt(n)` where n is dataset size.
+
+# DataLoader Streaming
+
+`dataloader_streaming.py` measures the whole DataLoader path, from staging a
+host batch to the final neighbors: the build pass that trains and adds every
+batch, the query pass that searches them back, peak process RSS, and peak
+device occupancy. Run it on two revisions to compare them.
+
+n=300000, k=15, B200, median of 3 runs. "per batch" hands each loader batch
+to FAISS unchanged; "auto" regroups batches into calls of 65536 rows.
+
+| Index | d | Loader batch | NumPy staging (s) | Tensor, per batch (s) | Tensor, auto (s) |
+|-------|-----|--------------|-------------------|-----------------------|------------------|
+| Flat | 64 | 1024 | 2.314 | 2.351 | 2.110 |
+| Flat | 64 | 16384 | 3.110 | 2.988 | 3.059 |
+| Flat | 128 | 1024 | 2.526 | 2.602 | 2.315 |
+| Flat | 128 | 16384 | 3.145 | 3.061 | 3.068 |
+| IVF | 64 | 1024 | 2.844 | 2.617 | 2.469 |
+| IVF | 64 | 16384 | 3.742 | 3.499 | 3.348 |
+| IVF | 128 | 1024 | 3.087 | 2.913 | 2.702 |
+| IVF | 128 | 16384 | 3.834 | 3.784 | 3.615 |
+
+Repeating a NumPy-staging arm at the end of the same allocation reproduced the
+1024-row cases to within 0.7% and the 16384-row cases to within 6.6%, so only
+the 1024-row column separates the arms with confidence. Neighbors agreed
+exactly in every case. Peak RSS was unchanged; peak device memory was unchanged
+for Flat and grew by about 270 MB for IVF at d=128, which is the training
+sample now being staged on the device rather than on the host.
+
+**Key insight**: tensor staging pays off most on the IVF build, where the
+training and add passes dominate, and regrouping pays off most when the loader
+batch is small. Setting `pin_memory=True` on the DataLoader did not help, since
+the streaming path already uploads through a pinned buffer of its own.

--- a/benchmarks/faiss/dataloader_streaming.py
+++ b/benchmarks/faiss/dataloader_streaming.py
@@ -1,0 +1,332 @@
+"""Benchmark k-NN over a DataLoader, from batch staging to final neighbors.
+
+The DataLoader path streams host batches into a FAISS index, so what it costs
+is decided as much by how a batch reaches the index as by the search itself.
+This measures the whole path: the build pass that trains and adds every batch,
+the query pass that searches them back, the peak resident set of the process,
+and the peak occupancy of the device. FAISS allocates outside the PyTorch
+caching allocator, so device memory is read from ``torch.cuda.mem_get_info``
+rather than from ``max_memory_allocated``.
+
+Timing and memory are collected in separate passes: the memory sampler polls
+from another thread and would otherwise perturb the numbers it sits next to.
+
+Run the same command on the base commit and on the branch to compare NumPy
+staging with tensor-native staging. Each row is printed and persisted as soon
+as it finishes, so a failure in a later case does not discard earlier results.
+The run also prints the resolved ``torchdr`` package path, because an editable
+install can shadow the checkout under test.
+
+Usage:
+    PYTHONPATH=$(git rev-parse --show-toplevel) python dataloader_streaming.py \
+        --n 500000 --d 128 --batch-sizes 1024 8192 65536 --output results.json
+"""
+
+import argparse
+import inspect
+import json
+import os
+import statistics
+import threading
+import time
+
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+
+import torchdr
+from torchdr.distance import FaissConfig, pairwise_distances
+from torchdr.distance import faiss as faiss_module
+
+ROW = "{:<12}{:>8}{:>16}{:>9}{:>9}{:>9}{:>9}{:>9}{:>7}"
+PAGE_SIZE = os.sysconf("SC_PAGE_SIZE")
+
+
+def device_used_mb() -> float:
+    """Megabytes occupied on the current CUDA device, including FAISS' own pools."""
+    free, total = torch.cuda.mem_get_info()
+    return (total - free) / 1024**2
+
+
+def host_rss_mb() -> float:
+    """Resident set size of this process right now, in megabytes."""
+    with open("/proc/self/statm") as handle:
+        pages = int(handle.read().split()[1])
+    return pages * PAGE_SIZE / 1024**2
+
+
+class MemorySampler:
+    """Poll host and device occupancy while a call runs."""
+
+    def __init__(self, device: int, interval: float = 0.01):
+        self.device = device
+        self.interval = interval
+        self.host_mb = 0.0
+        self.device_mb = 0.0
+        self._done = threading.Event()
+        self._thread = threading.Thread(target=self._poll, daemon=True)
+
+    def _poll(self):
+        torch.cuda.set_device(self.device)
+        while not self._done.is_set():
+            self.host_mb = max(self.host_mb, host_rss_mb())
+            self.device_mb = max(self.device_mb, device_used_mb())
+            self._done.wait(self.interval)
+
+    def start(self):
+        self._thread.start()
+
+    def stop(self):
+        self._done.set()
+        self._thread.join()
+
+
+def instrument():
+    """Time the build and query passes wherever the module defines them.
+
+    The two passes are private helpers whose names and signatures differ across
+    the revisions being compared, so they are wrapped by name and called
+    through, rather than invoked directly.
+    """
+    totals = {"build_s": 0.0, "search_s": 0.0}
+    originals = {}
+
+    def wrap(name, key):
+        original = getattr(faiss_module, name, None)
+        if original is None:
+            return
+        originals[name] = original
+
+        def timed(*args, **kwargs):
+            torch.cuda.synchronize()
+            start = time.perf_counter()
+            result = original(*args, **kwargs)
+            torch.cuda.synchronize()
+            totals[key] += time.perf_counter() - start
+            return result
+
+        setattr(faiss_module, name, timed)
+
+    wrap("_build_index_from_dataloader", "build_s")
+    wrap("_search_all_from_dataloader", "search_s")
+    wrap("_search_from_dataloader", "search_s")
+    return totals, originals
+
+
+def restore(originals):
+    """Undo :func:`instrument`."""
+    for name, original in originals.items():
+        setattr(faiss_module, name, original)
+
+
+def timed_call(call, repeats):
+    """Run ``call`` and return per-pass timings, the best total, and the result."""
+    totals, originals = instrument()
+    try:
+        durations = []
+        phases = []
+        result = None
+        for _ in range(repeats):
+            before = dict(totals)
+            torch.cuda.synchronize()
+            start = time.perf_counter()
+            result = call()
+            torch.cuda.synchronize()
+            durations.append(time.perf_counter() - start)
+            phases.append({k: totals[k] - before[k] for k in totals})
+    finally:
+        restore(originals)
+
+    median = statistics.median(durations)
+    closest = min(phases, key=lambda p: abs(sum(p.values()) - median))
+    return {
+        "total_s": median,
+        "total_min_s": min(durations),
+        "build_s": closest["build_s"],
+        "search_s": closest["search_s"],
+        "repeats": repeats,
+    }, result
+
+
+def sampled_call(call, device):
+    """Run ``call`` once while sampling occupancy, and return the peaks."""
+    torch.cuda.synchronize()
+    sampler = MemorySampler(device)
+    sampler.start()
+    try:
+        call()
+    finally:
+        torch.cuda.synchronize()
+        sampler.stop()
+    return {"peak_device_mb": sampler.device_mb, "peak_host_mb": sampler.host_mb}
+
+
+def neighbor_agreement(reference, indices) -> float:
+    """Fraction of neighbors shared with the reference, averaged over queries."""
+    reference = reference.cpu()
+    indices = indices.cpu()
+    hits = (reference.unsqueeze(2) == indices.unsqueeze(1)).any(dim=2).sum()
+    return float(hits) / reference.numel()
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--n", type=int, default=500_000, help="database size")
+    parser.add_argument("--d", type=int, nargs="+", default=[64, 128], help="dimension")
+    parser.add_argument(
+        "--batch-sizes", type=int, nargs="+", default=[1024, 8192, 65536]
+    )
+    parser.add_argument("--k", type=int, default=15, help="neighbors per query")
+    parser.add_argument("--repeats", type=int, default=3, help="timed runs per case")
+    parser.add_argument(
+        "--stream-rows",
+        type=int,
+        nargs="*",
+        default=[],
+        help="extra runs with an explicit FAISS call size, where supported",
+    )
+    parser.add_argument(
+        "--no-regroup-arm",
+        action="store_true",
+        help="add a run whose FAISS call size is the loader's batch size",
+    )
+    parser.add_argument("--index-type", type=str, nargs="+", default=["Flat"])
+    parser.add_argument("--pin-memory", action="store_true")
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--label", type=str, default="", help="provenance label")
+    parser.add_argument("--output", type=str, default=None, help="JSON output path")
+    args = parser.parse_args()
+
+    if not torch.cuda.is_available():
+        raise SystemExit("This benchmark requires a CUDA device.")
+
+    device = torch.cuda.current_device()
+    supports_stream_rows = (
+        "stream_batch_size" in inspect.signature(FaissConfig).parameters
+    )
+
+    report = {
+        "n": args.n,
+        "k": args.k,
+        "index_types": args.index_type,
+        "pin_memory": args.pin_memory,
+        "repeats": args.repeats,
+        "seed": args.seed,
+        "label": args.label,
+        "gpu": torch.cuda.get_device_name(device),
+        "torchdr_path": torchdr.__file__,
+        "supports_stream_batch_size": supports_stream_rows,
+        "rows": [],
+    }
+
+    index_types = " ".join(args.index_type)
+    print(f"n={args.n} k={args.k} index={index_types} repeats={args.repeats}")
+    print(f"label={args.label or '-'} gpu={report['gpu']}")
+    print(f"torchdr={report['torchdr_path']}")
+    print(f"stream_batch_size supported: {supports_stream_rows}")
+    print(
+        ROW.format(
+            "case",
+            "batch",
+            "stream",
+            "build",
+            "search",
+            "total",
+            "gpuMB",
+            "rssMB",
+            "agree",
+        )
+    )
+
+    def emit(row):
+        report["rows"].append(row)
+        print(
+            ROW.format(
+                row["case"],
+                row["batch"],
+                row["stream"],
+                f"{row['build_s']:.3f}",
+                f"{row['search_s']:.3f}",
+                f"{row['total_s']:.3f}",
+                f"{row['peak_device_mb']:.0f}",
+                f"{row['peak_host_mb']:.0f}",
+                f"{row['agreement']:.3f}",
+            )
+        )
+        if args.output:
+            with open(args.output, "w") as handle:
+                json.dump(report, handle, indent=2)
+
+    for index_type in args.index_type:
+        for d in args.d:
+            torch.manual_seed(args.seed)
+            X = torch.randn(args.n, d)
+
+            # Reference neighbors from the in-memory tensor path, same index type,
+            # so agreement measures the streaming path rather than the index.
+            _, reference = pairwise_distances(
+                X.cuda(),
+                k=args.k,
+                backend=FaissConfig(index_type=index_type),
+                return_indices=True,
+                exclude_diag=True,
+            )
+            reference = reference.cpu()
+            torch.cuda.empty_cache()
+
+            for batch in args.batch_sizes:
+                loader = DataLoader(
+                    TensorDataset(X),
+                    batch_size=batch,
+                    shuffle=False,
+                    pin_memory=args.pin_memory,
+                )
+
+                stream_arms = [None]
+                if supports_stream_rows:
+                    if args.no_regroup_arm:
+                        stream_arms.append(batch)
+                    stream_arms.extend(args.stream_rows)
+
+                for stream_rows in stream_arms:
+                    kwargs = {"index_type": index_type}
+                    if stream_rows is not None:
+                        kwargs["stream_batch_size"] = stream_rows
+
+                    def call(kwargs=kwargs):
+                        return pairwise_distances(
+                            loader,
+                            k=args.k,
+                            backend=FaissConfig(**kwargs),
+                            return_indices=True,
+                            exclude_diag=True,
+                        )
+
+                    timing, result = timed_call(call, args.repeats)
+                    agreement = neighbor_agreement(reference, result[1])
+                    result = None
+                    torch.cuda.empty_cache()
+
+                    memory = sampled_call(call, device)
+                    torch.cuda.empty_cache()
+
+                    emit(
+                        {
+                            "case": f"{index_type}/d{d}",
+                            "index_type": index_type,
+                            "batch": batch,
+                            "stream": "auto" if stream_rows is None else stream_rows,
+                            "agreement": agreement,
+                            **timing,
+                            **memory,
+                        }
+                    )
+
+            del X, reference
+            torch.cuda.empty_cache()
+
+    if args.output:
+        print(f"wrote {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/torchdr/distance/faiss.py
+++ b/torchdr/distance/faiss.py
@@ -8,7 +8,7 @@ import torch
 import numpy as np
 import warnings
 from weakref import WeakKeyDictionary
-from typing import Union, Optional, Dict, Any, Tuple, List
+from typing import Union, Optional, Dict, Any, Iterable, Tuple, List
 
 from torch.utils.data import (
     DataLoader,
@@ -20,6 +20,9 @@ from torch.utils.data import (
 from torchdr.utils.faiss import faiss, faiss_torch_interop
 
 LIST_METRICS_FAISS = ["euclidean", "sqeuclidean", "angular"]
+
+# Rows per FAISS add/search call when a DataLoader does not dictate one.
+_AUTO_STREAM_ROWS = 65536
 
 # Cache for DataLoader metadata to avoid redundant iterations
 _DATALOADER_METADATA_CACHE = WeakKeyDictionary()
@@ -146,6 +149,15 @@ class FaissConfig:
         Number of bits per sub-quantizer code. Determines the number of centroids
         per subspace (2^nbits). Standard value is 8 (256 centroids per subspace).
         Only used with index_type='IVFPQ'.
+    stream_batch_size : Union[str, int], default='auto'
+        Rows handed to FAISS per add or search call when streaming from a
+        DataLoader. 'auto' regroups batches for a GPU index, merging small ones
+        and splitting large ones, so the batch size chosen for the training loop
+        does not also decide the size of a FAISS call, and leaves a CPU index to
+        consume batches as they arrive. An integer overrides the target. FAISS
+        picks its exact-search kernel from the number of queries in a call, so
+        a different value can move a distance by the float32 cancellation
+        residual without changing the neighbors it ranks.
     **kwargs
         Additional FAISS configuration options to pass to the underlying FAISS
         index config objects (e.g., for advanced memory management).
@@ -195,6 +207,7 @@ class FaissConfig:
         nlist: int = 100,
         M: int = 16,
         nbits: int = 8,
+        stream_batch_size: Union[str, int] = "auto",
         **kwargs,
     ):
         self.temp_memory = temp_memory
@@ -204,6 +217,7 @@ class FaissConfig:
         self.nlist = nlist
         self.M = M
         self.nbits = nbits
+        self.stream_batch_size = stream_batch_size
         self.faiss_kwargs = kwargs
         self.gpu_resources: Dict[int, Any] = {}
 
@@ -217,6 +231,8 @@ class FaissConfig:
         ]
         if self.index_type == "IVFPQ":
             parts.extend([f"M={self.M}", f"nbits={self.nbits}"])
+        if self.stream_batch_size != "auto":
+            parts.append(f"stream_batch_size={self.stream_batch_size}")
         if self.faiss_kwargs:
             parts.append(f"**{self.faiss_kwargs}")
         return f"FaissConfig({', '.join(parts)})"
@@ -625,7 +641,10 @@ def pairwise_distances_faiss_from_dataloader(
     config : FaissConfig, optional
         Configuration object for FAISS. If None, uses default settings.
     device : str, default "auto"
-        Device for computation. If "auto", uses CUDA if available.
+        Device the index is built on. "auto" uses CUDA when available, so host
+        batches are streamed to a GPU index, and returns the results on the
+        device the batches came from, which is what the tensor path does. An
+        explicit device sets both the index and the output device.
     distributed_ctx : DistributedContext, optional
         Distributed context for multi-GPU computation. When provided,
         each GPU computes k-NN for its assigned chunk of samples.
@@ -653,6 +672,10 @@ def pairwise_distances_faiss_from_dataloader(
     - In distributed mode, all ranks build the same full index
     - Memory efficient: only one batch in CPU RAM at a time
     - GPU memory still required for the full FAISS index
+    - Batches reach FAISS as tensors where the build ships the PyTorch
+      wrappers. A host batch is uploaded through a reusable pinned buffer
+      rather than copied through NumPy, and consecutive batches are regrouped
+      into FAISS calls of ``config.stream_batch_size`` rows.
     """
     if metric not in LIST_METRICS_FAISS:
         raise ValueError(
@@ -666,7 +689,8 @@ def pairwise_distances_faiss_from_dataloader(
         config = FaissConfig()
 
     # Determine compute device
-    if distributed_ctx is not None and distributed_ctx.is_initialized:
+    distributed = distributed_ctx is not None and distributed_ctx.is_initialized
+    if distributed:
         config = distributed_ctx.get_faiss_config(config)
         compute_device = torch.device(f"cuda:{distributed_ctx.local_rank}")
     elif device == "auto":
@@ -677,28 +701,47 @@ def pairwise_distances_faiss_from_dataloader(
     if not hasattr(dataloader.dataset, "__len__"):
         raise ValueError("[TorchDR] DataLoader dataset must have __len__ method.")
 
+    index_device, use_gpu_index = _index_input_device(config, compute_device)
+    if compute_device.type == "cuda" and not use_gpu_index:
+        warnings.warn(
+            "[TorchDR] faiss-gpu not installed, using CPU. "
+            "Install faiss-gpu for faster computation."
+        )
+
+    # One stager for the whole call, so a single pinned buffer serves the
+    # training, add and search passes.
+    stage = _BatchStager(index_device, to_numpy=not faiss_torch_interop)
+    group_rows = _resolve_stream_rows(config, use_gpu_index)
+
     # Build FAISS index and extract metadata in one pass
     index, metadata = _build_index_from_dataloader(
-        dataloader, metric, config, compute_device
+        dataloader, metric, config, stage, group_rows, use_gpu_index
     )
     n_samples = metadata["n_samples"]
     dtype = metadata["dtype"]
 
+    # Results follow the batches, the way the tensor path follows ``X.device``.
+    # An explicit device, and distributed mode, pin the output instead.
+    if device == "auto" and not distributed:
+        output_device = metadata["device"]
+    else:
+        output_device = compute_device
+
     # Search for k-NN
     k_search = k + 1 if exclude_diag else k
 
-    if distributed_ctx is not None and distributed_ctx.is_initialized:
+    if distributed:
         # Multi-GPU: each rank searches its chunk
         chunk_start, chunk_end = distributed_ctx.compute_chunk_bounds(n_samples)
-        distances, indices = _search_chunk_from_dataloader(
-            dataloader, index, k_search, distributed_ctx, n_samples, compute_device
-        )
+        queries = _chunk_batches(dataloader, chunk_start, chunk_end)
     else:
         # Single GPU: search all queries
         chunk_start, chunk_end = 0, n_samples
-        distances, indices = _search_all_from_dataloader(
-            dataloader, index, k_search, compute_device
-        )
+        queries = _batches(dataloader)
+
+    distances, indices = _search_from_dataloader(
+        queries, index, k_search, stage, group_rows, output_device
+    )
 
     # Post-process results
     if metric == "euclidean":
@@ -715,17 +758,247 @@ def pairwise_distances_faiss_from_dataloader(
     return distances.to(dtype), indices
 
 
+def _batch_tensor(batch) -> torch.Tensor:
+    """Data tensor of a DataLoader batch, which datasets often wrap in a tuple."""
+    if isinstance(batch, (list, tuple)):
+        batch = batch[0]
+    return batch
+
+
+def _batch_metadata(n_samples: int, batch: torch.Tensor) -> Dict[str, Any]:
+    """Describe a DataLoader from its first batch."""
+    return {
+        "n_samples": n_samples,
+        "n_features": batch.shape[1],
+        "dtype": batch.dtype,
+        "device": batch.device,
+    }
+
+
+class _BatchStager:
+    """Present DataLoader batches to FAISS without a NumPy round trip.
+
+    Batches are made contiguous float32 and moved to the device the index reads
+    from. A host batch that is not already pinned is copied into a reusable
+    pinned buffer first, so the transfer is asynchronous and overlaps the FAISS
+    work already queued for earlier batches. The buffer is rewritten in place,
+    so the previous transfer must have finished before the next copy starts;
+    that is what the recorded event enforces.
+
+    Parameters
+    ----------
+    device : torch.device
+        Device FAISS reads its inputs from. CPU for a CPU index.
+    to_numpy : bool, default=False
+        Stage through NumPy instead, for FAISS builds that ship without the
+        PyTorch wrappers.
+    """
+
+    def __init__(self, device: torch.device, to_numpy: bool = False):
+        self.device = device
+        self.to_numpy = to_numpy
+        self._buffer: Optional[torch.Tensor] = None
+        self._event: Optional[torch.cuda.Event] = None
+
+    def __call__(self, batch: torch.Tensor):
+        batch = batch.detach()
+        if batch.dtype != torch.float32:
+            batch = batch.to(torch.float32)
+        batch = batch.contiguous()
+
+        if self.to_numpy:
+            return batch.cpu().numpy()
+        if self.device.type != "cuda":
+            return batch.cpu()
+        if batch.device.type == "cuda":
+            return batch.to(self.device)
+        if self.device.index != torch.cuda.current_device():
+            # An asynchronous upload is only ordered against the FAISS work
+            # when both run on the current device's stream, which is the stream
+            # the FAISS wrappers bind to. Copy synchronously otherwise.
+            return batch.to(self.device)
+        if batch.is_pinned():
+            return batch.to(self.device, non_blocking=True)
+        return self._upload_pinned(batch)
+
+    def _upload_pinned(self, batch: torch.Tensor) -> torch.Tensor:
+        n, d = batch.shape
+        if self._event is None:
+            self._event = torch.cuda.Event()
+        else:
+            self._event.synchronize()
+
+        # Batches shrink only at the end of a pass, so the buffer is normally
+        # allocated once and a shorter view of it serves the final batch.
+        reusable = self._buffer is not None and self._buffer.shape[1] == d
+        if not reusable or self._buffer.shape[0] < n:
+            self._buffer = torch.empty((n, d), dtype=torch.float32, pin_memory=True)
+        staged = self._buffer[:n]
+
+        staged.copy_(batch)
+        uploaded = staged.to(self.device, non_blocking=True)
+        self._event.record()
+        return uploaded
+
+
+def _concatenate(chunks: List[Any]):
+    """Join staged chunks, whichever staging format they use."""
+    if len(chunks) == 1:
+        return chunks[0]
+    if isinstance(chunks[0], torch.Tensor):
+        return torch.cat(chunks, dim=0)
+    return np.vstack(chunks)
+
+
+def _batches(dataloader: DataLoader):
+    """Yield the data tensor of every batch of a DataLoader."""
+    for batch in dataloader:
+        yield _batch_tensor(batch)
+
+
+def _stream(
+    batches: Iterable[torch.Tensor],
+    stage: "_BatchStager",
+    group_rows: Optional[int],
+):
+    """Stage batches for FAISS, in groups of about ``group_rows`` rows.
+
+    The DataLoader's batch size is usually chosen for the training loop, not
+    for FAISS. Grouping decouples the two: small batches are merged so each
+    call has enough work to amortize its overhead, and large ones are split so
+    a single call cannot blow up FAISS's temporary memory. Only whole batches
+    are ever held at once, so the dataset still never has to fit in memory.
+    ``None`` hands every batch over as it arrives.
+    """
+    if group_rows is None:
+        for batch in batches:
+            yield stage(batch)
+        return
+
+    pending: List[Any] = []
+    rows = 0
+
+    for batch in batches:
+        staged = stage(batch)
+
+        if len(staged) >= group_rows:
+            if pending:
+                yield _concatenate(pending)
+                pending, rows = [], 0
+            for start in range(0, len(staged), group_rows):
+                yield staged[start : start + group_rows]
+            continue
+
+        pending.append(staged)
+        rows += len(staged)
+        if rows >= group_rows:
+            yield _concatenate(pending)
+            pending, rows = [], 0
+
+    if pending:
+        yield _concatenate(pending)
+
+
+def _as_tensor(result) -> torch.Tensor:
+    """FAISS returns tensors with the PyTorch wrappers and arrays without."""
+    return result if isinstance(result, torch.Tensor) else torch.from_numpy(result)
+
+
+def _resolve_stream_rows(config: FaissConfig, use_gpu_index: bool) -> Optional[int]:
+    """Rows per FAISS call when streaming a DataLoader, or None to pass through."""
+    if config.stream_batch_size != "auto":
+        rows = int(config.stream_batch_size)
+        if rows < 1:
+            raise ValueError(
+                "[TorchDR] ERROR : stream_batch_size must be a positive number "
+                f"of rows or 'auto', got {config.stream_batch_size!r}."
+            )
+        return rows
+    # A CPU index gains nothing from regrouping and would pay for the copy, so
+    # only a GPU index, whose calls carry a transfer and a launch, gets one.
+    return _AUTO_STREAM_ROWS if use_gpu_index else None
+
+
+def _index_input_device(config: FaissConfig, compute_device: torch.device):
+    """Device FAISS reads from, and whether the index itself lives on the GPU."""
+    use_gpu_index = compute_device.type == "cuda" and hasattr(
+        faiss, "StandardGpuResources"
+    )
+    if use_gpu_index and faiss_torch_interop:
+        device_id = (
+            config.device if isinstance(config.device, int) else config.device[0]
+        )
+        return torch.device("cuda", device_id), use_gpu_index
+    return torch.device("cpu"), use_gpu_index
+
+
+def _create_index(
+    metric: str, config: FaissConfig, d: int, n_samples: int, use_gpu_index: bool
+):
+    """Create the empty index that the streaming passes will train and fill."""
+    if metric == "angular":
+        flat_index = faiss.IndexFlatIP(d)
+        metric_type = faiss.METRIC_INNER_PRODUCT
+    else:
+        flat_index = faiss.IndexFlatL2(d)
+        metric_type = faiss.METRIC_L2
+
+    if config.index_type in ("IVF", "IVFPQ"):
+        nlist = config.nlist
+        if nlist == 100 and n_samples > 10000:
+            nlist = min(int(4 * np.sqrt(n_samples)), n_samples // 40, 8192)
+
+        if config.index_type == "IVFPQ":
+            if d % config.M != 0:
+                raise ValueError(
+                    f"[TorchDR] ERROR : Vector dimension {d} must be divisible "
+                    f"by M={config.M} for IVFPQ. Choose M from divisors of {d}."
+                )
+            index = faiss.IndexIVFPQ(flat_index, d, nlist, config.M, config.nbits)
+        else:
+            index = faiss.IndexIVFFlat(flat_index, d, nlist, metric_type)
+        index.nprobe = config.nprobe
+    else:
+        index = flat_index
+
+    if use_gpu_index:
+        index = _setup_gpu_index(index, config, d)
+    return index
+
+
+def _reserve_index_capacity(index, n_vectors: int) -> None:
+    """Pre-allocate storage for the incremental additions that follow.
+
+    A GPU index grows by reallocating and copying its whole database, so a
+    stream of small additions moves the same vectors again and again. Only some
+    index types expose a reservation call, hence the feature detection; when it
+    is missing or the build rejects the request, the additions simply grow the
+    index as before.
+    """
+    reserve = getattr(index, "reserveVecs", None) or getattr(
+        index, "reserveMemory", None
+    )
+    if reserve is None:
+        return
+    try:
+        reserve(n_vectors)
+    except (RuntimeError, TypeError):  # pragma: no cover - build specific
+        pass
+
+
 def _build_index_from_dataloader(
     dataloader: DataLoader,
     metric: str,
     config: FaissConfig,
-    compute_device: torch.device,
+    stage: "_BatchStager",
+    group_rows: Optional[int],
+    use_gpu_index: bool,
 ):
     """Build FAISS index by streaming data from dataloader.
 
-    Extracts metadata (n_samples, n_features, dtype) during the first pass,
-    then builds the index. For Flat indices, only one pass through data is needed.
-    For IVF indices, two passes are required (training + adding).
+    Extracts metadata (n_samples, n_features, dtype, device) from the first
+    batch, then builds the index. For Flat indices, only one pass through data
+    is needed. For IVF indices, two passes are required (training + adding).
 
     Parameters
     ----------
@@ -735,126 +1008,58 @@ def _build_index_from_dataloader(
         Distance metric.
     config : FaissConfig
         FAISS configuration.
-    compute_device : torch.device
-        Device for computation.
+    stage : _BatchStager
+        Converts a batch into something FAISS can consume directly.
+    group_rows : int or None
+        Rows per add call, or None to add each batch as it arrives.
+    use_gpu_index : bool
+        Whether the index is moved to the GPU.
 
     Returns
     -------
     index : faiss.Index
         Built FAISS index containing all data.
     metadata : dict
-        Dictionary with keys: 'n_samples', 'n_features', 'dtype'.
+        Dictionary with keys: 'n_samples', 'n_features', 'dtype', 'device'.
     """
     metadata = None
     index = None
     n_samples = len(dataloader.dataset)
 
-    # For IVF/IVFPQ indices: first pass extracts metadata and trains
-    if config.index_type in ("IVF", "IVFPQ"):
-        collected = []
-        total = 0
+    # First pass: describe the stream from its first batch, then collect
+    # training rows if the index needs them. A Flat index stops right away.
+    collected: List[Any] = []
+    total = 0
 
-        for batch in dataloader:
-            if isinstance(batch, (list, tuple)):
-                batch = batch[0]
+    for batch in dataloader:
+        batch = _batch_tensor(batch)
 
-            # Extract metadata from first batch
-            if metadata is None:
-                metadata = {
-                    "n_samples": n_samples,
-                    "n_features": batch.shape[1],
-                    "dtype": batch.dtype,
-                }
-
-                # Create index now that we know dimensions
-                d = metadata["n_features"]
-                if metric == "angular":
-                    flat_index = faiss.IndexFlatIP(d)
-                    metric_type = faiss.METRIC_INNER_PRODUCT
-                else:
-                    flat_index = faiss.IndexFlatL2(d)
-                    metric_type = faiss.METRIC_L2
-
-                nlist = config.nlist
-                if nlist == 100 and n_samples > 10000:
-                    nlist = min(int(4 * np.sqrt(n_samples)), n_samples // 40, 8192)
-
-                if config.index_type == "IVFPQ":
-                    if d % config.M != 0:
-                        raise ValueError(
-                            f"[TorchDR] ERROR : Vector dimension {d} must be divisible "
-                            f"by M={config.M} for IVFPQ. Choose M from divisors of {d}."
-                        )
-                    index = faiss.IndexIVFPQ(
-                        flat_index, d, nlist, config.M, config.nbits
-                    )
-                else:
-                    index = faiss.IndexIVFFlat(flat_index, d, nlist, metric_type)
-                index.nprobe = config.nprobe
-
-                # Move to GPU if needed
-                if compute_device.type == "cuda":
-                    if hasattr(faiss, "StandardGpuResources"):
-                        index = _setup_gpu_index(index, config, d)
-                    else:
-                        warnings.warn(
-                            "[TorchDR] faiss-gpu not installed, using CPU. "
-                            "Install faiss-gpu for faster computation."
-                        )
-
-            # Collect training data
-            batch_np = batch.detach().cpu().numpy().astype(np.float32)
-            # IVFPQ benefits from more training data for better codebooks
-            if config.index_type == "IVFPQ":
-                max_train = max(256 * index.nlist, 256 * config.M)
-            else:
-                max_train = 256 * index.nlist
-            if total + len(batch_np) >= max_train:
-                collected.append(batch_np[: max_train - total])
+        if metadata is None:
+            metadata = _batch_metadata(n_samples, batch)
+            index = _create_index(
+                metric, config, metadata["n_features"], n_samples, use_gpu_index
+            )
+            if index.is_trained:
                 break
-            collected.append(batch_np)
-            total += len(batch_np)
+            # IVFPQ benefits from more training data for better codebooks
+            max_train = 256 * index.nlist
+            if config.index_type == "IVFPQ":
+                max_train = max(max_train, 256 * config.M)
 
-        # Train index
-        train_data = np.vstack(collected)
-        index.train(train_data)
-
-    # For Flat indices: extract metadata from first batch only
-    else:
-        for batch in dataloader:
-            if isinstance(batch, (list, tuple)):
-                batch = batch[0]
-
-            metadata = {
-                "n_samples": n_samples,
-                "n_features": batch.shape[1],
-                "dtype": batch.dtype,
-            }
-
-            # Create index
-            d = metadata["n_features"]
-            if metric == "angular":
-                index = faiss.IndexFlatIP(d)
-            else:
-                index = faiss.IndexFlatL2(d)
-
-            # Move to GPU if needed
-            if compute_device.type == "cuda":
-                if hasattr(faiss, "StandardGpuResources"):
-                    index = _setup_gpu_index(index, config, d)
-                else:
-                    warnings.warn(
-                        "[TorchDR] faiss-gpu not installed, using CPU. "
-                        "Install faiss-gpu for faster computation."
-                    )
+        staged = stage(batch)
+        if total + len(staged) >= max_train:
+            collected.append(staged[: max_train - total])
             break
+        collected.append(staged)
+        total += len(staged)
+
+    if not index.is_trained:
+        index.train(_concatenate(collected))
 
     # Second pass: add all data to index
-    for batch in dataloader:
-        if isinstance(batch, (list, tuple)):
-            batch = batch[0]
-        batch_np = batch.detach().cpu().numpy().astype(np.float32)
-        index.add(batch_np)
+    _reserve_index_capacity(index, n_samples)
+    for group in _stream(_batches(dataloader), stage, group_rows):
+        index.add(group)
 
     # Cache metadata for later reuse
     _cache_dataloader_metadata(dataloader, metadata)
@@ -862,130 +1067,75 @@ def _build_index_from_dataloader(
     return index, metadata
 
 
-def _search_all_from_dataloader(
-    dataloader: DataLoader,
+def _search_from_dataloader(
+    batches: Iterable[torch.Tensor],
     index,
     k: int,
-    compute_device: torch.device,
+    stage: "_BatchStager",
+    group_rows: Optional[int],
+    output_device: torch.device,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Search k-NN for all samples in dataloader (single-GPU mode).
+    """Search k-NN for a stream of query batches.
 
     Parameters
     ----------
-    dataloader : DataLoader
-        DataLoader with query samples.
+    batches : iterable of torch.Tensor
+        Query batches, in dataset order. Either every batch of the DataLoader
+        or, in distributed mode, this rank's slice of them.
     index : faiss.Index
         FAISS index to search.
     k : int
         Number of neighbors to find.
-    compute_device : torch.device
-        Device for output tensors.
+    stage : _BatchStager
+        Converts a batch into something FAISS can consume directly.
+    group_rows : int or None
+        Rows per search call, or None to search each batch as it arrives.
+    output_device : torch.device
+        Device for output tensors. Results are moved group by group, so a host
+        output never accumulates on the device.
 
     Returns
     -------
-    distances : torch.Tensor of shape (n_samples, k)
+    distances : torch.Tensor of shape (n_queries, k)
         k-NN distances.
-    indices : torch.Tensor of shape (n_samples, k)
+    indices : torch.Tensor of shape (n_queries, k)
         k-NN indices.
     """
     distances_list: List[torch.Tensor] = []
     indices_list: List[torch.Tensor] = []
 
-    for batch in dataloader:
-        if isinstance(batch, (list, tuple)):
-            batch = batch[0]
-        batch_np = batch.detach().cpu().numpy().astype(np.float32)
+    for group in _stream(batches, stage, group_rows):
+        D, Ind = index.search(group, k)
 
-        D, Ind = index.search(batch_np, k)
+        distances_list.append(_as_tensor(D).to(output_device))
+        indices_list.append(_as_tensor(Ind).to(output_device))
 
-        distances_list.append(torch.from_numpy(D))
-        indices_list.append(torch.from_numpy(Ind))
-
-    distances = torch.cat(distances_list, dim=0).to(compute_device)
-    indices = torch.cat(indices_list, dim=0).to(compute_device).long()
-
-    return distances, indices
-
-
-def _search_chunk_from_dataloader(
-    dataloader: DataLoader,
-    index,
-    k: int,
-    distributed_ctx,
-    n_samples: int,
-    compute_device: torch.device,
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Search k-NN for this rank's chunk of samples (distributed mode).
-
-    Each rank iterates through the dataloader but only processes
-    the samples assigned to its chunk.
-
-    Parameters
-    ----------
-    dataloader : DataLoader
-        DataLoader with all samples.
-    index : faiss.Index
-        FAISS index to search (contains full dataset).
-    k : int
-        Number of neighbors to find.
-    distributed_ctx : DistributedContext
-        Distributed context with rank info.
-    n_samples : int
-        Total number of samples in dataset.
-    compute_device : torch.device
-        Device for output tensors.
-
-    Returns
-    -------
-    distances : torch.Tensor of shape (chunk_size, k)
-        k-NN distances for this rank's chunk.
-    indices : torch.Tensor of shape (chunk_size, k)
-        k-NN indices for this rank's chunk.
-    """
-    chunk_start, chunk_end = distributed_ctx.compute_chunk_bounds(n_samples)
-
-    distances_list: List[torch.Tensor] = []
-    indices_list: List[torch.Tensor] = []
-
-    current_idx = 0
-
-    for batch in dataloader:
-        if isinstance(batch, (list, tuple)):
-            batch = batch[0]
-
-        batch_size = len(batch)
-        batch_end = current_idx + batch_size
-
-        # Check if this batch overlaps with our chunk
-        if batch_end > chunk_start and current_idx < chunk_end:
-            # Compute overlap indices within this batch
-            start_in_batch = max(0, chunk_start - current_idx)
-            end_in_batch = min(batch_size, chunk_end - current_idx)
-
-            # Extract our portion of this batch
-            my_batch = batch[start_in_batch:end_in_batch]
-            batch_np = my_batch.detach().cpu().numpy().astype(np.float32)
-
-            # Search
-            D, Ind = index.search(batch_np, k)
-
-            distances_list.append(torch.from_numpy(D))
-            indices_list.append(torch.from_numpy(Ind))
-
-        current_idx = batch_end
-
-        # Early exit if we've processed our entire chunk
-        if current_idx >= chunk_end:
-            break
-
-    # Handle empty chunk case (when n_samples < world_size)
-    if len(distances_list) == 0:
+    # Empty chunk case, when n_samples < world_size.
+    if not distances_list:
         return (
-            torch.empty(0, k, device=compute_device),
-            torch.empty(0, k, dtype=torch.long, device=compute_device),
+            torch.empty(0, k, device=output_device),
+            torch.empty(0, k, dtype=torch.long, device=output_device),
         )
 
-    distances = torch.cat(distances_list, dim=0).to(compute_device)
-    indices = torch.cat(indices_list, dim=0).to(compute_device).long()
+    distances = torch.cat(distances_list, dim=0)
+    indices = torch.cat(indices_list, dim=0).long()
 
     return distances, indices
+
+
+def _chunk_batches(dataloader: DataLoader, start: int, end: int):
+    """Yield the rows of each batch that fall in ``[start, end)``.
+
+    Every rank walks the same DataLoader, so a rank's chunk is the slice of the
+    stream it is responsible for querying. Iteration stops once the chunk is
+    exhausted.
+    """
+    offset = 0
+    for batch in dataloader:
+        batch = _batch_tensor(batch)
+        lo, hi = max(offset, start), min(offset + len(batch), end)
+        if lo < hi:
+            yield batch[lo - offset : hi - offset]
+        offset += len(batch)
+        if offset >= end:
+            break

--- a/torchdr/distance/faiss.py
+++ b/torchdr/distance/faiss.py
@@ -8,7 +8,7 @@ import torch
 import numpy as np
 import warnings
 from weakref import WeakKeyDictionary
-from typing import Union, Optional, Dict, Any, Iterable, Tuple, List
+from typing import Union, Optional, Dict, Any, Callable, Iterable, Tuple, List
 
 from torch.utils.data import (
     DataLoader,
@@ -686,8 +686,7 @@ def pairwise_distances_faiss_from_dataloader(
     - Memory efficient: only one batch in CPU RAM at a time
     - GPU memory still required for the full FAISS index
     - Batches reach FAISS as tensors where the build ships the PyTorch
-      wrappers. A host batch is uploaded through a reusable pinned buffer
-      rather than copied through NumPy, and consecutive batches are regrouped
+      wrappers, avoiding a NumPy round trip. Consecutive batches are regrouped
       into FAISS calls of ``config.stream_batch_size`` rows.
     """
     if metric not in LIST_METRICS_FAISS:
@@ -721,15 +720,19 @@ def pairwise_distances_faiss_from_dataloader(
             "Install faiss-gpu for faster computation."
         )
 
-    # One stager for the whole call, so a single pinned buffer serves the
-    # training, add and search passes.
-    stage = _BatchStager(index_device, to_numpy=not faiss_torch_interop)
+    def stage(batch):
+        return _stage_batch(batch, index_device, to_numpy=not faiss_torch_interop)
+
     group_rows = _resolve_stream_rows(config, use_gpu_index)
+    faiss_device = (
+        torch.device("cuda", _index_device_id(config)) if use_gpu_index else None
+    )
 
     # Build FAISS index and extract metadata in one pass
-    index, metadata = _build_index_from_dataloader(
-        dataloader, metric, config, stage, group_rows, use_gpu_index
-    )
+    with faiss_device_scope(faiss_device):
+        index, metadata = _build_index_from_dataloader(
+            dataloader, metric, config, stage, group_rows, use_gpu_index
+        )
     n_samples = metadata["n_samples"]
     dtype = metadata["dtype"]
 
@@ -752,9 +755,10 @@ def pairwise_distances_faiss_from_dataloader(
         chunk_start, chunk_end = 0, n_samples
         queries = _batches(dataloader)
 
-    distances, indices = _search_from_dataloader(
-        queries, index, k_search, stage, group_rows, output_device
-    )
+    with faiss_device_scope(faiss_device):
+        distances, indices = _search_from_dataloader(
+            queries, index, k_search, stage, group_rows, output_device
+        )
 
     # Post-process results
     if metric == "euclidean":
@@ -788,15 +792,12 @@ def _batch_metadata(n_samples: int, batch: torch.Tensor) -> Dict[str, Any]:
     }
 
 
-class _BatchStager:
-    """Present DataLoader batches to FAISS without a NumPy round trip.
+def _stage_batch(batch: torch.Tensor, device: torch.device, to_numpy: bool = False):
+    """Present one DataLoader batch to FAISS without a NumPy round trip.
 
     Batches are made contiguous float32 and moved to the device the index reads
-    from. A host batch that is not already pinned is copied into a reusable
-    pinned buffer first, so the transfer is asynchronous and overlaps the FAISS
-    work already queued for earlier batches. The buffer is rewritten in place,
-    so the previous transfer must have finished before the next copy starts;
-    that is what the recorded event enforces.
+    from. DataLoader-managed pinned batches retain their asynchronous upload;
+    ordinary host batches use PyTorch's direct device transfer.
 
     Parameters
     ----------
@@ -807,51 +808,13 @@ class _BatchStager:
         PyTorch wrappers.
     """
 
-    def __init__(self, device: torch.device, to_numpy: bool = False):
-        self.device = device
-        self.to_numpy = to_numpy
-        self._buffer: Optional[torch.Tensor] = None
-        self._event: Optional[torch.cuda.Event] = None
+    batch = batch.detach().to(dtype=torch.float32).contiguous()
 
-    def __call__(self, batch: torch.Tensor):
-        batch = batch.detach()
-        if batch.dtype != torch.float32:
-            batch = batch.to(torch.float32)
-        batch = batch.contiguous()
-
-        if self.to_numpy:
-            return batch.cpu().numpy()
-        if self.device.type != "cuda":
-            return batch.cpu()
-        if batch.device.type == "cuda":
-            return batch.to(self.device)
-        if self.device.index != torch.cuda.current_device():
-            # An asynchronous upload is only ordered against the FAISS work
-            # when both run on the current device's stream, which is the stream
-            # the FAISS wrappers bind to. Copy synchronously otherwise.
-            return batch.to(self.device)
-        if batch.is_pinned():
-            return batch.to(self.device, non_blocking=True)
-        return self._upload_pinned(batch)
-
-    def _upload_pinned(self, batch: torch.Tensor) -> torch.Tensor:
-        n, d = batch.shape
-        if self._event is None:
-            self._event = torch.cuda.Event()
-        else:
-            self._event.synchronize()
-
-        # Batches shrink only at the end of a pass, so the buffer is normally
-        # allocated once and a shorter view of it serves the final batch.
-        reusable = self._buffer is not None and self._buffer.shape[1] == d
-        if not reusable or self._buffer.shape[0] < n:
-            self._buffer = torch.empty((n, d), dtype=torch.float32, pin_memory=True)
-        staged = self._buffer[:n]
-
-        staged.copy_(batch)
-        uploaded = staged.to(self.device, non_blocking=True)
-        self._event.record()
-        return uploaded
+    if to_numpy:
+        return batch.cpu().numpy()
+    if device.type != "cuda":
+        return batch.cpu()
+    return batch.to(device, non_blocking=batch.is_pinned())
 
 
 def _concatenate(chunks: List[Any]):
@@ -871,7 +834,7 @@ def _batches(dataloader: DataLoader):
 
 def _stream(
     batches: Iterable[torch.Tensor],
-    stage: "_BatchStager",
+    stage: Callable[[torch.Tensor], Any],
     group_rows: Optional[int],
 ):
     """Stage batches for FAISS, in groups of about ``group_rows`` rows.
@@ -998,7 +961,7 @@ def _build_index_from_dataloader(
     dataloader: DataLoader,
     metric: str,
     config: FaissConfig,
-    stage: "_BatchStager",
+    stage: Callable[[torch.Tensor], Any],
     group_rows: Optional[int],
     use_gpu_index: bool,
 ):
@@ -1016,7 +979,7 @@ def _build_index_from_dataloader(
         Distance metric.
     config : FaissConfig
         FAISS configuration.
-    stage : _BatchStager
+    stage : callable
         Converts a batch into something FAISS can consume directly.
     group_rows : int or None
         Rows per add call, or None to add each batch as it arrives.
@@ -1079,7 +1042,7 @@ def _search_from_dataloader(
     batches: Iterable[torch.Tensor],
     index,
     k: int,
-    stage: "_BatchStager",
+    stage: Callable[[torch.Tensor], Any],
     group_rows: Optional[int],
     output_device: torch.device,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
@@ -1094,7 +1057,7 @@ def _search_from_dataloader(
         FAISS index to search.
     k : int
         Number of neighbors to find.
-    stage : _BatchStager
+    stage : callable
         Converts a batch into something FAISS can consume directly.
     group_rows : int or None
         Rows per search call, or None to search each batch as it arrives.

--- a/torchdr/distributed/__init__.py
+++ b/torchdr/distributed/__init__.py
@@ -398,6 +398,7 @@ class DistributedContext:
                 nlist=base_config.nlist,
                 M=base_config.M,
                 nbits=base_config.nbits,
+                stream_batch_size=base_config.stream_batch_size,
                 **base_config.faiss_kwargs,
             )
 

--- a/torchdr/tests/test_dataloader.py
+++ b/torchdr/tests/test_dataloader.py
@@ -7,6 +7,7 @@
 import gc
 import weakref
 
+import numpy as np
 import pytest
 import torch
 from torch.testing import assert_close
@@ -19,7 +20,10 @@ from torchdr.distance import (
 )
 from torchdr.distance.faiss import (
     _DATALOADER_METADATA_CACHE,
+    _BatchStager,
     _cache_dataloader_metadata,
+    _reserve_index_capacity,
+    _stream,
     get_dataloader_metadata,
 )
 from torchdr.utils import faiss
@@ -29,6 +33,12 @@ from torchdr.utils import faiss
 pytestmark = pytest.mark.skipif(
     faiss is None or faiss is False, reason="faiss not installed"
 )
+
+# A DataLoader is streamed into a GPU index where one is available, so its
+# distances are compared against a CPU index. Both compute exact L2 from
+# ``|x|^2 + |y|^2 - 2<x, y>``, and the cancellation leaves about 1e-5 on a
+# squared self-distance; the square root of that residual is a few 1e-3.
+EUCLIDEAN_ATOL = 1e-2
 
 
 class TestDataLoaderDistances:
@@ -62,7 +72,7 @@ class TestDataLoaderDistances:
         dist_dl, idx_dl = pairwise_distances(dataloader, k=k, return_indices=True)
 
         # Results should match
-        assert_close(dist_tensor, dist_dl, rtol=1e-4, atol=1e-4)
+        assert_close(dist_tensor, dist_dl, rtol=1e-4, atol=EUCLIDEAN_ATOL)
         assert torch.equal(idx_tensor, idx_dl)
 
     def test_dataloader_exclude_diag(self, sample_data, dataloader):
@@ -99,7 +109,8 @@ class TestDataLoaderDistances:
         )
 
         # Results should match
-        assert_close(dist_tensor, dist_dl, rtol=1e-4, atol=1e-4)
+        atol = EUCLIDEAN_ATOL if metric == "euclidean" else 1e-4
+        assert_close(dist_tensor, dist_dl, rtol=1e-4, atol=atol)
 
     def test_dataloader_with_config(self, sample_data, dataloader):
         """Test DataLoader with FaissConfig."""
@@ -130,6 +141,31 @@ class TestDataLoaderDistances:
         """Test that DataLoader raises error for non-FAISS backends."""
         with pytest.raises(ValueError, match="only supports FAISS backend"):
             pairwise_distances(dataloader, k=10, backend="keops")
+
+    def test_dataloader_results_follow_batch_device(self, sample_data, dataloader):
+        """Results come back on the device the batches live on."""
+        dist, idx = pairwise_distances(dataloader, k=10, return_indices=True)
+
+        assert dist.device == sample_data.device
+        assert idx.device == sample_data.device
+
+    @pytest.mark.parametrize(
+        "n_samples,batch_size", [(1000, 300), (997, 256), (513, 512)]
+    )
+    def test_dataloader_non_divisible_final_batch(self, n_samples, batch_size):
+        """A short final batch is handled like any other, down to a single row."""
+        torch.manual_seed(42)
+        X = torch.randn(n_samples, 32)
+        dl = DataLoader(TensorDataset(X), batch_size=batch_size, shuffle=False)
+
+        dist_ref, idx_ref = pairwise_distances(
+            X, k=10, backend="faiss", return_indices=True
+        )
+        dist_dl, idx_dl = pairwise_distances(dl, k=10, return_indices=True)
+
+        assert dist_dl.shape == (n_samples, 10)
+        assert_close(dist_ref, dist_dl, rtol=1e-3, atol=EUCLIDEAN_ATOL)
+        assert torch.equal(idx_ref, idx_dl)
 
     def test_dataloader_different_batch_sizes(self, sample_data):
         """Test DataLoader with different batch sizes produces same results."""
@@ -228,8 +264,159 @@ class TestDataLoaderGPU:
         dist_gpu = dist_gpu.cpu()
         idx_gpu = idx_gpu.cpu()
 
-        assert_close(dist_cpu, dist_gpu, rtol=1e-4, atol=1e-4)
+        assert_close(dist_cpu, dist_gpu, rtol=1e-4, atol=EUCLIDEAN_ATOL)
         assert torch.equal(idx_cpu, idx_gpu)
+
+    def test_dataloader_cuda_batches(self, sample_data):
+        """Batches already on the GPU are searched and answered in place."""
+        k = 10
+        X_gpu = sample_data.cuda()
+        dl = DataLoader(TensorDataset(X_gpu), batch_size=100, shuffle=False)
+
+        dist_cpu, idx_cpu = pairwise_distances(
+            sample_data, k=k, backend="faiss", device="cpu", return_indices=True
+        )
+        dist_gpu, idx_gpu = pairwise_distances(dl, k=k, return_indices=True)
+
+        assert dist_gpu.device.type == "cuda"
+        assert idx_gpu.device.type == "cuda"
+        assert_close(dist_cpu, dist_gpu.cpu(), rtol=1e-4, atol=EUCLIDEAN_ATOL)
+        assert torch.equal(idx_cpu, idx_gpu.cpu())
+
+    def test_dataloader_gpu_avoids_numpy(self, dataloader, monkeypatch):
+        """Host batches reach a GPU index without a NumPy round trip."""
+
+        def forbidden(self, *args, **kwargs):
+            raise AssertionError("batch was converted to NumPy")
+
+        monkeypatch.setattr(torch.Tensor, "numpy", forbidden)
+        dist, idx = pairwise_distances(
+            dataloader, k=10, device="cuda", return_indices=True
+        )
+
+        assert dist.device.type == "cuda"
+        assert idx.device.type == "cuda"
+
+
+class TestBatchStaging:
+    """Test how DataLoader batches are handed to FAISS."""
+
+    def test_stager_makes_batches_contiguous_float32(self):
+        """A non-contiguous float64 batch reaches FAISS as contiguous float32."""
+        batch = torch.randn(8, 6, dtype=torch.float64).T.contiguous().T[:, :4]
+        assert not batch.is_contiguous()
+
+        staged = _BatchStager(torch.device("cpu"))(batch)
+
+        assert isinstance(staged, torch.Tensor)
+        assert staged.dtype == torch.float32
+        assert staged.is_contiguous()
+        assert_close(staged, batch.float())
+
+    def test_stager_numpy_fallback(self):
+        """Builds without the torch wrappers still get float32 arrays."""
+        batch = torch.randn(8, 4, dtype=torch.float64)
+
+        staged = _BatchStager(torch.device("cpu"), to_numpy=True)(batch)
+
+        assert isinstance(staged, np.ndarray)
+        assert staged.dtype == np.float32
+
+    def test_stream_regroups_batches(self):
+        """Small batches are merged and large ones split, in order."""
+        stage = _BatchStager(torch.device("cpu"))
+        batches = [torch.full((3, 2), float(i)) for i in range(4)]
+
+        groups = list(_stream(batches, stage, group_rows=6))
+
+        assert [len(g) for g in groups] == [6, 6]
+        assert_close(torch.cat(groups, dim=0), torch.cat(batches, dim=0))
+
+        groups = list(_stream([torch.arange(20.0).reshape(10, 2)], stage, group_rows=4))
+        assert [len(g) for g in groups] == [4, 4, 2]
+
+    def test_stream_can_pass_batches_through(self):
+        """A None target hands every batch over as it arrives."""
+        stage = _BatchStager(torch.device("cpu"))
+        batches = [torch.zeros(3, 2), torch.zeros(3, 2)]
+
+        groups = list(_stream(batches, stage, group_rows=None))
+
+        assert [len(g) for g in groups] == [3, 3]
+
+    def test_stream_batch_size_must_be_positive(self):
+        """A nonsense call size is rejected before any work is done."""
+        X = torch.randn(64, 8)
+        dl = DataLoader(TensorDataset(X), batch_size=16, shuffle=False)
+
+        with pytest.raises(ValueError, match="stream_batch_size"):
+            pairwise_distances(
+                dl, k=5, backend=FaissConfig(stream_batch_size=0), return_indices=True
+            )
+
+    @pytest.mark.parametrize("stream_batch_size", [7, 64, 4096])
+    def test_stream_batch_size_does_not_change_neighbors(self, stream_batch_size):
+        """Regrouping is invisible in the neighbors it produces.
+
+        FAISS picks its exact-search kernel from the number of queries in a
+        call, so the distances move by the usual cancellation residual, but the
+        neighbors they rank do not.
+        """
+        torch.manual_seed(42)
+        X = torch.randn(300, 16)
+        dl = DataLoader(TensorDataset(X), batch_size=64, shuffle=False)
+
+        dist_ref, idx_ref = pairwise_distances(dl, k=5, return_indices=True)
+        dist, idx = pairwise_distances(
+            dl,
+            k=5,
+            backend=FaissConfig(stream_batch_size=stream_batch_size),
+            return_indices=True,
+        )
+
+        assert torch.equal(idx_ref, idx)
+        assert_close(dist_ref, dist, rtol=1e-4, atol=EUCLIDEAN_ATOL)
+
+    def test_reserve_capacity_ignores_unsupported_index(self):
+        """An index without a reservation call is left untouched."""
+
+        class NoReserve:
+            pass
+
+        _reserve_index_capacity(NoReserve(), 1000)
+
+    def test_reserve_capacity_uses_available_call(self):
+        """Whichever reservation call the build exposes is the one used."""
+
+        class ReserveVecs:
+            def __init__(self):
+                self.reserved = None
+
+            def reserveVecs(self, n):  # FAISS spelling
+                self.reserved = n
+
+        class ReserveMemory:
+            def __init__(self):
+                self.reserved = None
+
+            def reserveMemory(self, n):  # FAISS spelling
+                self.reserved = n
+
+        flat, ivf = ReserveVecs(), ReserveMemory()
+        _reserve_index_capacity(flat, 1000)
+        _reserve_index_capacity(ivf, 1000)
+
+        assert flat.reserved == 1000
+        assert ivf.reserved == 1000
+
+    def test_reserve_capacity_tolerates_rejected_request(self):
+        """A build that refuses the reservation just grows on demand."""
+
+        class Refuses:
+            def reserveVecs(self, n):  # FAISS spelling
+                raise RuntimeError("not supported for this index")
+
+        _reserve_index_capacity(Refuses(), 1000)
 
 
 class TestDataLoaderOptimizations:

--- a/torchdr/tests/test_dataloader.py
+++ b/torchdr/tests/test_dataloader.py
@@ -20,9 +20,9 @@ from torchdr.distance import (
 )
 from torchdr.distance.faiss import (
     _DATALOADER_METADATA_CACHE,
-    _BatchStager,
     _cache_dataloader_metadata,
     _reserve_index_capacity,
+    _stage_batch,
     _stream,
     get_dataloader_metadata,
 )
@@ -306,7 +306,7 @@ class TestBatchStaging:
         batch = torch.randn(8, 6, dtype=torch.float64).T.contiguous().T[:, :4]
         assert not batch.is_contiguous()
 
-        staged = _BatchStager(torch.device("cpu"))(batch)
+        staged = _stage_batch(batch, torch.device("cpu"))
 
         assert isinstance(staged, torch.Tensor)
         assert staged.dtype == torch.float32
@@ -317,14 +317,17 @@ class TestBatchStaging:
         """Builds without the torch wrappers still get float32 arrays."""
         batch = torch.randn(8, 4, dtype=torch.float64)
 
-        staged = _BatchStager(torch.device("cpu"), to_numpy=True)(batch)
+        staged = _stage_batch(batch, torch.device("cpu"), to_numpy=True)
 
         assert isinstance(staged, np.ndarray)
         assert staged.dtype == np.float32
 
     def test_stream_regroups_batches(self):
         """Small batches are merged and large ones split, in order."""
-        stage = _BatchStager(torch.device("cpu"))
+
+        def stage(batch):
+            return _stage_batch(batch, torch.device("cpu"))
+
         batches = [torch.full((3, 2), float(i)) for i in range(4)]
 
         groups = list(_stream(batches, stage, group_rows=6))
@@ -337,7 +340,10 @@ class TestBatchStaging:
 
     def test_stream_can_pass_batches_through(self):
         """A None target hands every batch over as it arrives."""
-        stage = _BatchStager(torch.device("cpu"))
+
+        def stage(batch):
+            return _stage_batch(batch, torch.device("cpu"))
+
         batches = [torch.zeros(3, 2), torch.zeros(3, 2)]
 
         groups = list(_stream(batches, stage, group_rows=None))


### PR DESCRIPTION
## Summary

- Stream DataLoader batches into FAISS as contiguous `torch.float32` tensors when FAISS's PyTorch wrappers are available, avoiding the previous `.cpu().numpy()` round trip.
- Decouple DataLoader batch size from FAISS call size. GPU indexes automatically regroup small batches and split large batches into calls of about 65,536 rows; `FaissConfig(stream_batch_size=...)` provides an expert override.
- Collapse the duplicated Flat/IVF ingestion code and the separate local/distributed query loops into one build path, one search path, and a small chunk generator.
- Reserve GPU IVF/IVFPQ index capacity before incremental additions when the installed FAISS index exposes `reserveMemory` or `reserveVecs`.
- Return results on the input batch device when `device="auto"`, matching the tensor-input API.
- Run build, train, add, and search under the index device scope introduced in #310, so PyTorch and FAISS agree on the CUDA stream for non-current devices.

The final review deliberately leaves pinned-memory ownership to the DataLoader. Pinned batches use a non-blocking PyTorch transfer; ordinary host batches use a direct transfer. The earlier reusable pinned-buffer/CUDA-event layer was removed because it added state and synchronization without isolated benchmark evidence that it helped. In the default regrouped path, all constituent uploads occur before the grouped FAISS call, so that extra layer had no FAISS work to overlap.

## Motivation

Closes #305.

The old DataLoader path converted every batch to a NumPy array. A GPU index therefore paid unnecessary host staging, and a training-oriented loader batch size also determined every FAISS add/search call. Small batches produced many transfers and launches.

## Benchmark

`benchmarks/faiss/dataloader_streaming.py` measures the complete DataLoader path: training/add, search, total time, process RSS, and device occupancy. Both revisions ran on the same NVIDIA B200 with the same data and seed. Values are medians of three runs for `n=300000`, `k=15`.

| Index | d | Loader batch | NumPy staging (s) | Tensor, per batch (s) | Tensor, auto (s) |
|-------|---:|-------------:|------------------:|----------------------:|----------------:|
| Flat | 64 | 1024 | 2.314 | 2.351 | 2.110 |
| Flat | 64 | 16384 | 3.110 | 2.988 | 3.059 |
| Flat | 128 | 1024 | 2.526 | 2.602 | 2.315 |
| Flat | 128 | 16384 | 3.145 | 3.061 | 3.068 |
| IVF | 64 | 1024 | 2.844 | 2.617 | 2.469 |
| IVF | 64 | 16384 | 3.742 | 3.499 | 3.348 |
| IVF | 128 | 1024 | 3.087 | 2.913 | 2.702 |
| IVF | 128 | 16384 | 3.834 | 3.784 | 3.615 |

At a 1,024-row loader batch, automatic regrouping was 8.4-8.8% faster for Flat and 12.5-13.2% faster for IVF. At 16,384 rows, the Flat difference was within the measured noise and IVF improved by 5.7-10.5%. Neighbor IDs agreed exactly in all cases. Peak host RSS was unchanged; Flat device memory was unchanged, while IVF at `d=128` used about 270 MB more because its training sample is now staged on the GPU.

The separate `pin_memory=True` arm was slightly slower at a 1,024-row loader batch. The implementation therefore supports DataLoader-provided pinning but does not manage a second pinned buffer internally.

## Correctness and validation

- Neighbor order, global IDs, exclusion of self-neighbors, and output dtype are preserved.
- Builds without FAISS's PyTorch wrappers retain the NumPy fallback.
- The installed FAISS 1.11 GPU API exposes `reserveMemory` on IVF/IVFPQ and no reservation method on Flat; the feature detection handles both.
- Focused post-review tests: 72 passed, 9 GPU-only skips.
- Full pre-commit suite passes.
- Fresh GitHub FAISS, minimal, macOS, Windows, pre-commit, and distributed-CPU jobs pass.

FAISS may choose a different exact-search kernel when the query call size changes. Neighbor IDs remain identical, while Euclidean self-distances can differ by a few `1e-3` after the square root amplifies float32 cancellation; tests retain tight comparison for squared distances and assert exact neighbor IDs.

## Non-goals

- Database sharding across ranks.
- Persistent index caching.
- cuVS/CAGRA support.
