### PR TITLE
[Test] Real-process coverage for the distributed neighbor-embedding path

### DIFF
--- a/.github/workflows/distributed-integration.yml
+++ b/.github/workflows/distributed-integration.yml
@@ -11,8 +11,10 @@ on:
       - ".github/workflows/distributed-integration.yml"
       - "torchdr/affinity_matcher.py"
       - "torchdr/distributed/**"
+      - "torchdr/neighbor_embedding/**"
       - "torchdr/spectral_embedding/pca.py"
       - "torchdr/tests/test_distributed_integration.py"
+      - "torchdr/tests/test_distributed_neighbor_embedding.py"
       - "torchdr/tests/test_distributed_sparse.py"
       - "torchdr/utils/sparse.py"
   push:
@@ -22,8 +24,10 @@ on:
       - ".github/workflows/distributed-integration.yml"
       - "torchdr/affinity_matcher.py"
       - "torchdr/distributed/**"
+      - "torchdr/neighbor_embedding/**"
       - "torchdr/spectral_embedding/pca.py"
       - "torchdr/tests/test_distributed_integration.py"
+      - "torchdr/tests/test_distributed_neighbor_embedding.py"
       - "torchdr/tests/test_distributed_sparse.py"
       - "torchdr/utils/sparse.py"
 
@@ -54,3 +58,10 @@ jobs:
           python -m torch.distributed.run --standalone --nnodes=1
           --nproc-per-node=2 -m pytest
           torchdr/tests/test_distributed_sparse.py -q
+      - name: Run two-process neighbor-embedding training-step test
+        env:
+          TORCHDR_DISTRIBUTED_TEST: "1"
+        run: >-
+          python -m torch.distributed.run --standalone --nnodes=1
+          --nproc-per-node=2 -m pytest
+          torchdr/tests/test_distributed_neighbor_embedding.py -q

--- a/torchdr/tests/test_distributed_neighbor_embedding.py
+++ b/torchdr/tests/test_distributed_neighbor_embedding.py
@@ -1,0 +1,181 @@
+"""Real-process tests for the distributed neighbor-embedding training step.
+
+These run on the Gloo CPU backend and exercise the transport-agnostic pieces
+of the sparse neighbor-embedding distributed path -- the row partitioning and
+the per-iteration gradient synchronization in
+:meth:`torchdr.affinity_matcher.AffinityMatcher._training_step` -- across real
+processes, without a GPU or an NCCL process group.
+
+The end-to-end ``UMAP(distributed=True).fit`` path itself is GPU-only by design
+(:class:`torchdr.affinity.base.SparseAffinity` and
+:class:`torchdr.neighbor_embedding.base.NeighborEmbedding` force a CUDA device
+in distributed mode), so it is covered separately by
+``test_distributed_neighbor_embedding_gpu.py`` on a provisioned NCCL runner.
+What is verified here is the collective that every distributed neighbor
+embedding relies on: each rank scatters the gradient for its own chunk of rows
+into a full-size buffer and an ``all_reduce`` sums the disjoint chunks so that
+every rank ends the step with the complete gradient. Both gradient modes are
+covered -- the closed-form path used by UMAP and the autograd path used by
+InfoTSNE, TSNE and LargeVis -- each against a single-process reference.
+"""
+
+# Author: Hugues Van Assel <vanasselhugues@gmail.com>
+#
+# License: BSD 3-Clause License
+
+import os
+
+import pytest
+import torch
+import torch.distributed as dist
+
+from torchdr import InfoTSNE, UMAP
+from torchdr.distributed import DistributedContext
+
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("TORCHDR_DISTRIBUTED_TEST") != "1",
+    reason="run through the dedicated multi-process integration workflow",
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def distributed_process_group():
+    """Initialize the process group created by torchrun.
+
+    Fails loudly on a single process: these tests are meaningless unless the
+    gradient chunks really cross a rank boundary, and a silent one-rank run
+    would report green while exercising none of the collective.
+    """
+    dist.init_process_group(backend="gloo")
+    world_size = dist.get_world_size()
+    if world_size < 2:
+        dist.destroy_process_group()
+        pytest.fail(f"launch this module with at least two processes, got {world_size}")
+    yield
+    dist.barrier()
+    dist.destroy_process_group()
+
+
+def _reference_gradient(n_samples, n_components):
+    """Full-matrix gradient a single process would assemble.
+
+    Row ``i`` carries a value that depends only on its global index, so the
+    reference is independent of how the rows are partitioned across ranks.
+    """
+    rows = torch.arange(n_samples, dtype=torch.float32)
+    columns = torch.arange(1, n_components + 1, dtype=torch.float32)
+    return rows[:, None] * columns[None, :]
+
+
+def test_partition_tiles_the_rows_exactly_once():
+    """Every global row is owned by exactly one rank, with no gaps.
+
+    ``compute_chunk_bounds`` and ``get_rank_for_indices`` drive both the sparse
+    symmetrization routing and the gradient scatter, so their agreement across
+    real ranks is a precondition for everything else in this module.
+    """
+    context = DistributedContext()
+    world_size = context.world_size
+
+    for n_samples in (12, 97, 100):
+        chunk_start, chunk_end = context.compute_chunk_bounds(n_samples)
+
+        # This rank's chunk is non-empty and lies inside the range.
+        assert 0 <= chunk_start < chunk_end <= n_samples
+        assert chunk_end - chunk_start < n_samples, "rows must be split across ranks"
+
+        # Every global index is attributed back to the rank that owns it.
+        all_indices = torch.arange(n_samples)
+        owners = DistributedContext.get_rank_for_indices(
+            all_indices, n_samples, world_size
+        )
+        mine = all_indices[owners == context.rank]
+        assert torch.equal(mine, torch.arange(chunk_start, chunk_end))
+
+        # Ranks agree on a partition that covers the range exactly once.
+        gathered_bounds = [None] * world_size
+        dist.all_gather_object(gathered_bounds, (chunk_start, chunk_end))
+        covered = sorted(gathered_bounds)
+        assert covered[0][0] == 0
+        assert covered[-1][1] == n_samples
+        for (_, prev_end), (next_start, _) in zip(covered, covered[1:]):
+            assert prev_end == next_start
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_closed_form_training_step_matches_single_process(dtype):
+    """UMAP's distributed closed-form step reproduces the full gradient.
+
+    Each rank computes the gradient for its own chunk of rows; the step
+    scatters it at ``chunk_start_`` and all-reduces so every rank recovers the
+    gradient a single process would have assembled from all rows.
+    """
+    context = DistributedContext()
+    n_samples, n_components = 40, 3
+    chunk_start, chunk_end = context.compute_chunk_bounds(n_samples)
+
+    # distributed=False avoids the constructor forcing a CUDA device while a
+    # process group is live; world_size>1 is set by hand to take the
+    # distributed branch of _training_step, mirroring the single-process unit
+    # test in test_distributed.py but with a *real* collective.
+    model = UMAP(n_components=n_components, optimizer="SGD", lr=0.0, distributed=False)
+    model.rank = context.rank
+    model.world_size = context.world_size
+    model.encoder = None
+    model.scheduler_ = None
+    model.device_ = torch.device("cpu")
+    model.embedding_ = torch.nn.Parameter(
+        torch.zeros(n_samples, n_components, dtype=dtype)
+    )
+    model.optimizer_ = torch.optim.SGD([model.embedding_], lr=0.0)
+    model.chunk_indices_ = torch.arange(chunk_start, chunk_end)
+    model.chunk_start_ = chunk_start
+
+    reference = _reference_gradient(n_samples, n_components).to(dtype)
+    local_gradient = reference[chunk_start:chunk_end].clone()
+    model._compute_gradients = lambda: local_gradient
+
+    model._training_step()
+
+    assert model.embedding_.grad is not None
+    assert model.embedding_.grad.dtype == dtype
+    torch.testing.assert_close(model.embedding_.grad, reference)
+
+
+def test_autograd_training_step_reduces_gradients_across_ranks():
+    """InfoTSNE's distributed autograd step sums per-rank gradients.
+
+    The autograd branch back-propagates a local loss and all-reduces
+    ``embedding_.grad``. Each rank contributes a distinct scalar multiple of
+    the same embedding, so the summed gradient is a deterministic multiple that
+    is independent of the world size.
+    """
+    context = DistributedContext()
+    n_samples, n_components = 16, 2
+
+    model = InfoTSNE(
+        n_components=n_components, optimizer="SGD", lr=0.0, distributed=False
+    )
+    model.rank = context.rank
+    model.world_size = context.world_size
+    model.encoder = None
+    model.scheduler_ = None
+    model.device_ = torch.device("cpu")
+    model._use_closed_form_gradients = False
+    model.embedding_ = torch.nn.Parameter(torch.ones(n_samples, n_components))
+    model.optimizer_ = torch.optim.SGD([model.embedding_], lr=0.0)
+
+    # Rank r contributes a loss of (r + 1) * sum(Z ** 2); the gradient is
+    # 2 * (r + 1) * Z, so the all-reduced gradient is 2 * Z * sum_r (r + 1).
+    weight = float(context.rank + 1)
+    model._compute_loss = lambda: weight * (model.embedding_**2).sum()
+
+    model._training_step()
+
+    world_size = context.world_size
+    weight_sum = world_size * (world_size + 1) / 2.0
+    expected = 2.0 * torch.ones(n_samples, n_components) * weight_sum
+
+    assert model.embedding_.grad is not None
+    torch.testing.assert_close(model.embedding_.grad, expected)

--- a/torchdr/tests/test_distributed_neighbor_embedding_gpu.py
+++ b/torchdr/tests/test_distributed_neighbor_embedding_gpu.py
@@ -1,0 +1,170 @@
+"""End-to-end distributed neighbor-embedding tests on real GPUs (NCCL).
+
+Unlike the transport-agnostic pieces in
+``test_distributed_neighbor_embedding.py`` (which run on the Gloo CPU backend),
+the full ``UMAP``/``InfoTSNE`` distributed path is GPU-only by design: both
+:class:`torchdr.affinity.base.SparseAffinity` and
+:class:`torchdr.neighbor_embedding.base.NeighborEmbedding` force a CUDA device
+in distributed mode and raise on ``device="cpu"``. These tests therefore cover
+the whole stack -- k-NN sharding, distributed sparse symmetrization, and the
+per-iteration gradient collective -- against a single-process reference, on a
+real NCCL process group.
+
+They are **not** wired into GitHub CI, which has no multi-GPU runner. They are
+gated behind ``TORCHDR_DISTRIBUTED_GPU_TEST=1`` (plus CUDA and at least two
+ranks) and are meant to be run manually or on a scheduled provisioned runner::
+
+    TORCHDR_DISTRIBUTED_GPU_TEST=1 python -m torch.distributed.run \\
+        --standalone --nnodes=1 --nproc-per-node=2 \\
+        -m pytest torchdr/tests/test_distributed_neighbor_embedding_gpu.py -q
+"""
+
+# Author: Hugues Van Assel <vanasselhugues@gmail.com>
+#
+# License: BSD 3-Clause License
+
+import os
+
+import pytest
+import torch
+import torch.distributed as dist
+
+from torchdr import InfoTSNE, UMAP
+from torchdr.affinity import UMAPAffinity
+from torchdr.distributed import init_distributed, shutdown_distributed
+
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("TORCHDR_DISTRIBUTED_GPU_TEST") != "1"
+    or not torch.cuda.is_available(),
+    reason="run manually on a provisioned NCCL multi-GPU runner",
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def distributed_process_group():
+    """Initialize the NCCL process group created by torchrun.
+
+    Fails loudly on a single process: these tests are meaningless unless the
+    rows really cross a rank boundary, and a silent one-rank run would report
+    green while exercising none of the distributed path.
+    """
+    # TorchDR already creates the NCCL group on import when launched under
+    # torchrun with a GPU, so go through its idempotent helper: calling
+    # torch.distributed.init_process_group directly would raise "trying to
+    # initialize the default process group twice". shutdown_distributed only
+    # tears down a group TorchDR itself created, so it is a safe cleanup.
+    init_distributed(backend="nccl")
+    if not dist.is_initialized():
+        pytest.fail("launch this module with torchrun and at least two processes")
+    local_rank = int(os.environ.get("LOCAL_RANK", 0))
+    torch.cuda.set_device(local_rank)
+    world_size = dist.get_world_size()
+    if world_size < 2:
+        shutdown_distributed()
+        pytest.fail(f"launch this module with at least two processes, got {world_size}")
+    yield
+    dist.barrier()
+    shutdown_distributed()
+
+
+def _identical_data(n_samples, n_features, dtype, seed=0):
+    """Deterministic data, identical on every rank.
+
+    The distributed design replicates the full input on each rank and shards
+    only the *rows* that a rank owns, so every rank must start from the same X.
+    """
+    generator = torch.Generator().manual_seed(seed)
+    return torch.randn(n_samples, n_features, generator=generator, dtype=dtype)
+
+
+def _rowwise_to_dense(values, indices, n_columns):
+    """Padded row-wise sparse representation to dense, summing duplicate slots."""
+    dense = torch.zeros((values.shape[0], n_columns), dtype=values.dtype)
+    valid = indices >= 0
+    dense.scatter_add_(1, indices.clamp_min(0), values * valid)
+    return dense
+
+
+def _gather_full_matrix(local_dense):
+    """All-gather each rank's row block (variable height) into the full matrix."""
+    gathered = [None] * dist.get_world_size()
+    dist.all_gather_object(gathered, local_dense.cpu())
+    return torch.cat(gathered)
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_distributed_umap_affinity_matches_single_process(dtype):
+    """Distributed UMAP affinity must equal the single-process affinity.
+
+    Each rank computes the affinity for its own chunk of rows against the full
+    replicated input; concatenating the chunks must rebuild exactly the matrix
+    a single process assembles. This exercises the real k-NN + distributed
+    ``sum_minus_prod`` symmetrization wiring and is sensitive to both the
+    symmetrization-direction bug (rows would stop matching) and any dtype drift.
+    """
+    n_samples, n_features = 128, 16
+    X = _identical_data(n_samples, n_features, dtype)
+
+    distributed = UMAPAffinity(n_neighbors=15, distributed=True, backend="faiss")
+    local_values, local_indices = distributed(X.cuda())
+    local_dense = _rowwise_to_dense(local_values.cpu(), local_indices.cpu(), n_samples)
+    assert local_dense.shape[0] == distributed.chunk_size_
+    full = _gather_full_matrix(local_dense)
+
+    single = UMAPAffinity(n_neighbors=15, distributed=False, backend="faiss")
+    ref_values, ref_indices = single(X.cuda())
+    reference = _rowwise_to_dense(ref_values.cpu(), ref_indices.cpu(), n_samples)
+
+    assert full.shape == (n_samples, n_samples)
+    assert full.dtype == reference.dtype == dtype
+    torch.testing.assert_close(full, reference)
+    # UMAP's sum_minus_prod symmetrization is exactly symmetric; a direction
+    # bug in the distributed exchange breaks this even when shapes line up.
+    torch.testing.assert_close(full, full.T)
+
+
+def _assert_replicated_embedding(embedding, n_samples, n_components):
+    """Embedding is finite, correctly shaped, and identical on every rank."""
+    assert embedding.shape == (n_samples, n_components)
+    assert torch.isfinite(embedding).all()
+    gathered = [None] * dist.get_world_size()
+    dist.all_gather_object(gathered, embedding.detach().cpu())
+    for other in gathered[1:]:
+        # Every rank applies the same all-reduced gradient to the same initial
+        # embedding, so the replicated embeddings must stay in lock-step.
+        torch.testing.assert_close(gathered[0], other)
+
+
+def test_distributed_umap_fit_smoke():
+    """A full distributed UMAP fit (closed-form path) runs and stays replicated."""
+    n_samples, n_features, n_components = 128, 16, 2
+    X = _identical_data(n_samples, n_features, torch.float32, seed=1)
+
+    model = UMAP(
+        n_neighbors=15,
+        n_components=n_components,
+        max_iter=50,
+        random_state=0,
+        distributed=True,
+    )
+    embedding = model.fit_transform(X.cuda())
+
+    _assert_replicated_embedding(embedding, n_samples, n_components)
+
+
+def test_distributed_infotsne_fit_smoke():
+    """A full distributed InfoTSNE fit (autograd path) runs and stays replicated."""
+    n_samples, n_features, n_components = 128, 16, 2
+    X = _identical_data(n_samples, n_features, torch.float32, seed=2)
+
+    model = InfoTSNE(
+        perplexity=30,
+        n_components=n_components,
+        max_iter=50,
+        random_state=0,
+        distributed=True,
+    )
+    embedding = model.fit_transform(X.cuda())
+
+    _assert_replicated_embedding(embedding, n_samples, n_components)


### PR DESCRIPTION
Closes #313.

## Summary

- Adds real-process test coverage for the distributed neighbor-embedding path, which was previously exercised only by a single-process test that mocks `all_reduce` and touches only the closed-form branch.
- `test_distributed_neighbor_embedding.py` (Gloo CPU, wired into CI): row-partition tiling and both gradient modes of `_training_step` — closed-form (UMAP) and autograd (InfoTSNE/TSNE/LargeVis) — against a single-process reference, using the real cross-rank `all_reduce`. The autograd collective had no prior test of any kind.
- `test_distributed_neighbor_embedding_gpu.py` (NCCL GPU, skipped unless `TORCHDR_DISTRIBUTED_GPU_TEST=1` with CUDA and ≥2 ranks; not wired to CI, which has no GPU runner): distributed `UMAPAffinity` matches the single-process affinity (float32/float64), plus end-to-end UMAP and InfoTSNE distributed fit smoke tests.
- Wires the CPU module into `distributed-integration.yml` as a two-process step and adds the relevant trigger paths.

## Test plan

- Gloo CPU, real 2- and 4-process groups: new module passes (4/4 each); existing `test_distributed_integration.py` + `test_distributed_sparse.py` still pass (11/11).
- NCCL, 2× GPU: new GPU module passes (affinity match float32/float64 + UMAP/InfoTSNE fit smoke).
- Decisive baseline/candidate demonstration — each new test fails on a reintroduced defect in the path it covers and passes once reverted:
  - dropping the autograd `all_reduce` → the autograd test fails;
  - scattering the closed-form gradient at offset 0 → the closed-form test fails;
  - routing the distributed run through chunk-local symmetrization → the GPU affinity-match test fails.
