### PR TITLE
[Fix] Coalesce distributed sparse symmetrization on device by default

### DIFF
--- a/torchdr/tests/test_distributed_sparse.py
+++ b/torchdr/tests/test_distributed_sparse.py
@@ -64,7 +64,7 @@ def _rowwise_to_dense(values, indices, n_columns):
     return dense
 
 
-def _symmetrize_local_chunk(values, indices, n_samples, mode):
+def _symmetrize_local_chunk(values, indices, n_samples, mode, coalesce_device="auto"):
     """Run the distributed path on this rank's row chunk."""
     context = DistributedContext()
     chunk_start, chunk_end = context.compute_chunk_bounds(n_samples)
@@ -78,6 +78,7 @@ def _symmetrize_local_chunk(values, indices, n_samples, mode):
         chunk_size=chunk_size,
         n_total=n_samples,
         mode=mode,
+        coalesce_device=coalesce_device,
     )
     return chunk_start, chunk_end, out_values, out_indices
 
@@ -168,3 +169,48 @@ def test_skewed_payload_matches_reference():
             chunk_start:chunk_end
         ],
     )
+
+
+@pytest.mark.parametrize("coalesce_device", ["auto", "cpu", "gpu"])
+def test_coalesce_device_matches_reference(coalesce_device):
+    """Every ``coalesce_device`` setting reproduces the reference on CPU.
+
+    On the Gloo CPU backend all three settings coalesce on the host, so this
+    only locks in that the dispatch accepts each value and leaves the result
+    unchanged. GPU-vs-CPU bitwise equivalence is covered by the opt-in GPU
+    module (``test_distributed_sparse_gpu.py``).
+    """
+    n_samples, n_neighbors = 101, 7
+    values, indices = _build_graph(n_samples, n_neighbors, seed=13, dtype=torch.float32)
+
+    chunk_start, chunk_end, out_values, out_indices = _symmetrize_local_chunk(
+        values, indices, n_samples, "sum_minus_prod", coalesce_device=coalesce_device
+    )
+
+    reference_values, reference_indices = symmetrize_sparse(
+        values, indices, mode="sum_minus_prod"
+    )
+    torch.testing.assert_close(
+        _rowwise_to_dense(out_values, out_indices, n_samples),
+        _rowwise_to_dense(reference_values, reference_indices, n_samples)[
+            chunk_start:chunk_end
+        ],
+    )
+
+
+def test_invalid_coalesce_device_raises():
+    """An unknown ``coalesce_device`` is rejected before any collective runs."""
+    n_samples, n_neighbors = 64, 4
+    values, indices = _build_graph(n_samples, n_neighbors, seed=5, dtype=torch.float32)
+
+    context = DistributedContext()
+    chunk_start, chunk_end = context.compute_chunk_bounds(n_samples)
+    with pytest.raises(ValueError, match="coalesce_device"):
+        distributed_symmetrize_sparse(
+            values[chunk_start:chunk_end].contiguous(),
+            indices[chunk_start:chunk_end].contiguous(),
+            chunk_start=chunk_start,
+            chunk_size=chunk_end - chunk_start,
+            n_total=n_samples,
+            coalesce_device="bogus",
+        )

--- a/torchdr/tests/test_distributed_sparse_gpu.py
+++ b/torchdr/tests/test_distributed_sparse_gpu.py
@@ -24,7 +24,11 @@ import torch
 import torch.distributed as dist
 
 import torchdr.utils.sparse as sparse_mod
-from torchdr.distributed import DistributedContext
+from torchdr.distributed import (
+    DistributedContext,
+    init_distributed,
+    shutdown_distributed,
+)
 from torchdr.utils.sparse import distributed_symmetrize_sparse
 
 
@@ -42,15 +46,20 @@ def distributed_process_group():
     Fails loudly on a single process: the exchange is meaningless unless the
     edges cross a rank boundary.
     """
-    dist.init_process_group(backend="nccl")
+    # Importing TorchDR under torchrun may already have initialized the process
+    # group, so use the idempotent lifecycle helper instead of initializing it
+    # a second time.
+    init_distributed(backend="nccl")
+    if not dist.is_initialized():
+        pytest.fail("launch this module with torchrun and at least two processes")
+    torch.cuda.set_device(int(os.environ.get("LOCAL_RANK", 0)))
     world_size = dist.get_world_size()
     if world_size < 2:
-        dist.destroy_process_group()
+        shutdown_distributed()
         pytest.fail(f"launch this module with at least two processes, got {world_size}")
-    torch.cuda.set_device(int(os.environ.get("LOCAL_RANK", 0)))
     yield
     dist.barrier()
-    dist.destroy_process_group()
+    shutdown_distributed()
 
 
 def _local_device():

--- a/torchdr/tests/test_distributed_sparse_gpu.py
+++ b/torchdr/tests/test_distributed_sparse_gpu.py
@@ -1,0 +1,202 @@
+"""Opt-in GPU/NCCL tests for the distributed sparse symmetrization coalesce.
+
+These require CUDA and an NCCL process group with at least two ranks, so they
+never run on the CPU-only CI. Launch them explicitly on a multi-GPU node::
+
+    TORCHDR_DISTRIBUTED_GPU_TEST=1 python -m torch.distributed.run \
+        --standalone --nnodes=1 --nproc-per-node=2 \
+        -m pytest torchdr/tests/test_distributed_sparse_gpu.py -q
+
+They cover what the Gloo CPU tests cannot: that coalescing on the accelerator
+(``coalesce_device="gpu"`` / ``"auto"``) is bitwise-identical to the CPU offload
+(``coalesce_device="cpu"``), and that ``"auto"`` falls back to CPU on an
+accelerator out-of-memory error while ``"gpu"`` propagates it.
+"""
+
+# Author: Hugues Van Assel <vanasselhugues@gmail.com>
+#
+# License: BSD 3-Clause License
+
+import os
+
+import pytest
+import torch
+import torch.distributed as dist
+
+import torchdr.utils.sparse as sparse_mod
+from torchdr.distributed import DistributedContext
+from torchdr.utils.sparse import distributed_symmetrize_sparse
+
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("TORCHDR_DISTRIBUTED_GPU_TEST") != "1"
+    or not torch.cuda.is_available(),
+    reason="requires CUDA and the opt-in multi-GPU symmetrization workflow",
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def distributed_process_group():
+    """Initialize the NCCL group created by torchrun on this GPU node.
+
+    Fails loudly on a single process: the exchange is meaningless unless the
+    edges cross a rank boundary.
+    """
+    dist.init_process_group(backend="nccl")
+    world_size = dist.get_world_size()
+    if world_size < 2:
+        dist.destroy_process_group()
+        pytest.fail(f"launch this module with at least two processes, got {world_size}")
+    torch.cuda.set_device(int(os.environ.get("LOCAL_RANK", 0)))
+    yield
+    dist.barrier()
+    dist.destroy_process_group()
+
+
+def _local_device():
+    return torch.device("cuda", int(os.environ.get("LOCAL_RANK", 0)))
+
+
+def _build_graph(n_samples, n_neighbors, seed, dtype):
+    """Deterministic asymmetric sparse graph, identical on every rank.
+
+    Columns may repeat within a row, exercising duplicate-edge coalescing.
+    """
+    generator = torch.Generator().manual_seed(seed)
+    indices = torch.randint(
+        0, n_samples, (n_samples, n_neighbors), generator=generator, dtype=torch.long
+    )
+    values = torch.rand(
+        (n_samples, n_neighbors), generator=generator, dtype=torch.float64
+    )
+    return values.to(dtype), indices
+
+
+def _build_graph_distinct(n_samples, n_neighbors, seed, dtype):
+    """Graph with distinct columns per row, mirroring a real k-NN graph.
+
+    With no repeated column in a row, every coalesced (i, j) slot receives at
+    most one contribution from P and one from Pᵀ, so the CPU and accelerator
+    ``scatter_add_`` are bitwise-identical (the accelerator's non-deterministic
+    atomic accumulation only bites for three or more summands per slot).
+    """
+    generator = torch.Generator().manual_seed(seed)
+    order = torch.rand((n_samples, n_samples), generator=generator).argsort(dim=1)
+    indices = order[:, :n_neighbors].contiguous()
+    values = torch.rand(
+        (n_samples, n_neighbors), generator=generator, dtype=torch.float64
+    )
+    return values.to(dtype), indices
+
+
+def _local_chunk(values, indices, n_samples, device):
+    """This rank's contiguous row chunk, moved to ``device``."""
+    context = DistributedContext()
+    chunk_start, chunk_end = context.compute_chunk_bounds(n_samples)
+    assert chunk_end - chunk_start < n_samples, "the rows must be split across ranks"
+    values_chunk = values[chunk_start:chunk_end].contiguous().to(device)
+    indices_chunk = indices[chunk_start:chunk_end].contiguous().to(device)
+    return chunk_start, chunk_end, values_chunk, indices_chunk
+
+
+def _run(
+    values_chunk, indices_chunk, chunk_start, chunk_size, n_total, coalesce_device
+):
+    """Symmetrize a fresh copy of the chunk with the given coalesce device."""
+    return distributed_symmetrize_sparse(
+        values_chunk.clone(),
+        indices_chunk.clone(),
+        chunk_start=chunk_start,
+        chunk_size=chunk_size,
+        n_total=n_total,
+        mode="sum_minus_prod",
+        coalesce_device=coalesce_device,
+    )
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+@pytest.mark.parametrize(
+    "n_samples, n_neighbors", [(256, 8), (301, 7)], ids=["even", "uneven"]
+)
+def test_coalesce_device_bitwise_equivalence(n_samples, n_neighbors, dtype):
+    """CPU, GPU, and auto coalescing yield bitwise-identical output on CUDA."""
+    device = _local_device()
+    values, indices = _build_graph_distinct(
+        n_samples, n_neighbors, seed=n_samples, dtype=dtype
+    )
+    chunk_start, chunk_end, values_chunk, indices_chunk = _local_chunk(
+        values, indices, n_samples, device
+    )
+    chunk_size = chunk_end - chunk_start
+
+    outputs = {
+        arm: _run(values_chunk, indices_chunk, chunk_start, chunk_size, n_samples, arm)
+        for arm in ("cpu", "gpu", "auto")
+    }
+
+    for arm, (out_values, out_indices) in outputs.items():
+        assert out_values.device.type == "cuda", arm
+        assert out_indices.device.type == "cuda", arm
+        assert out_values.dtype == dtype, arm
+
+    ref_values, ref_indices = outputs["cpu"]
+    for arm in ("gpu", "auto"):
+        arm_values, arm_indices = outputs[arm]
+        assert torch.equal(arm_indices, ref_indices), f"{arm} indices differ from cpu"
+        max_abs = (arm_values - ref_values).abs().max().item()
+        assert max_abs == 0.0, f"{arm} values differ from cpu by {max_abs}"
+
+
+def _patch_oom_on_cuda(monkeypatch):
+    """Force the coalesce merge to OOM on CUDA inputs but succeed on CPU."""
+    real_merge = sparse_mod._merge_sparse_keys
+
+    def fake_merge(keys_P, values_P, keys_PT, values_PT, n):
+        if keys_P.is_cuda:
+            raise torch.cuda.OutOfMemoryError
+        return real_merge(keys_P, values_P, keys_PT, values_PT, n)
+
+    monkeypatch.setattr(sparse_mod, "_merge_sparse_keys", fake_merge)
+
+
+def test_auto_falls_back_to_cpu_on_oom(monkeypatch):
+    """``auto`` retries on CPU after an accelerator OOM and stays correct.
+
+    The reference and the fallback both coalesce on CPU, so the result is
+    bitwise-identical regardless of duplicate edges.
+    """
+    n_samples, n_neighbors = 301, 7
+    device = _local_device()
+    values, indices = _build_graph(n_samples, n_neighbors, seed=23, dtype=torch.float32)
+    chunk_start, chunk_end, values_chunk, indices_chunk = _local_chunk(
+        values, indices, n_samples, device
+    )
+    chunk_size = chunk_end - chunk_start
+
+    ref_values, ref_indices = _run(
+        values_chunk, indices_chunk, chunk_start, chunk_size, n_samples, "cpu"
+    )
+
+    _patch_oom_on_cuda(monkeypatch)
+    out_values, out_indices = _run(
+        values_chunk, indices_chunk, chunk_start, chunk_size, n_samples, "auto"
+    )
+
+    assert out_values.device.type == "cuda"
+    assert torch.equal(out_indices, ref_indices)
+    assert (out_values - ref_values).abs().max().item() == 0.0
+
+
+def test_gpu_coalesce_reraises_oom(monkeypatch):
+    """``gpu`` has no fallback: an accelerator OOM propagates to the caller."""
+    n_samples, n_neighbors = 301, 7
+    device = _local_device()
+    values, indices = _build_graph(n_samples, n_neighbors, seed=29, dtype=torch.float32)
+    chunk_start, chunk_end, values_chunk, indices_chunk = _local_chunk(
+        values, indices, n_samples, device
+    )
+    chunk_size = chunk_end - chunk_start
+
+    _patch_oom_on_cuda(monkeypatch)
+    with pytest.raises(torch.cuda.OutOfMemoryError):
+        _run(values_chunk, indices_chunk, chunk_start, chunk_size, n_samples, "gpu")

--- a/torchdr/utils/sparse.py
+++ b/torchdr/utils/sparse.py
@@ -219,6 +219,7 @@ def distributed_symmetrize_sparse(
     chunk_size: int,
     n_total: int,
     mode: Literal["sum", "sum_minus_prod"] = "sum_minus_prod",
+    coalesce_device: Literal["auto", "cpu", "gpu"] = "auto",
 ) -> Tuple[torch.Tensor, torch.LongTensor]:
     """Symmetrize sparse affinity matrix in distributed multi-GPU setting.
 
@@ -241,6 +242,15 @@ def distributed_symmetrize_sparse(
         How to combine P and P^T:
         - "sum": compute Q = P + P^T
         - "sum_minus_prod": compute Q = P + P^T - P∘P^T (default)
+    coalesce_device : {"auto", "cpu", "gpu"}
+        Device on which to coalesce and pack the exchanged edges:
+        - "auto" (default): coalesce on the input device, falling back to CPU on
+          an accelerator out-of-memory error. Fastest, and correct whenever
+          symmetrization is not the memory high-water mark (always true in an
+          end-to-end fit).
+        - "cpu": always coalesce on CPU, minimizing accelerator memory for a
+          standalone affinity build on a constrained device at a wall-time cost.
+        - "gpu": always coalesce on the input device with no CPU fallback.
 
     Returns
     -------
@@ -252,13 +262,21 @@ def distributed_symmetrize_sparse(
     Notes
     -----
     Edge exchange is performed on the input device with ``all_to_all_single``
-    over flat buffers, which both NCCL and the Gloo CPU backend support.
-    Coalescing and row-wise packing are then performed on CPU to reduce peak
-    accelerator memory. The returned tensors are moved back to the input device.
+    over flat buffers, which both NCCL and the Gloo CPU backend support. The
+    subsequent coalescing (a ``torch.unique`` over the encoded edge keys) and
+    row-wise packing run on the device chosen by ``coalesce_device``. Coalescing
+    on the accelerator is markedly faster but transiently raises accelerator
+    memory; the ``"cpu"`` option, and the ``"auto"`` out-of-memory fallback, cap
+    that memory for a standalone build on a constrained device. The returned
+    tensors are always on the input device.
     """
     if not dist.is_initialized():
         raise RuntimeError(
             "distributed_symmetrize requires torch.distributed to be initialized"
+        )
+    if coalesce_device not in ("auto", "cpu", "gpu"):
+        raise ValueError(
+            f"coalesce_device must be 'auto', 'cpu', or 'gpu', got {coalesce_device!r}"
         )
 
     world_size = dist.get_world_size()
@@ -301,38 +319,58 @@ def distributed_symmetrize_sparse(
     dist.all_to_all_single(transpose_values, values_sorted, recv_splits, send_splits)
     del keys_sorted, values_sorted, send_splits, recv_splits
 
-    # Step 5: Offload local and received edges before the memory-heavy unique.
-    local_keys = keys.cpu()
-    local_values = v.cpu()
-    del keys, v
-    transpose_keys = transpose_keys.cpu()
-    transpose_values = transpose_values.cpu()
+    # Step 5: Coalesce and pack the exchanged edges on the selected device. The
+    # ``torch.unique`` over the int64 keys is the memory-heavy step; running it on
+    # the accelerator is far faster but transiently costs memory. ``_coalesce``
+    # rebinds only its own parameters, so the post-exchange buffers survive intact
+    # and the "auto" path can retry on CPU after an accelerator OOM.
+    def _coalesce(local_keys, local_values, recv_keys, recv_values):
+        # Received keys encode original (i, j) entries. Rewrite them out-of-place
+        # as (j, i) to retain their provenance as Pᵀ rather than treating them as
+        # P, leaving ``recv_keys`` intact for a possible CPU retry.
+        received_rows = torch.div(recv_keys, n_total, rounding_mode="floor")
+        recv_keys = recv_keys.remainder(n_total)
+        recv_keys.mul_(n_total).add_(received_rows)
+        del received_rows
 
-    # Received keys encode original (i, j) entries. Rewrite them in place as
-    # (j, i), retaining their provenance as Pᵀ rather than treating them as P.
-    received_rows = torch.div(transpose_keys, n_total, rounding_mode="floor")
-    transpose_keys.remainder_(n_total).mul_(n_total).add_(received_rows)
-    del received_rows
+        # Coalesce P and Pᵀ separately. This is both correct for reciprocal edges
+        # and avoids duplicating the already combined edge list a second time.
+        i_sym, j_sym, vP, vPT = _merge_sparse_keys(
+            local_keys, local_values, recv_keys, recv_values, n_total
+        )
+        v_sym = _combine_P_PT(vP, vPT, mode)
+        del vP, vPT
 
-    # Step 6: Coalesce P and Pᵀ separately. This is both correct for reciprocal
-    # edges and avoids duplicating the already combined edge list a second time.
-    i_sym, j_sym, vP, vPT = _merge_sparse_keys(
-        local_keys,
-        local_values,
-        transpose_keys,
-        transpose_values,
-        n_total,
-    )
-    del local_keys, local_values, transpose_keys, transpose_values
+        # Keep only the rows this rank owns and pack them row-wise.
+        local_mask = (i_sym >= chunk_start) & (i_sym < chunk_start + chunk_size)
+        i_local = i_sym[local_mask].sub_(chunk_start)
+        return pack_to_rowwise(
+            i_local, j_sym[local_mask], v_sym[local_mask], chunk_size
+        )
 
-    # Step 7: Combine components on CPU and pack the rows owned by this rank.
-    v_sym = _combine_P_PT(vP, vPT, mode)
-    del vP, vPT
-    local_mask = (i_sym >= chunk_start) & (i_sym < chunk_start + chunk_size)
-    i_local = i_sym[local_mask].sub_(chunk_start)
-    j_local = j_sym[local_mask]
-    v_local = v_sym[local_mask]
-    values_out, indices_out = pack_to_rowwise(i_local, j_local, v_local, chunk_size)
+    force_cpu = coalesce_device == "cpu" or device.type != "cuda"
+    if not force_cpu:
+        try:
+            values_out, indices_out = _coalesce(
+                keys, v, transpose_keys, transpose_values
+            )
+        except torch.cuda.OutOfMemoryError:
+            if coalesce_device == "gpu":
+                raise
+            # Never regress to an OOM: retry the coalesce on CPU.
+            torch.cuda.empty_cache()
+            force_cpu = True
 
-    # Step 8: Restore the caller's device contract.
+    if force_cpu:
+        # Move the exchanged buffers to host and free the accelerator originals so
+        # a standalone build on a constrained device keeps a minimal accelerator
+        # footprint (the memory behavior introduced in #254).
+        local_keys, local_values = keys.cpu(), v.cpu()
+        recv_keys, recv_values = transpose_keys.cpu(), transpose_values.cpu()
+        del keys, v, transpose_keys, transpose_values
+        values_out, indices_out = _coalesce(
+            local_keys, local_values, recv_keys, recv_values
+        )
+
+    # Step 6: Restore the caller's device contract.
     return values_out.to(device), indices_out.to(device)


### PR DESCRIPTION
## Verdict

**APPROVE** — coalescing on the input device makes the default multi-GPU fit
~20% faster with bitwise-identical output and no change to whole-fit peak memory;
the CPU offload stays available for a memory-constrained standalone build.

## Summary

- `distributed_symmetrize_sparse` unconditionally offloaded the post-exchange
  coalesce and row-wise packing to CPU to cap peak accelerator memory during a
  standalone affinity build.
- In an end-to-end fit the symmetrization region is never the memory
  high-water mark (the optimization loop's negative-sampling buffers dominate),
  so the offload buys no headroom while costing ~20% of the multi-GPU fit.
- Adds a `coalesce_device` keyword: `"auto"` (default) coalesces on the input
  device and falls back to CPU on an accelerator out-of-memory error; `"cpu"`
  forces the previous offload for a standalone build on a constrained device;
  `"gpu"` forces on-device with no fallback.
- The received-key rewrite is now out-of-place so the exchanged buffers survive
  intact for the CPU retry; the fallback runs after all collectives complete, so
  a per-rank OOM cannot deadlock.
- The single library caller (multi-GPU sparse `UMAPAffinity`) keeps the default,
  so the fit path gets the speedup with no API change.

Closes #315.

## Test plan

- New opt-in NCCL tests (`test_distributed_sparse_gpu.py`,
  `TORCHDR_DISTRIBUTED_GPU_TEST=1`): `cpu`/`gpu`/`auto` are bitwise-identical on
  CUDA (float32/float64, even/uneven chunks); `auto` falls back to CPU on an
  injected OOM and stays bitwise-correct; `gpu` re-raises.
- Existing Gloo CPU suite (`test_distributed_sparse.py`) parametrized over the
  three modes plus an invalid-value `ValueError` check — 14 passed on a
  2-process runner.
- Production validation on 2x B200 (NCCL): bitwise `cpu == gpu == auto` at
  n=200k and n=1M on both ranks; the OOM fallback returns on-device and
  bitwise-equal to `cpu`.
- End-to-end `UMAP.fit_transform` on real data (zheng PCA-50), 2x B200, 3 reps:
  default `auto` is ~21% faster at n=200k and ~20% faster at n=1.3M than the CPU
  offload; symmetrization drops from ~21% of the fit to under 0.2%; whole-fit
  peak allocation unchanged (delta +0.2 MB); final embedding bitwise-identical
  across all three modes.
