### PR TITLE
[Fix] Suppress duplicate INFO logs on non-zero distributed ranks

### DIFF
--- a/torchdr/tests/test_utils.py
+++ b/torchdr/tests/test_utils.py
@@ -4,6 +4,8 @@
 #
 # License: BSD 3-Clause License
 
+import logging
+
 import numpy as np
 import pytest
 import torch
@@ -1668,3 +1670,69 @@ def test_faiss_check_installation_mock_incomplete():
         assert faiss_module is None
         assert error_msg is not None
         assert "incomplete" in error_msg.lower() or "missing" in error_msg.lower()
+
+
+class TestRankAwareLogging:
+    """`set_logger` keeps INFO on rank 0 and silences other ranks.
+
+    In a distributed run every rank executes the same code, so INFO progress
+    logs would otherwise be printed once per rank. These tests exercise the
+    rank-aware gating without spawning real processes by monkeypatching the
+    ``torch.distributed`` primitives that :func:`_info_logging_is_silenced`
+    inspects. Each case uses a unique logger name because ``logging.getLogger``
+    returns process-wide singletons that would otherwise leak state.
+    """
+
+    @staticmethod
+    def _fake_dist(monkeypatch, *, available, initialized, rank):
+        monkeypatch.setattr(torch.distributed, "is_available", lambda: available)
+        monkeypatch.setattr(torch.distributed, "is_initialized", lambda: initialized)
+        monkeypatch.setattr(torch.distributed, "get_rank", lambda: rank)
+
+    def test_non_distributed_verbose_is_info(self, monkeypatch):
+        from torchdr.utils import set_logger
+
+        monkeypatch.delenv("TORCHDR_LOG_ALL_RANKS", raising=False)
+        self._fake_dist(monkeypatch, available=True, initialized=False, rank=0)
+        logger = set_logger("torchdr_test_nd_verbose", verbose=True)
+        assert logger.level == logging.INFO
+
+    def test_non_distributed_quiet_is_warning(self, monkeypatch):
+        from torchdr.utils import set_logger
+
+        monkeypatch.delenv("TORCHDR_LOG_ALL_RANKS", raising=False)
+        self._fake_dist(monkeypatch, available=True, initialized=False, rank=0)
+        logger = set_logger("torchdr_test_nd_quiet", verbose=False)
+        assert logger.level == logging.WARNING
+
+    def test_rank0_keeps_info(self, monkeypatch):
+        from torchdr.utils import set_logger
+
+        monkeypatch.delenv("TORCHDR_LOG_ALL_RANKS", raising=False)
+        self._fake_dist(monkeypatch, available=True, initialized=True, rank=0)
+        logger = set_logger("torchdr_test_rank0", verbose=True)
+        assert logger.level == logging.INFO
+
+    def test_nonzero_rank_is_silenced(self, monkeypatch):
+        from torchdr.utils import set_logger
+
+        monkeypatch.delenv("TORCHDR_LOG_ALL_RANKS", raising=False)
+        self._fake_dist(monkeypatch, available=True, initialized=True, rank=2)
+        logger = set_logger("torchdr_test_rank2", verbose=True)
+        assert logger.level == logging.WARNING
+
+    def test_nonzero_rank_opt_in_restores_info(self, monkeypatch):
+        from torchdr.utils import set_logger
+
+        monkeypatch.setenv("TORCHDR_LOG_ALL_RANKS", "1")
+        self._fake_dist(monkeypatch, available=True, initialized=True, rank=2)
+        logger = set_logger("torchdr_test_rank2_optin", verbose=True)
+        assert logger.level == logging.INFO
+
+    def test_nonzero_rank_quiet_unchanged(self, monkeypatch):
+        from torchdr.utils import set_logger
+
+        monkeypatch.delenv("TORCHDR_LOG_ALL_RANKS", raising=False)
+        self._fake_dist(monkeypatch, available=True, initialized=True, rank=2)
+        logger = set_logger("torchdr_test_rank2_quiet", verbose=False)
+        assert logger.level == logging.WARNING

--- a/torchdr/utils/utils.py
+++ b/torchdr/utils/utils.py
@@ -17,6 +17,24 @@ from .keops import is_lazy_tensor, LazyTensor, LazyTensorType
 from .wrappers import wrap_vectors
 
 
+def _info_logging_is_silenced() -> bool:
+    """Whether ``INFO`` logging should be suppressed on this process.
+
+    In a distributed run every rank runs the same code and would otherwise emit
+    identical progress logs, so the output is duplicated ``world_size`` times. By
+    default only rank 0 keeps ``INFO`` logging; the other ranks are silenced down
+    to ``WARNING`` so warnings and errors are never hidden. Set the environment
+    variable ``TORCHDR_LOG_ALL_RANKS=1`` to keep ``INFO`` logging on every rank.
+    """
+    if os.environ.get("TORCHDR_LOG_ALL_RANKS", "0") == "1":
+        return False
+    return (
+        torch.distributed.is_available()
+        and torch.distributed.is_initialized()
+        and torch.distributed.get_rank() != 0
+    )
+
+
 def set_logger(name: str, verbose: bool = False) -> logging.Logger:
     """Set up a logger for a given name.
 
@@ -32,6 +50,13 @@ def set_logger(name: str, verbose: bool = False) -> logging.Logger:
     -------
     logging.Logger
         The configured logger instance.
+
+    Notes
+    -----
+    In a distributed run only rank 0 emits ``INFO`` messages by default so the
+    per-iteration progress logs are printed once instead of once per rank;
+    warnings and errors are still emitted on every rank. Set
+    ``TORCHDR_LOG_ALL_RANKS=1`` to restore ``INFO`` logging on all ranks.
     """
     logger = logging.getLogger(name)
     if not logger.handlers:
@@ -40,7 +65,7 @@ def set_logger(name: str, verbose: bool = False) -> logging.Logger:
         handler.setFormatter(formatter)
         logger.addHandler(handler)
 
-    if verbose:
+    if verbose and not _info_logging_is_silenced():
         logger.setLevel(logging.INFO)
     else:
         logger.setLevel(logging.WARNING)


### PR DESCRIPTION
## Verdict

**APPROVE** (usability)

## Summary

- In a distributed run every rank executes the same code, so every `INFO` progress line is emitted once per rank. The console shows `world_size` interleaved copies of identical output (the seed message, affinity symmetrization, the per-iteration `[k/max_iter]` progress, the edge-keep percentage, and so on). On an 8-GPU node that is 8× the log volume, and the duplication grows with the number of ranks, so it is worst exactly when distributed mode matters most.
- The fix gates `INFO` by rank at a single chokepoint, `set_logger`, which both `DRModule` and the affinity base use, so every estimator and affinity benefits. By default only rank 0 keeps `INFO`; the other ranks drop to `WARNING`, so warnings and errors are still emitted on every rank and problems are never hidden. Set `TORCHDR_LOG_ALL_RANKS=1` to restore `INFO` on all ranks for debugging a specific rank.
- Non-distributed behavior is unchanged: the gate only engages when a process group is initialized.
- Production diff: `torchdr/utils/utils.py` +26 −1, plus regression tests.

## Motivation

Closes #317.

This is a pure logging change with no data-path effect: it only sets logger levels. It removes progress output that is duplicated once per rank while guaranteeing that warnings and errors continue to appear on every rank.

## Benchmark design

- A real two-process run on the **Gloo** CPU backend. The gate keys off the global process-group state (`torch.distributed.is_initialized()` and `get_rank()`), which is identical under Gloo and NCCL, so the behavior is backend- and device-independent. The end-to-end `distributed=True` fit forces a CUDA device by design, so each rank runs an ordinary verbose fit under a live group, which reproduces exactly the per-rank duplication of a real multi-GPU run.
- Each rank records the level that `set_logger(verbose=True)` assigns it and counts the `INFO` and `WARNING` records that reach the root logger during the fit. An explicit `WARNING` confirms warnings survive on silenced ranks.
- Three configurations were run: baseline, candidate with default environment, and candidate with `TORCHDR_LOG_ALL_RANKS=1`; three repetitions for wall time.

## Results (world size 2)

| Configuration | rank 0 level / INFO | rank 1 level / INFO | WARNING per rank |
|---|---|---|---|
| Baseline | INFO / 5 | INFO / 5 | 1 |
| Candidate (default) | INFO / 5 | WARNING / 0 | 1 |
| Candidate (`TORCHDR_LOG_ALL_RANKS=1`) | INFO / 5 | INFO / 5 | 1 |

- Baseline prints the full `INFO` stream on both ranks (2× duplication, growing with `world_size`). The candidate prints it once, on rank 0, while every rank still emits `WARNING`. The opt-in environment variable restores per-rank `INFO`.
- Median fit wall time (rank 0, three repetitions): baseline 0.463 s versus candidate 0.461 s, a −0.4% difference that is within run-to-run noise. A logging-level gate allocates nothing and does strictly less work on a silenced rank, so there is no runtime or memory cost; this is well within the 5% usability bar.

## Review and validation

- New `TestRankAwareLogging` (6 cases) covers rank 0, a non-zero rank, the opt-in variable, non-distributed mode, and quiet mode, monkeypatching the `torch.distributed` primitives so it runs in ordinary CPU CI.
- The two-process Gloo demonstration above confirms the end-to-end effect on real processes.
- Full pre-commit suite passes.
- No benchmark scripts or machine-specific artifacts are added to the repository.

## Risks and limitations

- The gate engages for any estimator constructed while a process group is live, regardless of the estimator's own `distributed` flag. This is intentional: if a group is initialized the output is duplicated across ranks, so rank-0-only `INFO` is the right default, and `TORCHDR_LOG_ALL_RANKS=1` opts back in per rank.
- The demonstration uses Gloo on CPU because the `distributed=True` fit path is GPU-only, but the gate logic is identical under NCCL.
