### PR TITLE
[Perf] Flatten UMAP's padded affinity into a CSR attractive gradient

### DIFF
--- a/torchdr/neighbor_embedding/umap.py
+++ b/torchdr/neighbor_embedding/umap.py
@@ -265,6 +265,9 @@ class UMAP(NegativeSamplingNeighborEmbedding):
 
         self.register_buffer("attractive_source_", source, persistent=False)
         self.register_buffer("attractive_target_", target, persistent=False)
+        self.register_buffer(
+            "attractive_counts_", edge_mask.sum(dim=1), persistent=False
+        )
         self.register_buffer("epochs_per_sample", epochs_per_sample, persistent=False)
         self.register_buffer(
             "epoch_of_next_sample", epochs_per_sample.clone(), persistent=False
@@ -298,13 +301,12 @@ class UMAP(NegativeSamplingNeighborEmbedding):
         ]
         D.masked_fill_(~self.mask_affinity_in_, 0)
 
-        # Segment-reduce the per-edge contributions back to their source rows.
-        grad = torch.zeros(
-            (self.chunk_indices_.shape[0], self.embedding_.shape[1]),
-            dtype=self.embedding_.dtype,
-            device=self.embedding_.device,
+        # The edges are ordered by source row, so a segmented reduction avoids
+        # CUDA atomics and remains deterministic without giving up the flat
+        # representation's performance and memory savings.
+        grad = torch.segment_reduce(
+            diff.mul_(D.unsqueeze(1)), "sum", lengths=self.attractive_counts_
         )
-        grad.index_add_(0, source, diff.mul_(D.unsqueeze(1)))
         grad.clamp_(-4, 4)  # clamp as in umap repo
         return grad
 
@@ -323,15 +325,12 @@ class UMAP(NegativeSamplingNeighborEmbedding):
         # Filter to keep 'negative_sample_rate' negative edges per positive edge.
         # mask_affinity_in_ is a flat per-edge mask, so the per-row count of
         # active positive edges is a segment sum over their source rows.
-        active_positive = torch.zeros(
-            self.chunk_indices_.shape[0],
-            dtype=torch.long,
-            device=self.embedding_.device,
+        active_positive = torch.segment_reduce(
+            self.mask_affinity_in_.to(self.embedding_.dtype),
+            "sum",
+            lengths=self.attractive_counts_,
         )
-        active_positive.index_add_(
-            0, self.attractive_source_, self.mask_affinity_in_.to(torch.long)
-        )
-        neg_counts = (active_positive * self.negative_sample_rate).to(torch.long)
+        neg_counts = (active_positive * self.negative_sample_rate).long()
         col_idx = torch.arange(self.n_negatives, device=self.embedding_.device)
         filtered_edges = col_idx[None, :].ge(neg_counts[:, None])
         D.masked_fill_(filtered_edges, 0)
@@ -451,6 +450,7 @@ class UMAP(NegativeSamplingNeighborEmbedding):
             "mask_affinity_in_",
             "attractive_source_",
             "attractive_target_",
+            "attractive_counts_",
         ):
             saved[attr] = (hasattr(self, attr), getattr(self, attr, None))
 
@@ -461,6 +461,7 @@ class UMAP(NegativeSamplingNeighborEmbedding):
         source, target, edge_mask = self._flatten_padded_edges(self.NN_indices_)
         self.attractive_source_ = source
         self.attractive_target_ = target
+        self.attractive_counts_ = edge_mask.sum(dim=1)
         self.epochs_per_sample = epochs_per_sample[edge_mask]
         self.epoch_of_next_sample = self.epochs_per_sample.clone()
 

--- a/torchdr/neighbor_embedding/umap.py
+++ b/torchdr/neighbor_embedding/umap.py
@@ -220,34 +220,69 @@ class UMAP(NegativeSamplingNeighborEmbedding):
             **kwargs,
         )
 
+    @staticmethod
+    def _flatten_padded_edges(nn_indices):
+        """Flatten a max-degree-padded neighbor grid to flat per-edge arrays.
+
+        The symmetrized UMAP affinity is delivered as a ``(chunk, max_degree)``
+        grid padded with ``-1`` column indices, where ``max_degree`` can be far
+        larger than the mean degree. This returns, in row-major order over the
+        real (non-padded) edges, the local ``source`` row and the global
+        ``target`` column of every edge, together with the boolean ``mask`` so
+        that aligned per-edge tensors (e.g. the affinity values) can be
+        flattened the same way.
+        """
+        mask = nn_indices >= 0
+        counts = mask.sum(dim=1)
+        source = torch.repeat_interleave(
+            torch.arange(nn_indices.shape[0], device=nn_indices.device), counts
+        )
+        target = nn_indices[mask].contiguous()
+        return source, target, mask
+
     def on_affinity_computation_end(self):
         super().on_affinity_computation_end()
 
-        # Remove small affinity edges
-        A_max = self.affinity_in_.max()
+        # Flatten the max-degree-padded affinity grid to its real edges only
+        # (a CSR-style layout), so the closed-form attractive gradient runs over
+        # ``nnz`` edges instead of ``chunk * max_degree`` mostly-padded slots.
+        source, target, edge_mask = self._flatten_padded_edges(self.NN_indices_)
+        edge_affinity = self.affinity_in_[edge_mask]
+
+        # Remove small affinity edges (padded slots are already excluded).
+        A_max = edge_affinity.max()
         threshold = A_max / self.max_iter
-        small_affinity_edges = self.affinity_in_ <= threshold
+        small_affinity_edges = edge_affinity <= threshold
 
         if self.verbose:
             kept_pct = (~small_affinity_edges).float().mean().item() * 100
             self.logger.info(f"Keeping {kept_pct:.1f}% of affinity edges.")
 
-        self.affinity_in_.add_(1e-3).reciprocal_().mul_(A_max)
-        self.affinity_in_.masked_fill_(
+        epochs_per_sample = edge_affinity.add(1e-3).reciprocal_().mul_(A_max)
+        epochs_per_sample.masked_fill_(
             small_affinity_edges, float("inf")
         )  # avoid updating these edges
-        self.register_buffer("epochs_per_sample", self.affinity_in_, persistent=False)
+
+        self.register_buffer("attractive_source_", source, persistent=False)
+        self.register_buffer("attractive_target_", target, persistent=False)
+        self.register_buffer("epochs_per_sample", epochs_per_sample, persistent=False)
         self.register_buffer(
-            "epoch_of_next_sample", self.epochs_per_sample.clone(), persistent=False
+            "epoch_of_next_sample", epochs_per_sample.clone(), persistent=False
         )
 
+        # The padded grid is no longer needed: UMAP uses closed-form gradients
+        # (no loss reads ``affinity_in_``) and both gradient terms now index the
+        # flat edge buffers. Free it to reclaim the max-degree padding overhead.
+        del self.affinity_in_
+        del self.NN_indices_
+
     def _compute_attractive_gradients(self):
-        D = pairwise_distances_indexed(
-            self.embedding_,
-            query_indices=self.chunk_indices_,
-            key_indices=self.NN_indices_,
-            metric="sqeuclidean",
+        source = self.attractive_source_
+        diff = (
+            self.embedding_[self.chunk_indices_[source]]
+            - self.embedding_[self.attractive_target_]
         )
+        D = diff.pow(2).sum(dim=1)
         positive_edges = D > 0
         D_ = 1 + self._a * D**self._b
         D.pow_(self._b - 1)
@@ -263,11 +298,13 @@ class UMAP(NegativeSamplingNeighborEmbedding):
         ]
         D.masked_fill_(~self.mask_affinity_in_, 0)
 
-        diff = (
-            self.embedding_[self.chunk_indices_].unsqueeze(1)
-            - self.embedding_[self.NN_indices_]
+        # Segment-reduce the per-edge contributions back to their source rows.
+        grad = torch.zeros(
+            (self.chunk_indices_.shape[0], self.embedding_.shape[1]),
+            dtype=self.embedding_.dtype,
+            device=self.embedding_.device,
         )
-        grad = torch.einsum("ijk,ij->ik", diff, D)
+        grad.index_add_(0, source, diff.mul_(D.unsqueeze(1)))
         grad.clamp_(-4, 4)  # clamp as in umap repo
         return grad
 
@@ -284,9 +321,17 @@ class UMAP(NegativeSamplingNeighborEmbedding):
         D.reciprocal_().mul_(-2 * self._b)
 
         # Filter to keep 'negative_sample_rate' negative edges per positive edge.
-        neg_counts = (self.mask_affinity_in_.sum(dim=1) * self.negative_sample_rate).to(
-            torch.long
+        # mask_affinity_in_ is a flat per-edge mask, so the per-row count of
+        # active positive edges is a segment sum over their source rows.
+        active_positive = torch.zeros(
+            self.chunk_indices_.shape[0],
+            dtype=torch.long,
+            device=self.embedding_.device,
         )
+        active_positive.index_add_(
+            0, self.attractive_source_, self.mask_affinity_in_.to(torch.long)
+        )
+        neg_counts = (active_positive * self.negative_sample_rate).to(torch.long)
         col_idx = torch.arange(self.n_negatives, device=self.embedding_.device)
         filtered_edges = col_idx[None, :].ge(neg_counts[:, None])
         D.masked_fill_(filtered_edges, 0)
@@ -400,10 +445,23 @@ class UMAP(NegativeSamplingNeighborEmbedding):
         saved = super()._enter_transform(embedding_new, train_emb, affinity, nn_indices)
 
         # Save UMAP-specific state
-        for attr in ("epochs_per_sample", "epoch_of_next_sample", "mask_affinity_in_"):
+        for attr in (
+            "epochs_per_sample",
+            "epoch_of_next_sample",
+            "mask_affinity_in_",
+            "attractive_source_",
+            "attractive_target_",
+        ):
             saved[attr] = (hasattr(self, attr), getattr(self, attr, None))
 
-        self.epochs_per_sample = epochs_per_sample
-        self.epoch_of_next_sample = epochs_per_sample.clone()
+        # Flatten the (offset) transform neighbor grid to the same flat edge
+        # layout used at fit time so the shared closed-form gradient runs over
+        # real edges. super()._enter_transform set NN_indices_ to the global
+        # transform neighbor indices.
+        source, target, edge_mask = self._flatten_padded_edges(self.NN_indices_)
+        self.attractive_source_ = source
+        self.attractive_target_ = target
+        self.epochs_per_sample = epochs_per_sample[edge_mask]
+        self.epoch_of_next_sample = self.epochs_per_sample.clone()
 
         return saved

--- a/torchdr/tests/test_transform.py
+++ b/torchdr/tests/test_transform.py
@@ -345,8 +345,13 @@ def test_umap_transform_uses_epoch_schedule():
         assert not torch.equal(
             model.epochs_per_sample, torch.zeros_like(model.epochs_per_sample)
         )
-        assert torch.isfinite(model.epochs_per_sample[0, 0])
-        assert torch.isinf(model.epochs_per_sample[1, 1])
+        # epochs_per_sample is a flat per-edge buffer (one entry per real
+        # neighbor edge, row-major), not a padded (n, k) grid: the strongest
+        # edge (affinity 1.0) keeps a finite schedule and the weakest edge
+        # (affinity 0.01, below the drop threshold) is set to inf.
+        assert model.epochs_per_sample.ndim == 1
+        assert torch.isfinite(model.epochs_per_sample[0])
+        assert torch.isinf(model.epochs_per_sample[-1])
     finally:
         model._exit_transform(saved)
 

--- a/torchdr/tests/test_umap_csr.py
+++ b/torchdr/tests/test_umap_csr.py
@@ -2,7 +2,7 @@
 
 UMAP flattens the max-degree-padded ``(chunk, max_degree)`` neighbor grid into
 flat per-edge ``source``/``target`` buffers and computes the closed-form
-attractive gradient with a segment reduction (``index_add_``) instead of a
+attractive gradient with a deterministic segment reduction instead of a
 padded ``einsum``. These tests pin that flattening and verify the segment
 reduction against an independent brute-force reference, on CPU (run in CI) and,
 when available, on CUDA (opt-in device coverage; the campaign's target setting).
@@ -58,7 +58,7 @@ def _reference_attractive_grad(emb, chunk_indices, source, target, a, b, sampled
     """Brute-force per-edge accumulation of the UMAP attractive gradient.
 
     Mirrors the closed-form coefficient in ``_compute_attractive_gradients`` but
-    accumulates edge by edge in Python, independent of ``index_add_``.
+    accumulates edge by edge in Python, independent of ``segment_reduce``.
     """
     n_rows = chunk_indices.shape[0]
     grad = torch.zeros((n_rows, emb.shape[1]), dtype=emb.dtype, device=emb.device)
@@ -109,6 +109,7 @@ def test_attractive_gradient_matches_bruteforce_reference(device):
     model.chunk_indices_ = torch.arange(n, device=device)
     model.attractive_source_ = source.to(device)
     model.attractive_target_ = target.to(device)
+    model.attractive_counts_ = torch.bincount(source, minlength=n).to(device)
     # epoch_of_next_sample <= n_iter_ + 1 selects an edge this step; push the
     # unsampled edges just past the threshold.
     epoch_next = torch.where(
@@ -131,17 +132,14 @@ def test_attractive_gradient_matches_bruteforce_reference(device):
     torch.testing.assert_close(grad, grad_ref, rtol=1e-9, atol=1e-9)
 
 
-def test_umap_fit_cpu_is_reproducible():
-    """The CSR path stays reproducible on CPU (index_add_ is deterministic there).
-
-    GPU atomics make the segment reduction order-dependent, but the CPU
-    reduction is deterministic, so a fixed seed reproduces the embedding.
-    """
+@pytest.mark.parametrize("device", DEVICES)
+def test_umap_fit_is_reproducible(device):
+    """The CSR path remains reproducible with a fixed seed."""
     X, _ = toy_dataset(80, "float32")
     kw = dict(
         n_components=2,
         backend=None,
-        device="cpu",
+        device=device,
         init="normal",
         max_iter=40,
         random_state=0,
@@ -150,7 +148,7 @@ def test_umap_fit_cpu_is_reproducible():
     )
     a = torch.as_tensor(UMAP(**kw).fit_transform(X))
     b = torch.as_tensor(UMAP(**kw).fit_transform(X))
-    torch.testing.assert_close(a, b, rtol=1e-5, atol=1e-5)
+    assert torch.equal(a, b)
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")

--- a/torchdr/tests/test_umap_csr.py
+++ b/torchdr/tests/test_umap_csr.py
@@ -1,0 +1,179 @@
+"""Tests for UMAP's flat (CSR-style) attractive-gradient representation.
+
+UMAP flattens the max-degree-padded ``(chunk, max_degree)`` neighbor grid into
+flat per-edge ``source``/``target`` buffers and computes the closed-form
+attractive gradient with a segment reduction (``index_add_``) instead of a
+padded ``einsum``. These tests pin that flattening and verify the segment
+reduction against an independent brute-force reference, on CPU (run in CI) and,
+when available, on CUDA (opt-in device coverage; the campaign's target setting).
+"""
+
+# License: BSD 3-Clause License
+
+import numpy as np
+import pytest
+import torch
+
+from torchdr.neighbor_embedding import UMAP
+from torchdr.tests.utils import toy_dataset
+
+
+DEVICES = ["cpu"] + (["cuda"] if torch.cuda.is_available() else [])
+
+
+def test_flatten_padded_edges_row_major():
+    """Padded grid flattens to row-major real edges with a sorted source."""
+    # max_degree 4; rows with 2, 4, 0 and 1 real edges (-1 is padding).
+    nn = torch.tensor(
+        [
+            [3, 5, -1, -1],
+            [0, 1, 2, 4],
+            [-1, -1, -1, -1],
+            [7, -1, -1, -1],
+        ]
+    )
+    source, target, mask = UMAP._flatten_padded_edges(nn)
+
+    assert source.tolist() == [0, 0, 1, 1, 1, 1, 3]
+    assert target.tolist() == [3, 5, 0, 1, 2, 4, 7]
+    assert mask.tolist() == (nn >= 0).tolist()
+    # source is monotonic non-decreasing (contiguous per-row segments): this is
+    # what lets an aligned per-edge tensor be gathered the same way ...
+    assert torch.all(source[1:] >= source[:-1])
+    # ... e.g. the affinity values flatten by the very same mask.
+    aff = torch.arange(nn.numel(), dtype=torch.float32).reshape(nn.shape)
+    assert aff[mask].tolist() == [0, 1, 4, 5, 6, 7, 12]
+
+
+def test_flatten_padded_edges_all_padded_row_is_dropped():
+    """A fully-padded row contributes no edges (an isolated node)."""
+    nn = torch.tensor([[-1, -1], [2, 3]])
+    source, target, mask = UMAP._flatten_padded_edges(nn)
+    assert source.tolist() == [1, 1]
+    assert target.tolist() == [2, 3]
+    assert mask.sum().item() == 2
+
+
+def _reference_attractive_grad(emb, chunk_indices, source, target, a, b, sampled):
+    """Brute-force per-edge accumulation of the UMAP attractive gradient.
+
+    Mirrors the closed-form coefficient in ``_compute_attractive_gradients`` but
+    accumulates edge by edge in Python, independent of ``index_add_``.
+    """
+    n_rows = chunk_indices.shape[0]
+    grad = torch.zeros((n_rows, emb.shape[1]), dtype=emb.dtype, device=emb.device)
+    for e in range(source.shape[0]):
+        s_local = int(source[e])
+        d = emb[int(chunk_indices[s_local])] - emb[int(target[e])]
+        dist2 = float((d * d).sum())
+        if dist2 > 0 and bool(sampled[e]):
+            coef = (2 * a * b * dist2 ** (b - 1)) / (1 + a * dist2**b)
+        else:
+            coef = 0.0
+        grad[s_local] += d * coef
+    return grad.clamp_(-4, 4)
+
+
+@pytest.mark.parametrize("device", DEVICES)
+def test_attractive_gradient_matches_bruteforce_reference(device):
+    """The flat segment-reduced gradient equals an edge-by-edge reference.
+
+    A subset of edges is left unsampled (schedule) and one edge is degenerate
+    (zero distance) so both masking branches are exercised.
+    """
+    n, dim, a, b = 6, 2, 1.577, 0.895
+    gen = torch.Generator().manual_seed(0)
+    emb = torch.randn(n, dim, dtype=torch.float64, generator=gen)
+    emb[4] = emb[0]  # a zero-distance edge (4 -> 0) must contribute nothing
+
+    nn = torch.tensor(
+        [
+            [1, 2, -1],
+            [0, 3, 4],
+            [-1, -1, -1],
+            [5, -1, -1],
+            [0, -1, -1],
+            [1, 2, 3],
+        ]
+    )
+    source, target, _ = UMAP._flatten_padded_edges(nn)
+
+    # Sample every other edge to exercise the epoch-schedule masking.
+    n_edges = source.shape[0]
+    sampled = torch.zeros(n_edges, dtype=torch.bool)
+    sampled[::2] = True
+
+    model = UMAP(n_components=dim, n_neighbors=2, optimizer="SGD")
+    model._a, model._b, model.n_iter_ = a, b, 0
+    model.embedding_ = emb.to(device)
+    model.chunk_indices_ = torch.arange(n, device=device)
+    model.attractive_source_ = source.to(device)
+    model.attractive_target_ = target.to(device)
+    # epoch_of_next_sample <= n_iter_ + 1 selects an edge this step; push the
+    # unsampled edges just past the threshold.
+    epoch_next = torch.where(
+        sampled, torch.ones(n_edges), torch.full((n_edges,), 5.0)
+    ).to(device)
+    model.epoch_of_next_sample = epoch_next.clone()
+    model.epochs_per_sample = torch.ones(n_edges, device=device)
+
+    grad = model._compute_attractive_gradients()
+
+    grad_ref = _reference_attractive_grad(
+        emb.to(device),
+        torch.arange(n, device=device),
+        source.to(device),
+        target.to(device),
+        a,
+        b,
+        sampled.to(device),
+    )
+    torch.testing.assert_close(grad, grad_ref, rtol=1e-9, atol=1e-9)
+
+
+def test_umap_fit_cpu_is_reproducible():
+    """The CSR path stays reproducible on CPU (index_add_ is deterministic there).
+
+    GPU atomics make the segment reduction order-dependent, but the CPU
+    reduction is deterministic, so a fixed seed reproduces the embedding.
+    """
+    X, _ = toy_dataset(80, "float32")
+    kw = dict(
+        n_components=2,
+        backend=None,
+        device="cpu",
+        init="normal",
+        max_iter=40,
+        random_state=0,
+        n_neighbors=8,
+        optimizer="SGD",
+    )
+    a = torch.as_tensor(UMAP(**kw).fit_transform(X))
+    b = torch.as_tensor(UMAP(**kw).fit_transform(X))
+    torch.testing.assert_close(a, b, rtol=1e-5, atol=1e-5)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_umap_fit_cuda_smoke():
+    """UMAP fits on CUDA and returns a finite embedding (device path exercised)."""
+    X, _ = toy_dataset(200, "float32")
+    model = UMAP(
+        n_components=2,
+        device="cuda",
+        init="normal",
+        max_iter=50,
+        random_state=0,
+        n_neighbors=10,
+        optimizer="SGD",
+    )
+    # Be robust to a global deterministic mode that another test may have left
+    # enabled: UMAP's repulsive einsum uses cuBLAS, which raises under
+    # deterministic algorithms unless CUBLAS_WORKSPACE_CONFIG is set.
+    prev = torch.are_deterministic_algorithms_enabled()
+    torch.use_deterministic_algorithms(False)
+    try:
+        emb = torch.as_tensor(model.fit_transform(X))
+    finally:
+        torch.use_deterministic_algorithms(prev)
+    assert emb.shape == (200, 2)
+    assert np.isfinite(emb.cpu().numpy()).all()


### PR DESCRIPTION
## Summary

- UMAP's closed-form attractive gradient ran over a max-degree-padded `(chunk, max_degree)` affinity grid. A few high-degree vertices therefore made every optimization step materialize and process mostly padding; distributed execution amplified this because all ranks use the global maximum degree (#319).
- Flatten the graph once into row-ordered edge buffers, retain per-row counts, and release the padded affinity after initialization. Attractive gradients and negative-sample counts now operate only on real edges. Fit and non-parametric transform share the same representation.
- Use `torch.segment_reduce` over the row-ordered edges. This avoids CUDA atomics: fixed-seed fits remain exactly reproducible on both one GPU and two GPUs, while the segmented kernel is faster than the atomic prototype.
- The production change remains local to UMAP; shared sparse kernels and other estimators are unchanged.

## Performance and quality

The initial B200 campaign measured the flat representation across 200k–653k points and float32/float64: single-GPU fits were 61–85% faster with 48–59% lower peak memory, and two-GPU fits were 43–70% faster with 48–59% lower peak memory.

The final deterministic implementation was revalidated against latest `main` in an alternating, node-local-staged, two-B200 run on 200k Zheng PCA-50 points (`k=30`, 250 iterations, float32):

| Arm | Fit times | Mean | Peak memory/rank |
|---|---:|---:|---:|
| latest `main` | 4394 ms, 3966 ms | 4180 ms | 2975 MB |
| this PR | 2716 ms, 2658 ms | 2687 ms | 1549 MB |

That is a 35.7% end-to-end speedup and a 48.0% reduction in peak GPU memory. Two repeated distributed candidate fits were bit-for-bit identical. Input-neighborhood recall changed by -0.00129 absolute (0.07963 to 0.07833), within ordinary optimization variation and without a material quality regression.

For approximately 12 million two-dimensional edge contributions on one B200, the final segmented reduction took 0.14 ms versus 0.22 ms for the earlier atomic `index_add_` prototype, while remaining exactly reproducible without enabling PyTorch's global deterministic mode.

## Test plan

- New `torchdr/tests/test_umap_csr.py` covers padded-to-flat ordering, empty rows, attractive-gradient equivalence against an independent edge-wise reference on CPU and CUDA, exact fixed-seed fit reproducibility on CPU and CUDA, and a CUDA fit smoke test.
- Updated the UMAP transform epoch-schedule test for the flat per-edge representation.
- Focused CPU suite: 30 passed, 1 skipped.
- Focused B200 suite: 33 passed.
- Real two-B200/NCCL neighbor-embedding suite: 4 passed on each rank, including distributed UMAP affinity equivalence and end-to-end UMAP fit.
- `compile=True` fit plus neighbor-exclusion and non-parametric transform probe passed on B200.
- Repository-wide pre-commit passed.

Closes #319
