### PR TITLE
[Fix] Build contiguous row indices in flatten_sparse for single-row chunks

### DIFF
--- a/torchdr/tests/test_distributed_sparse.py
+++ b/torchdr/tests/test_distributed_sparse.py
@@ -108,6 +108,40 @@ def test_chunk_matches_single_process_reference(n_samples, n_neighbors, dtype, m
     )
 
 
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+@pytest.mark.parametrize("mode", ["sum", "sum_minus_prod"])
+def test_single_row_chunk_matches_reference(dtype, mode):
+    """A rank owning a single row must not crash the exchange.
+
+    With ``n_samples == world_size + 1`` exactly one rank owns two rows and
+    every other rank owns a single row. ``flatten_sparse`` used to build the row
+    indices with ``arange(n).unsqueeze(1).expand(n, k).reshape(-1)``, which
+    returns a stride-0 view for a one-row chunk (all ``k`` elements alias one
+    memory location). The in-place ``i.add_(chunk_start)`` inside
+    ``distributed_symmetrize_sparse`` then raised "more than one element of the
+    written-to tensor refers to a single memory location". This exercises that
+    partition on the real Gloo backend.
+    """
+    world_size = dist.get_world_size()
+    n_samples = world_size + 1
+    n_neighbors = 2
+    values, indices = _build_graph(n_samples, n_neighbors, seed=n_samples, dtype=dtype)
+
+    chunk_start, chunk_end, out_values, out_indices = _symmetrize_local_chunk(
+        values, indices, n_samples, mode
+    )
+    # This partition gives every rank one or two rows; at least one has a single.
+    assert chunk_end - chunk_start in (1, 2)
+
+    reference_values, reference_indices = symmetrize_sparse(values, indices, mode=mode)
+    torch.testing.assert_close(
+        _rowwise_to_dense(out_values, out_indices, n_samples),
+        _rowwise_to_dense(reference_values, reference_indices, n_samples)[
+            chunk_start:chunk_end
+        ],
+    )
+
+
 def test_gathered_ranks_reconstruct_the_full_matrix():
     """Concatenating every rank's rows must rebuild the reference matrix."""
     n_samples, n_neighbors = 101, 7

--- a/torchdr/utils/sparse.py
+++ b/torchdr/utils/sparse.py
@@ -28,8 +28,13 @@ def flatten_sparse(
     n, k = values.shape
     device = values.device
 
-    rows = torch.arange(n, device=device).unsqueeze(1).expand(n, k)
-    i = rows.reshape(-1)
+    # ``repeat_interleave`` returns a fresh contiguous row-index vector for every
+    # ``n``. Expanding and reshaping instead yields a stride-0 view when ``n == 1``
+    # (a single-row chunk), where all ``k`` elements alias one memory location, so
+    # an in-place mutation such as ``distributed_symmetrize_sparse``'s
+    # ``i.add_(chunk_start)`` raises "more than one element of the written-to
+    # tensor refers to a single memory location".
+    i = torch.arange(n, device=device).repeat_interleave(k)
     j = indices.reshape(-1)
     v = values.reshape(-1)
     return i, j, v


### PR DESCRIPTION
Fixes #321.

### Summary

- `flatten_sparse` built its flat row-index vector with `arange(n).unsqueeze(1).expand(n, k).reshape(-1)`, which returns a stride-0 view when a chunk has a single row (`n == 1`) — all `k` entries alias one memory cell.
- `distributed_symmetrize_sparse` then applies the in-place offset `i.add_(chunk_start)`, which raises `RuntimeError: more than one element of the written-to tensor refers to a single memory location` whenever a rank owns a single row (`n_samples` close to `world_size`). The crashing rank also wedges its peers in the following `all_to_all_single`.
- Replace the expand/reshape with `arange(n).repeat_interleave(k)`, which returns a fresh contiguous vector for every `n`. Output is value-identical for all shapes, so single-process `symmetrize_sparse` is unchanged and the distributed in-place add stays valid and allocation-free.

### Test plan

- New real-process regression test `test_single_row_chunk_matches_reference` (Gloo, `world_size >= 2`, `n_samples == world_size + 1`) exercises a partition where at least one rank owns a single row and checks the local chunk against the single-process reference.
- Verified the new test **fails** on the pre-fix code (aliasing `RuntimeError`) and **passes** with the fix, at `nproc=2` (CI-equivalent) and `nproc=4`.
- Full `test_distributed_sparse.py` and `test_sparse.py` suites pass with the fix; `pre-commit` (ruff, ruff-format, codespell) clean.

### Out of scope

A distinct `ZeroDivisionError` when `world_size > n_samples` (a rank owns zero rows) is noted in #321 and will be handled separately.
