### PR TITLE
[Fix] Reject distributed runs with more ranks than samples

### DIFF
--- a/torchdr/distributed/__init__.py
+++ b/torchdr/distributed/__init__.py
@@ -340,6 +340,12 @@ class DistributedContext:
         >>> # Returns: tensor([0, 1, 2, 3, 3])
         """
         chunk_size = n_samples // world_size
+        if chunk_size == 0:
+            raise ValueError(
+                f"[TorchDR] cannot distribute {n_samples} samples across "
+                f"{world_size} ranks: some ranks would own zero rows. Launch "
+                f"with at most n_samples ranks."
+            )
         remainder = n_samples % world_size
 
         # Threshold where chunking strategy changes

--- a/torchdr/distributed/input_contract.py
+++ b/torchdr/distributed/input_contract.py
@@ -151,3 +151,17 @@ def validate_distributed_input(X, dist_ctx) -> None:
             f"{_describe(field, reference)}, while rank {mismatch} reports "
             f"{_describe(field, int(column[mismatch]))}. {_CONTRACT}"
         )
+
+    # Reject more ranks than samples. Only the query rows are partitioned, so
+    # with world_size > n_samples some ranks own zero rows and the index->owner
+    # lookup divides by a zero-sized block (ZeroDivisionError deep in sparse
+    # symmetrization). Catch it here with an actionable message.
+    n_samples_column = gathered[:, _FIELDS.index("n_samples")]
+    known = n_samples_column[n_samples_column != _UNKNOWN]
+    if known.numel() and int(known.min()) < dist_ctx.world_size:
+        raise ValueError(
+            f"[TorchDR] distributed neighbor embedding needs at least one "
+            f"sample per rank, but n_samples={int(known.min())} with "
+            f"world_size={dist_ctx.world_size}. Launch with at most n_samples "
+            f"ranks. {_CONTRACT}"
+        )

--- a/torchdr/tests/test_distributed.py
+++ b/torchdr/tests/test_distributed.py
@@ -275,6 +275,20 @@ class TestGetRankForIndices:
         expected = torch.tensor([0, 0, 1, 1, 2, 2])
         assert torch.equal(ranks, expected)
 
+    def test_more_ranks_than_samples_raises(self):
+        """Reject world_size > n_samples instead of dividing by a zero chunk."""
+        with pytest.raises(ValueError, match="zero rows"):
+            DistributedContext.get_rank_for_indices(
+                torch.arange(3), n_samples=3, world_size=4
+            )
+
+    def test_one_sample_per_rank_is_allowed(self):
+        """world_size == n_samples is the boundary and must still work."""
+        ranks = DistributedContext.get_rank_for_indices(
+            torch.arange(4), n_samples=4, world_size=4
+        )
+        assert torch.equal(ranks, torch.arange(4))
+
     def test_inverse_of_compute_chunk_bounds(self):
         """Test that get_rank_for_indices is inverse of compute_chunk_bounds."""
         n_samples = 97

--- a/torchdr/tests/test_distributed_input_contract.py
+++ b/torchdr/tests/test_distributed_input_contract.py
@@ -67,6 +67,11 @@ class TestAcceptedInputs:
         assert validate_distributed_input(X, None) is None
         assert validate_distributed_input(X, DistributedContext()) is None
 
+    def test_one_sample_per_rank_is_accepted(self, simulate_world):
+        """world_size == n_samples is the boundary and must not be rejected."""
+        X = torch.randn(4, 4)
+        assert simulate_world([X, X.clone(), X.clone(), X.clone()]) is None
+
 
 class TestRejectedInputs:
     def test_distributed_sampler_is_rejected_on_every_rank(self, simulate_world):
@@ -122,6 +127,11 @@ class TestRejectedInputs:
         X = torch.randn(64, 4)
         with pytest.raises(ValueError, match="input_kind"):
             simulate_world([X, _loader(X)])
+
+    def test_more_ranks_than_samples_is_rejected(self, simulate_world):
+        X = torch.randn(3, 4)
+        with pytest.raises(ValueError, match="at least one sample per rank"):
+            simulate_world([X, X.clone(), X.clone(), X.clone()])
 
     def test_loader_dataset_size_mismatch(self, simulate_world):
         X = torch.randn(64, 4)


### PR DESCRIPTION
## Verdict

**APPROVE** (correctness / usability)

Fixes #323.

## Hypothesis

Distributed neighbor embedding with more ranks than samples (`world_size > n_samples`)
crashes with an opaque `ZeroDivisionError` deep in sparse symmetrization. Rejecting
the configuration early, with an actionable message, turns a confusing failure into a
clear one without affecting any valid configuration.

## Cause

Only the query rows are partitioned. When `world_size > n_samples`,
`chunk_size = n_samples // world_size == 0`, and
`DistributedContext.get_rank_for_indices` divides by `chunk_size` when mapping global
edge indices back to owning ranks. `torch.where` evaluates both branches eagerly, so
this faults for any indices. The production caller is `distributed_symmetrize_sparse`
(UMAP affinity symmetrization), so it is on the live fit path. The input-contract
validation from #300 does not catch it: the full dataset is replicated on every rank,
so all metadata fields agree and validation passes. Distinct from #322, which fixes
`n_samples == world_size + 1` (there `chunk_size >= 1`).

## Change

- `validate_distributed_input`: reject `world_size > n_samples` at the start of the fit
  with an actionable `ValueError` (earliest point, before any index is built).
- `get_rank_for_indices`: defensive `ValueError` when `chunk_size == 0`, so the
  primitive fails clearly instead of dividing by zero if reached directly.

Both guards fire only for `world_size > n_samples`; `world_size == n_samples`
(one sample per rank) is unchanged.

## Evidence

- Baseline commit: `a41b308`
- Candidate commit: this branch
- Hardware / world size: single node, Gloo CPU, 4 processes (n_samples=3)
- Repetitions: deterministic correctness demonstration (one run per side)

Decisive baseline vs candidate (controlled: same tests, fix stashed for baseline):

| Check | Baseline (`a41b308`) | Candidate |
|---|---|---|
| `get_rank_for_indices(arange(3), 3, 4)` | `RuntimeError: ZeroDivisionError` | clear `ValueError` |
| `validate_distributed_input` rejects 4 ranks / 3 samples | DID NOT RAISE | clear `ValueError` |
| `world_size == n_samples` boundary (both layers) | pass | pass |
| Real 4-process Gloo `validate_distributed_input`, n=3 | `NO_ERROR` on all ranks | clean `ValueError` on all ranks |

## Validation

- New regression tests run on ordinary GPU-less CI (no process group needed):
  `test_more_ranks_than_samples_raises`, `test_one_sample_per_rank_is_allowed`
  (`test_distributed.py`); `test_more_ranks_than_samples_is_rejected`,
  `test_one_sample_per_rank_is_accepted` (`test_distributed_input_contract.py`).
- `test_distributed.py` + `test_distributed_input_contract.py`: 47 passed.
- `pre-commit` clean (ruff, ruff-format, codespell).

## Risks and limitations

- `world_size > n_samples` means more ranks than data points; the change only converts
  its crash into an early, clear error and does not enable that (degenerate) regime.
- No behavior change for any valid configuration (`world_size <= n_samples`).
