### PR TITLE
[Feature] Train distributed IVF/PQ FAISS indexes once and broadcast

### DIFF
--- a/.github/workflows/distributed-integration.yml
+++ b/.github/workflows/distributed-integration.yml
@@ -10,9 +10,12 @@ on:
     paths:
       - ".github/workflows/distributed-integration.yml"
       - "torchdr/affinity_matcher.py"
+      - "torchdr/distance/base.py"
+      - "torchdr/distance/faiss.py"
       - "torchdr/distributed/**"
       - "torchdr/neighbor_embedding/**"
       - "torchdr/spectral_embedding/pca.py"
+      - "torchdr/tests/test_distributed_faiss_training.py"
       - "torchdr/tests/test_distributed_integration.py"
       - "torchdr/tests/test_distributed_neighbor_embedding.py"
       - "torchdr/tests/test_distributed_sparse.py"
@@ -23,9 +26,12 @@ on:
     paths:
       - ".github/workflows/distributed-integration.yml"
       - "torchdr/affinity_matcher.py"
+      - "torchdr/distance/base.py"
+      - "torchdr/distance/faiss.py"
       - "torchdr/distributed/**"
       - "torchdr/neighbor_embedding/**"
       - "torchdr/spectral_embedding/pca.py"
+      - "torchdr/tests/test_distributed_faiss_training.py"
       - "torchdr/tests/test_distributed_integration.py"
       - "torchdr/tests/test_distributed_neighbor_embedding.py"
       - "torchdr/tests/test_distributed_sparse.py"
@@ -65,3 +71,32 @@ jobs:
           python -m torch.distributed.run --standalone --nnodes=1
           --nproc-per-node=2 -m pytest
           torchdr/tests/test_distributed_neighbor_embedding.py -q
+
+  test-distributed-faiss-cpu:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Set up Miniconda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          auto-update-conda: true
+          python-version: "3.10"
+          activate-environment: test-distributed-faiss-env
+      - name: Install FAISS
+        run: conda install -c pytorch -c conda-forge faiss-cpu=1.11.0 "numpy<2" --yes
+      - name: Install TorchDR
+        run: python -m pip install --upgrade pip && pip install -e ".[test]"
+      - name: Verify FAISS installation
+        run: python -c "from torchdr.utils.faiss import faiss; assert faiss"
+      - name: Run two-process index training test
+        env:
+          TORCHDR_DISTRIBUTED_TEST: "1"
+        run: >-
+          python -m torch.distributed.run --standalone --nnodes=1
+          --nproc-per-node=2 -m pytest
+          torchdr/tests/test_distributed_faiss_training.py -q

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -180,7 +180,7 @@ jobs:
       - name: Verify FAISS installation
         run: python -c "from torchdr.utils.faiss import faiss; assert faiss, 'FAISS failed to import'"
       - name: Run Tests
-        run: pytest torchdr/tests/test_utils.py torchdr/tests/test_dataloader.py torchdr/tests/test_eval.py --verbose --cov=torchdr --cov-report term --cov-report xml
+        run: pytest torchdr/tests/test_utils.py torchdr/tests/test_dataloader.py torchdr/tests/test_eval.py torchdr/tests/test_faiss_index_training.py --verbose --cov=torchdr --cov-report term --cov-report xml
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/torchdr/distance/base.py
+++ b/torchdr/distance/base.py
@@ -185,14 +185,11 @@ def pairwise_distances(
 
         # Force FAISS backend for distributed mode
         if isinstance(backend, FaissConfig):
-            config = distributed_ctx.get_faiss_config(backend)
-        elif backend == "faiss":
-            config = distributed_ctx.get_faiss_config()
-        elif backend is None:
-            config = distributed_ctx.get_faiss_config()
+            config = backend
         else:
-            # User specified keops or other backend - override with FAISS
-            config = distributed_ctx.get_faiss_config()
+            # Distributed search always uses FAISS. The lower-level function
+            # maps this base configuration to the rank-local GPU.
+            config = FaissConfig()
 
         # Compute chunk bounds for this rank
         n_samples = X.shape[0]

--- a/torchdr/distance/base.py
+++ b/torchdr/distance/base.py
@@ -211,6 +211,7 @@ def pairwise_distances(
             config=config,
             device=device,
             query_ids=torch.arange(chunk_start, chunk_end, device=X.device),
+            distributed_ctx=distributed_ctx,
         )
 
         if return_indices:

--- a/torchdr/distance/faiss.py
+++ b/torchdr/distance/faiss.py
@@ -372,7 +372,8 @@ def pairwise_distances_faiss(
     distributed_ctx : DistributedContext, optional
         Context of the ranks that share this search. Every rank indexes the
         same database, so an approximate index is trained once on rank 0 and
-        broadcast rather than trained again on each of them.
+        broadcast rather than trained again on each of them. The index device
+        is mapped to the context's local rank.
 
     Returns
     -------
@@ -419,6 +420,10 @@ def pairwise_distances_faiss(
 
     if config is None:
         config = FaissConfig()
+    if distributed_ctx is not None and distributed_ctx.is_initialized:
+        # Keep the exported low-level API safe when it is called directly: a
+        # default config names GPU 0, while each rank must build on local_rank.
+        config = distributed_ctx.get_faiss_config(config)
 
     if isinstance(k, torch.Tensor):
         k = int(k.item())

--- a/torchdr/distance/faiss.py
+++ b/torchdr/distance/faiss.py
@@ -5,6 +5,7 @@
 # License: BSD 3-Clause License
 
 import torch
+import torch.distributed as dist
 import numpy as np
 import warnings
 from weakref import WeakKeyDictionary
@@ -17,6 +18,7 @@ from torch.utils.data import (
     BatchSampler,
 )
 
+from torchdr.distributed.input_contract import collective_device
 from torchdr.utils.faiss import faiss, faiss_torch_interop
 from torchdr.utils.faiss_runtime import (
     faiss_device_scope,
@@ -325,6 +327,7 @@ def pairwise_distances_faiss(
     config: Optional[FaissConfig] = None,
     device: str = "auto",
     query_ids: Optional[torch.Tensor] = None,
+    distributed_ctx: Optional[Any] = None,
 ):
     r"""Compute the k nearest neighbors using FAISS.
 
@@ -366,6 +369,10 @@ def pairwise_distances_faiss(
         Row of Y that each query of X corresponds to. Only used when
         `exclude_diag` is True, and only needed when X is a chunk of Y rather
         than Y itself, as in distributed search. Defaults to `arange(n)`.
+    distributed_ctx : DistributedContext, optional
+        Context of the ranks that share this search. Every rank indexes the
+        same database, so an approximate index is trained once on rank 0 and
+        broadcast rather than trained again on each of them.
 
     Returns
     -------
@@ -437,64 +444,24 @@ def pairwise_distances_faiss(
             stacklevel=2,
         )
 
-    if metric == "angular":
-        flat_index = faiss.IndexFlatIP(d)
-        metric_type = faiss.METRIC_INNER_PRODUCT
-    elif metric in {"euclidean", "sqeuclidean"}:
-        flat_index = faiss.IndexFlatL2(d)
-        metric_type = faiss.METRIC_L2
-    else:
-        raise ValueError(f"[TorchDR] ERROR : Metric '{metric}' is not supported.")
-
-    if config.index_type == "Flat":
-        index = flat_index
-    elif config.index_type == "IVF":
-        n_vectors = len(Y)
-        if config.nlist == 100 and n_vectors > 10000:
-            config.nlist = min(int(4 * np.sqrt(n_vectors)), n_vectors // 40, 8192)
-        index = faiss.IndexIVFFlat(flat_index, d, config.nlist, metric_type)
-        index.nprobe = config.nprobe
-    elif config.index_type == "IVFPQ":
-        n_vectors = len(Y)
-        if config.nlist == 100 and n_vectors > 10000:
-            config.nlist = min(int(4 * np.sqrt(n_vectors)), n_vectors // 40, 8192)
-        if d % config.M != 0:
-            raise ValueError(
-                f"[TorchDR] ERROR : Vector dimension {d} must be divisible by M={config.M} "
-                f"for IVFPQ. Choose M from divisors of {d}."
-            )
-        index = faiss.IndexIVFPQ(flat_index, d, config.nlist, config.M, config.nbits)
-        index.nprobe = config.nprobe
-    else:
-        raise ValueError(
-            f"[TorchDR] ERROR : Index type '{config.index_type}' is not supported. "
-            "Supported types are 'Flat', 'IVF', and 'IVFPQ'."
-        )
-
-    needs_training = config.index_type in ("IVF", "IVFPQ")
-
     if device == "auto":
         compute_device = X.device
     else:
         compute_device = torch.device(device)
 
-    use_gpu_index = compute_device.type == "cuda" and faiss_gpu_available()
-    # Device the index lives on, or None when FAISS stays on the host.
-    faiss_device = None
-    if compute_device.type == "cuda":
-        if use_gpu_index:
-            index = _setup_gpu_index(index, config, d)
-            faiss_device = torch.device("cuda", _index_device_id(config))
-        else:
-            warnings.warn(
-                "[TorchDR] WARNING: `faiss-gpu` not installed, using CPU for Faiss computations. "
-                "This may be slow. For faster performance, install `faiss-gpu`."
-            )
+    index_device, use_gpu_index = _index_input_device(config, compute_device)
+    if compute_device.type == "cuda" and not use_gpu_index:
+        warnings.warn(
+            "[TorchDR] WARNING: `faiss-gpu` not installed, using CPU for Faiss computations. "
+            "This may be slow. For faster performance, install `faiss-gpu`."
+        )
 
-    if faiss_device is not None and faiss_torch_interop:
-        index_device = faiss_device
-    else:
-        index_device = torch.device("cpu")
+    # Device the index lives on, or None when FAISS stays on the host.
+    faiss_device = (
+        torch.device("cuda", _index_device_id(config)) if use_gpu_index else None
+    )
+
+    index = _create_index(metric, config, d, len(Y), use_gpu_index)
 
     X_faiss = X.detach().to(device=index_device, dtype=torch.float32).contiguous()
     Y_faiss = Y.detach().to(device=index_device, dtype=torch.float32).contiguous()
@@ -511,19 +478,15 @@ def pairwise_distances_faiss(
     # Every FAISS call runs with the index device current, which is what makes
     # FAISS adopt the PyTorch stream holding the writes to X_faiss and Y_faiss.
     with faiss_device_scope(faiss_device):
-        if needs_training and not index.is_trained:
-            train_data = Y_faiss
-            max_train_points = 256 * config.nlist
-            if len(Y_faiss) > max_train_points:
-                sample_indices = np.random.choice(
-                    len(Y_faiss), max_train_points, replace=False
-                )
-                if isinstance(Y_faiss, torch.Tensor):
-                    sample_indices = torch.as_tensor(
-                        sample_indices, device=Y_faiss.device
-                    )
-                train_data = Y_faiss[sample_indices]
-            index.train(train_data)
+        if not index.is_trained:
+            index = _train_index(
+                index,
+                lambda: _training_sample(Y_faiss, 256 * index.nlist),
+                config,
+                d,
+                use_gpu_index,
+                distributed_ctx,
+            )
 
         index.add(Y_faiss)
 
@@ -731,7 +694,13 @@ def pairwise_distances_faiss_from_dataloader(
     # Build FAISS index and extract metadata in one pass
     with faiss_device_scope(faiss_device):
         index, metadata = _build_index_from_dataloader(
-            dataloader, metric, config, stage, group_rows, use_gpu_index
+            dataloader,
+            metric,
+            config,
+            stage,
+            group_rows,
+            use_gpu_index,
+            distributed_ctx if distributed else None,
         )
     n_samples = metadata["n_samples"]
     dtype = metadata["dtype"]
@@ -906,7 +875,18 @@ def _index_input_device(config: FaissConfig, compute_device: torch.device):
 def _create_index(
     metric: str, config: FaissConfig, d: int, n_samples: int, use_gpu_index: bool
 ):
-    """Create the empty index that the streaming passes will train and fill."""
+    """Create the empty index that the training and adding passes will fill.
+
+    An automatic ``nlist`` is resolved here rather than written back into
+    ``config``, so the configuration the caller passed in keeps its own values
+    and describes the same search whichever dataset it is used on.
+    """
+    if config.index_type not in ("Flat", "IVF", "IVFPQ"):
+        raise ValueError(
+            f"[TorchDR] ERROR : Index type '{config.index_type}' is not supported. "
+            "Supported types are 'Flat', 'IVF', and 'IVFPQ'."
+        )
+
     if metric == "angular":
         flat_index = faiss.IndexFlatIP(d)
         metric_type = faiss.METRIC_INNER_PRODUCT
@@ -937,6 +917,115 @@ def _create_index(
     return index
 
 
+def _training_sample(data, max_train_points: int):
+    """Rows an IVF/PQ index trains on: at most ``max_train_points`` of ``data``.
+
+    The draw comes from the global NumPy generator, which ``random_state``
+    seeds, so a seeded estimator trains on the same rows from one run to the
+    next.
+    """
+    if len(data) <= max_train_points:
+        return data
+
+    sample_indices = np.random.choice(len(data), max_train_points, replace=False)
+    if isinstance(data, torch.Tensor):
+        sample_indices = torch.as_tensor(sample_indices, device=data.device)
+    return data[sample_indices]
+
+
+def _shares_training(distributed_ctx) -> bool:
+    """Whether one rank trains for the group instead of each rank training."""
+    return (
+        distributed_ctx is not None
+        and distributed_ctx.is_initialized
+        and distributed_ctx.world_size > 1
+        and dist.is_initialized()
+    )
+
+
+def _train_index(
+    index,
+    training_rows: Callable[[], Any],
+    config: FaissConfig,
+    d: int,
+    use_gpu_index: bool,
+    distributed_ctx,
+):
+    """Train an IVF/PQ index once for the group rather than once per rank.
+
+    Every rank indexes the same database, so training on all of them repeats
+    identical work, and because each draws its own training sample the ranks
+    end up with different quantizers and disagree on the neighbors of a query.
+    Rank 0 trains and broadcasts the trained, still empty, index; the others
+    receive it and go straight to adding their vectors.
+
+    Parameters
+    ----------
+    index : faiss.Index
+        Untrained index, already on its final device.
+    training_rows : callable
+        Produces the rows to train on. It is only called on the rank that
+        trains, so the others never materialize a training sample.
+    config : FaissConfig
+        Configuration used to move a received index back onto the GPU.
+    d : int
+        Dimension of the vectors.
+    use_gpu_index : bool
+        Whether the index lives on the GPU.
+    distributed_ctx : DistributedContext or None
+        Context of the ranks sharing the index. None trains locally.
+
+    Returns
+    -------
+    index : faiss.Index
+        The trained index, which on a receiving rank is a new object.
+    """
+    if not _shares_training(distributed_ctx):
+        index.train(training_rows())
+        return index
+
+    trainer = 0
+    payload = None
+    trained = True
+    if distributed_ctx.rank == trainer:
+        try:
+            index.train(training_rows())
+            template = faiss.index_gpu_to_cpu(index) if use_gpu_index else index
+            payload = faiss.serialize_index(template)
+        except Exception as error:  # reported on every rank, not just this one
+            trained = False
+            reason = f"{type(error).__name__}: {error}"
+            payload = np.frombuffer(reason.encode(), dtype=np.uint8).copy()
+
+    # The header travels first: the receivers need the length to size their
+    # buffer, and it carries a failure on the same two collectives, so a rank
+    # that could not train never leaves the others waiting on a third.
+    device = collective_device(distributed_ctx)
+    header = torch.zeros(2, dtype=torch.int64, device=device)
+    if payload is not None:
+        header[0] = trained
+        header[1] = payload.size
+    dist.broadcast(header, src=trainer)
+
+    buffer = torch.empty(int(header[1]), dtype=torch.uint8, device=device)
+    if payload is not None:
+        buffer.copy_(torch.from_numpy(payload))
+    dist.broadcast(buffer, src=trainer)
+
+    if not int(header[0]):
+        raise RuntimeError(
+            f"[TorchDR] ERROR : rank {trainer} failed to train the "
+            f"'{config.index_type}' index that every rank shares: "
+            + bytes(buffer.cpu().numpy()).decode("utf-8", "replace")
+        )
+
+    if distributed_ctx.rank == trainer:
+        return index
+
+    index = faiss.deserialize_index(buffer.cpu().numpy())
+    return _setup_gpu_index(index, config, d) if use_gpu_index else index
+
+
 def _reserve_index_capacity(index, n_vectors: int) -> None:
     """Pre-allocate storage for the incremental additions that follow.
 
@@ -964,6 +1053,7 @@ def _build_index_from_dataloader(
     stage: Callable[[torch.Tensor], Any],
     group_rows: Optional[int],
     use_gpu_index: bool,
+    distributed_ctx=None,
 ):
     """Build FAISS index by streaming data from dataloader.
 
@@ -985,6 +1075,9 @@ def _build_index_from_dataloader(
         Rows per add call, or None to add each batch as it arrives.
     use_gpu_index : bool
         Whether the index is moved to the GPU.
+    distributed_ctx : DistributedContext, optional
+        Context of the ranks sharing the index. Only rank 0 reads training
+        rows; the others receive the trained index from it.
 
     Returns
     -------
@@ -998,7 +1091,8 @@ def _build_index_from_dataloader(
     n_samples = len(dataloader.dataset)
 
     # First pass: describe the stream from its first batch, then collect
-    # training rows if the index needs them. A Flat index stops right away.
+    # training rows if the index needs them. A Flat index stops right away, and
+    # so does a rank that will be given its trained index by rank 0.
     collected: List[Any] = []
     total = 0
 
@@ -1011,6 +1105,8 @@ def _build_index_from_dataloader(
                 metric, config, metadata["n_features"], n_samples, use_gpu_index
             )
             if index.is_trained:
+                break
+            if _shares_training(distributed_ctx) and distributed_ctx.rank != 0:
                 break
             # IVFPQ benefits from more training data for better codebooks
             max_train = 256 * index.nlist
@@ -1025,7 +1121,14 @@ def _build_index_from_dataloader(
         total += len(staged)
 
     if not index.is_trained:
-        index.train(_concatenate(collected))
+        index = _train_index(
+            index,
+            lambda: _concatenate(collected),
+            config,
+            metadata["n_features"],
+            use_gpu_index,
+            distributed_ctx,
+        )
 
     # Second pass: add all data to index
     _reserve_index_capacity(index, n_samples)

--- a/torchdr/distributed/input_contract.py
+++ b/torchdr/distributed/input_contract.py
@@ -76,7 +76,8 @@ def _local_metadata(X, sharded: bool):
     return [n_samples, n_features, dtype, kind, int(sharded)]
 
 
-def _collective_device(dist_ctx) -> torch.device:
+def collective_device(dist_ctx) -> torch.device:
+    """Device a collective's tensors must live on for the active backend."""
     if dist.get_backend() == "nccl":
         return torch.device("cuda", dist_ctx.local_rank)
     return torch.device("cpu")
@@ -119,7 +120,7 @@ def validate_distributed_input(X, dist_ctx) -> None:
             raise _sharded_loader_error(shard_info, ())
         return
 
-    device = _collective_device(dist_ctx)
+    device = collective_device(dist_ctx)
     local = torch.tensor(
         _local_metadata(X, shard_info is not None), dtype=torch.int64, device=device
     )

--- a/torchdr/tests/test_distributed_faiss_training.py
+++ b/torchdr/tests/test_distributed_faiss_training.py
@@ -1,0 +1,178 @@
+"""Real-process tests for training a FAISS index once for a group of ranks.
+
+These run on the Gloo CPU backend against a CPU FAISS index, so ordinary CI
+runners cover the broadcast that gives every rank the same trained quantizer.
+"""
+
+# Author: Hugues Van Assel <vanasselhugues@gmail.com>
+#
+# License: BSD 3-Clause License
+
+import os
+
+import pytest
+import torch
+import torch.distributed as dist
+from torch.utils.data import DataLoader, TensorDataset
+
+from torchdr.distance import FaissConfig, pairwise_distances
+from torchdr.distance.faiss import (
+    _build_index_from_dataloader,
+    _create_index,
+    _train_index,
+)
+from torchdr.distributed import DistributedContext
+from torchdr.utils import faiss
+
+
+pytestmark = [
+    pytest.mark.skipif(
+        os.environ.get("TORCHDR_DISTRIBUTED_TEST") != "1",
+        reason="run through the dedicated multi-process integration workflow",
+    ),
+    pytest.mark.skipif(faiss is None or faiss is False, reason="faiss not installed"),
+]
+
+N_SAMPLES = 4000
+N_FEATURES = 8
+NLIST = 16
+METRIC = "sqeuclidean"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def distributed_process_group():
+    """Initialize the process group created by torchrun.
+
+    Fails loudly on a single process: one rank trains for itself, so a silent
+    one-rank run would report green while exercising none of the broadcast.
+    """
+    dist.init_process_group(backend="gloo")
+    world_size = dist.get_world_size()
+    if world_size < 2:
+        dist.destroy_process_group()
+        pytest.fail(f"launch this module with at least two processes, got {world_size}")
+    yield
+    dist.barrier()
+    dist.destroy_process_group()
+
+
+@pytest.fixture(scope="module")
+def context(distributed_process_group):
+    return DistributedContext()
+
+
+@pytest.fixture(scope="module")
+def data():
+    """The same dataset on every rank, which is the contract TorchDR expects."""
+    generator = torch.Generator().manual_seed(0)
+    return torch.randn(N_SAMPLES, N_FEATURES, generator=generator)
+
+
+def _untrained(index_type="IVF", **kwargs):
+    config = FaissConfig(index_type=index_type, nlist=NLIST, **kwargs)
+    return _create_index(METRIC, config, N_FEATURES, N_SAMPLES, False), config
+
+
+def _gather(value):
+    gathered = [None] * dist.get_world_size()
+    dist.all_gather_object(gathered, value)
+    return gathered
+
+
+class TestSharedTraining:
+    def test_every_rank_ends_with_the_same_trained_index(self, data, context):
+        # Each rank draws different training rows, so agreeing afterwards can
+        # only come from the broadcast and not from a coincidence.
+        generator = torch.Generator().manual_seed(context.rank)
+        drawn = torch.randperm(N_SAMPLES, generator=generator)[: N_SAMPLES // 2]
+        rows = data[drawn].numpy()
+        index, config = _untrained()
+
+        index = _train_index(index, lambda: rows, config, N_FEATURES, False, context)
+
+        assert index.is_trained
+        payloads = _gather(bytes(faiss.serialize_index(index)))
+        assert len(set(payloads)) == 1
+
+    def test_only_the_first_rank_reads_training_rows(self, data, context):
+        calls = []
+
+        def rows():
+            calls.append(1)
+            return data.numpy()
+
+        index, config = _untrained()
+        _train_index(index, rows, config, N_FEATURES, False, context)
+
+        assert len(calls) == (1 if context.rank == 0 else 0)
+        assert _gather(len(calls)).count(1) == 1
+
+    def test_a_failure_on_the_first_rank_reaches_every_rank(self, data, context):
+        def rows():
+            raise ValueError("no training rows available")
+
+        index, config = _untrained()
+        with pytest.raises(RuntimeError, match="no training rows available"):
+            _train_index(index, rows, config, N_FEATURES, False, context)
+
+    def test_a_flat_index_never_reaches_the_broadcast(self, data, context):
+        # Flat has nothing to train, so the ranks skip the collective entirely
+        # and each still answers its own chunk exactly.
+        index, _ = _untrained(index_type="Flat")
+        assert index.is_trained
+
+        _, exact = pairwise_distances(
+            data, k=5, backend=FaissConfig(), return_indices=True
+        )
+        _, chunk = pairwise_distances(
+            data,
+            k=5,
+            backend=FaissConfig(),
+            return_indices=True,
+            distributed_ctx=context,
+        )
+
+        start, end = context.compute_chunk_bounds(N_SAMPLES)
+        assert torch.equal(chunk, exact[start:end])
+
+    # Probing every list makes IVF exact, so only ties keep it below one. IVFPQ
+    # answers from its codes, and the loose bound is there to catch an index
+    # that arrived broken rather than to measure how good the codes are.
+    @pytest.mark.parametrize("index_type, min_recall", [("IVF", 0.99), ("IVFPQ", 0.5)])
+    def test_the_received_index_still_finds_neighbors(
+        self, data, context, index_type, min_recall
+    ):
+        config = FaissConfig(index_type=index_type, nlist=NLIST, nprobe=NLIST, M=2)
+        _, exact = pairwise_distances(
+            data, k=5, backend=FaissConfig(), return_indices=True
+        )
+
+        _, approximate = pairwise_distances(
+            data, k=5, backend=config, return_indices=True, distributed_ctx=context
+        )
+
+        start, end = context.compute_chunk_bounds(N_SAMPLES)
+        mine = exact[start:end]
+        hits = (mine.unsqueeze(2) == approximate.unsqueeze(1)).any(dim=2).sum()
+        assert hits / mine.numel() > min_recall
+
+
+class TestSharedTrainingFromDataLoader:
+    def test_only_the_first_rank_streams_training_batches(self, data, context):
+        loader = DataLoader(TensorDataset(data), batch_size=500, shuffle=False)
+        config = FaissConfig(index_type="IVF", nlist=NLIST)
+        staged = []
+
+        def stage(batch):
+            staged.append(len(batch))
+            return batch.numpy()
+
+        index, _ = _build_index_from_dataloader(
+            loader, METRIC, config, stage, None, False, context
+        )
+
+        # The adding pass stages every batch; a training pass would stage more.
+        assert index.is_trained
+        assert index.ntotal == N_SAMPLES
+        assert len(staged) == (len(loader) if context.rank else 2 * len(loader))
+        assert len(set(_gather(bytes(faiss.serialize_index(index))))) == 1

--- a/torchdr/tests/test_distributed_faiss_training.py
+++ b/torchdr/tests/test_distributed_faiss_training.py
@@ -83,27 +83,21 @@ class TestSharedTraining:
     def test_every_rank_ends_with_the_same_trained_index(self, data, context):
         # Each rank draws different training rows, so agreeing afterwards can
         # only come from the broadcast and not from a coincidence.
-        generator = torch.Generator().manual_seed(context.rank)
-        drawn = torch.randperm(N_SAMPLES, generator=generator)[: N_SAMPLES // 2]
-        rows = data[drawn].numpy()
-        index, config = _untrained()
-
-        index = _train_index(index, lambda: rows, config, N_FEATURES, False, context)
-
-        assert index.is_trained
-        payloads = _gather(bytes(faiss.serialize_index(index)))
-        assert len(set(payloads)) == 1
-
-    def test_only_the_first_rank_reads_training_rows(self, data, context):
         calls = []
 
         def rows():
             calls.append(1)
-            return data.numpy()
+            generator = torch.Generator().manual_seed(context.rank)
+            drawn = torch.randperm(N_SAMPLES, generator=generator)[: N_SAMPLES // 2]
+            return data[drawn].numpy()
 
         index, config = _untrained()
-        _train_index(index, rows, config, N_FEATURES, False, context)
 
+        index = _train_index(index, rows, config, N_FEATURES, False, context)
+
+        assert index.is_trained
+        payloads = _gather(bytes(faiss.serialize_index(index)))
+        assert len(set(payloads)) == 1
         assert len(calls) == (1 if context.rank == 0 else 0)
         assert _gather(len(calls)).count(1) == 1
 
@@ -143,6 +137,7 @@ class TestSharedTraining:
         self, data, context, index_type, min_recall
     ):
         config = FaissConfig(index_type=index_type, nlist=NLIST, nprobe=NLIST, M=2)
+        original_config = vars(config).copy()
         _, exact = pairwise_distances(
             data, k=5, backend=FaissConfig(), return_indices=True
         )
@@ -155,6 +150,7 @@ class TestSharedTraining:
         mine = exact[start:end]
         hits = (mine.unsqueeze(2) == approximate.unsqueeze(1)).any(dim=2).sum()
         assert hits / mine.numel() > min_recall
+        assert vars(config) == original_config
 
 
 class TestSharedTrainingFromDataLoader:

--- a/torchdr/tests/test_faiss_index_training.py
+++ b/torchdr/tests/test_faiss_index_training.py
@@ -7,20 +7,9 @@
 import numpy as np
 import pytest
 import torch
-from torch.utils.data import DataLoader, TensorDataset
 
-from torchdr.distance import (
-    FaissConfig,
-    pairwise_distances,
-    pairwise_distances_faiss_from_dataloader,
-)
-from torchdr.distance.faiss import (
-    _create_index,
-    _shares_training,
-    _train_index,
-    _training_sample,
-)
-from torchdr.distributed import DistributedContext
+from torchdr.distance import FaissConfig, pairwise_distances
+from torchdr.distance.faiss import _create_index
 from torchdr.utils import faiss, seed_everything
 
 
@@ -40,8 +29,8 @@ def data():
     return torch.randn(N_SAMPLES, N_FEATURES, generator=generator)
 
 
-class TestResolvedParameters:
-    """An automatic nlist is resolved for the index, not written into config."""
+class TestApproximateIndexTraining:
+    """Stable behavior of approximate-index initialization."""
 
     @pytest.mark.parametrize("index_type", ["IVF", "IVFPQ"])
     def test_index_gets_the_automatic_nlist(self, index_type):
@@ -52,83 +41,19 @@ class TestResolvedParameters:
         assert index.nlist == expected
         assert expected != config.nlist
 
-    @pytest.mark.parametrize("index_type", ["Flat", "IVF", "IVFPQ"])
-    def test_tensor_search_leaves_config_alone(self, data, index_type):
+    @pytest.mark.parametrize("index_type", ["IVF", "IVFPQ"])
+    def test_automatic_nlist_does_not_mutate_config(self, data, index_type):
         config = FaissConfig(index_type=index_type, M=2)
-        before = repr(config)
+        before = vars(config).copy()
 
         pairwise_distances(data, k=5, backend=config, return_indices=True)
 
-        assert repr(config) == before
+        assert vars(config) == before
 
-    @pytest.mark.parametrize("index_type", ["Flat", "IVF", "IVFPQ"])
-    def test_dataloader_search_leaves_config_alone(self, data, index_type):
-        config = FaissConfig(index_type=index_type, M=2)
-        before = repr(config)
-        loader = DataLoader(TensorDataset(data), batch_size=2048, shuffle=False)
-
-        pairwise_distances_faiss_from_dataloader(loader, k=5, config=config)
-
-        assert repr(config) == before
-
-    def test_an_explicit_nlist_is_respected(self):
-        config = FaissConfig(index_type="IVF", nlist=37)
-        index = _create_index("sqeuclidean", config, N_FEATURES, N_SAMPLES, False)
-        assert index.nlist == 37
-
-    def test_unsupported_index_type_is_rejected(self):
-        config = FaissConfig(index_type="HNSW")
-        with pytest.raises(ValueError, match="not supported"):
-            _create_index("sqeuclidean", config, N_FEATURES, N_SAMPLES, False)
-
-
-class TestTrainingSample:
-    def test_smaller_data_is_used_whole(self, data):
-        assert _training_sample(data, len(data) + 1) is data
-
-    def test_larger_data_is_capped(self, data):
-        assert len(_training_sample(data, 128)) == 128
-
-    def test_a_seed_selects_the_same_rows(self, data):
-        np.random.seed(0)
-        first = _training_sample(data, 128)
-        np.random.seed(0)
-        assert torch.equal(_training_sample(data, 128), first)
-
-    def test_numpy_input_is_supported(self, data):
-        sample = _training_sample(data.numpy(), 128)
-        assert isinstance(sample, np.ndarray)
-        assert len(sample) == 128
-
-
-class TestLocalTraining:
-    """Without a group of ranks to share it with, training stays where it is."""
-
-    @pytest.mark.parametrize("distributed_ctx", [None, "uninitialized"])
-    def test_index_is_trained_in_place(self, data, distributed_ctx):
-        if distributed_ctx == "uninitialized":
-            distributed_ctx = DistributedContext()
-
-        config = FaissConfig(index_type="IVF", nlist=16)
-        index = _create_index("sqeuclidean", config, N_FEATURES, N_SAMPLES, False)
-        assert not index.is_trained
-
-        trained = _train_index(
-            index, lambda: data.numpy(), config, N_FEATURES, False, distributed_ctx
-        )
-
-        assert trained is index
-        assert index.is_trained
-        assert not _shares_training(distributed_ctx)
-
-
-class TestSeededSearch:
-    """The seed the estimator sets is enough to repeat an approximate search."""
-
-    # nlist is set low enough that the training sample is a strict subset of the
-    # data, which is what makes the draw, and so the seed, matter at all.
     @pytest.mark.parametrize("index_type", ["IVF", "IVFPQ"])
-    def test_the_same_seed_gives_the_same_neighbors(self, data, index_type):
+    def test_seeded_search_is_reproducible(self, data, index_type):
+        # nlist is low enough that training uses a random subset. This exercises
+        # the public search behavior instead of the sampling helper itself.
         config = FaissConfig(index_type=index_type, nlist=32, M=2)
 
         runs = []
@@ -140,11 +65,3 @@ class TestSeededSearch:
             runs.append(indices)
 
         assert torch.equal(runs[0], runs[1])
-
-    def test_a_different_seed_draws_different_training_rows(self, data):
-        draws = []
-        for seed in (0, 1):
-            seed_everything(seed)
-            draws.append(_training_sample(data, N_SAMPLES // 4))
-
-        assert not torch.equal(draws[0], draws[1])

--- a/torchdr/tests/test_faiss_index_training.py
+++ b/torchdr/tests/test_faiss_index_training.py
@@ -1,0 +1,150 @@
+"""Tests for how FAISS approximate indexes resolve and train their parameters."""
+
+# Author: Hugues Van Assel <vanasselhugues@gmail.com>
+#
+# License: BSD 3-Clause License
+
+import numpy as np
+import pytest
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+
+from torchdr.distance import (
+    FaissConfig,
+    pairwise_distances,
+    pairwise_distances_faiss_from_dataloader,
+)
+from torchdr.distance.faiss import (
+    _create_index,
+    _shares_training,
+    _train_index,
+    _training_sample,
+)
+from torchdr.distributed import DistributedContext
+from torchdr.utils import faiss, seed_everything
+
+
+pytestmark = pytest.mark.skipif(
+    faiss is None or faiss is False, reason="faiss not installed"
+)
+
+# Above the 10000 rows that turn on the automatic ``nlist``, and enough of them
+# that the resolved value differs from the default.
+N_SAMPLES = 20000
+N_FEATURES = 8
+
+
+@pytest.fixture(scope="module")
+def data():
+    generator = torch.Generator().manual_seed(0)
+    return torch.randn(N_SAMPLES, N_FEATURES, generator=generator)
+
+
+class TestResolvedParameters:
+    """An automatic nlist is resolved for the index, not written into config."""
+
+    @pytest.mark.parametrize("index_type", ["IVF", "IVFPQ"])
+    def test_index_gets_the_automatic_nlist(self, index_type):
+        config = FaissConfig(index_type=index_type, M=2)
+        index = _create_index("sqeuclidean", config, N_FEATURES, N_SAMPLES, False)
+
+        expected = min(int(4 * np.sqrt(N_SAMPLES)), N_SAMPLES // 40, 8192)
+        assert index.nlist == expected
+        assert expected != config.nlist
+
+    @pytest.mark.parametrize("index_type", ["Flat", "IVF", "IVFPQ"])
+    def test_tensor_search_leaves_config_alone(self, data, index_type):
+        config = FaissConfig(index_type=index_type, M=2)
+        before = repr(config)
+
+        pairwise_distances(data, k=5, backend=config, return_indices=True)
+
+        assert repr(config) == before
+
+    @pytest.mark.parametrize("index_type", ["Flat", "IVF", "IVFPQ"])
+    def test_dataloader_search_leaves_config_alone(self, data, index_type):
+        config = FaissConfig(index_type=index_type, M=2)
+        before = repr(config)
+        loader = DataLoader(TensorDataset(data), batch_size=2048, shuffle=False)
+
+        pairwise_distances_faiss_from_dataloader(loader, k=5, config=config)
+
+        assert repr(config) == before
+
+    def test_an_explicit_nlist_is_respected(self):
+        config = FaissConfig(index_type="IVF", nlist=37)
+        index = _create_index("sqeuclidean", config, N_FEATURES, N_SAMPLES, False)
+        assert index.nlist == 37
+
+    def test_unsupported_index_type_is_rejected(self):
+        config = FaissConfig(index_type="HNSW")
+        with pytest.raises(ValueError, match="not supported"):
+            _create_index("sqeuclidean", config, N_FEATURES, N_SAMPLES, False)
+
+
+class TestTrainingSample:
+    def test_smaller_data_is_used_whole(self, data):
+        assert _training_sample(data, len(data) + 1) is data
+
+    def test_larger_data_is_capped(self, data):
+        assert len(_training_sample(data, 128)) == 128
+
+    def test_a_seed_selects_the_same_rows(self, data):
+        np.random.seed(0)
+        first = _training_sample(data, 128)
+        np.random.seed(0)
+        assert torch.equal(_training_sample(data, 128), first)
+
+    def test_numpy_input_is_supported(self, data):
+        sample = _training_sample(data.numpy(), 128)
+        assert isinstance(sample, np.ndarray)
+        assert len(sample) == 128
+
+
+class TestLocalTraining:
+    """Without a group of ranks to share it with, training stays where it is."""
+
+    @pytest.mark.parametrize("distributed_ctx", [None, "uninitialized"])
+    def test_index_is_trained_in_place(self, data, distributed_ctx):
+        if distributed_ctx == "uninitialized":
+            distributed_ctx = DistributedContext()
+
+        config = FaissConfig(index_type="IVF", nlist=16)
+        index = _create_index("sqeuclidean", config, N_FEATURES, N_SAMPLES, False)
+        assert not index.is_trained
+
+        trained = _train_index(
+            index, lambda: data.numpy(), config, N_FEATURES, False, distributed_ctx
+        )
+
+        assert trained is index
+        assert index.is_trained
+        assert not _shares_training(distributed_ctx)
+
+
+class TestSeededSearch:
+    """The seed the estimator sets is enough to repeat an approximate search."""
+
+    # nlist is set low enough that the training sample is a strict subset of the
+    # data, which is what makes the draw, and so the seed, matter at all.
+    @pytest.mark.parametrize("index_type", ["IVF", "IVFPQ"])
+    def test_the_same_seed_gives_the_same_neighbors(self, data, index_type):
+        config = FaissConfig(index_type=index_type, nlist=32, M=2)
+
+        runs = []
+        for _ in range(2):
+            seed_everything(0)
+            _, indices = pairwise_distances(
+                data, k=5, backend=config, return_indices=True
+            )
+            runs.append(indices)
+
+        assert torch.equal(runs[0], runs[1])
+
+    def test_a_different_seed_draws_different_training_rows(self, data):
+        draws = []
+        for seed in (0, 1):
+            seed_everything(seed)
+            draws.append(_training_sample(data, N_SAMPLES // 4))
+
+        assert not torch.equal(draws[0], draws[1])


### PR DESCRIPTION
## Verdict: APPROVE (closes #306)

Each distributed rank used to build and train its own IVF/IVFPQ index over the
shared database. That repeated identical training work once per GPU and, when
the run was not seeded, could also give ranks different trained quantizers.
Rank 0 now trains one empty template, serializes it (moving a GPU-trained
template to CPU first), and broadcasts it; every rank then adds the replicated
database locally and searches only its query-row chunk.

## Summary

- Train a shared IVF/IVFPQ template exactly once on rank 0 and broadcast it.
- Propagate a trainer failure to every rank instead of leaving receivers hung.
- Preserve the no-collective local path for CPU and single-process searches.
- Resolve automatic `nlist` without mutating the caller's `FaissConfig`.
- Map the exported low-level distributed API to each process's local GPU, not
  the default GPU 0.

## Benchmark (B200, real NCCL, n=300k, d=128, k=15)

Single warm measurement per arm; times and memory are the worst rank. Arrows
show prior per-rank training -> this PR. Recall is against Flat on each rank's
query chunk.

| GPUs | index | train calls | train s | total s | recall | peak device MB |
|---:|:---|:---:|:---:|:---:|---:|:---:|
| 1 | IVF | 1 -> 1 | 0.37 -> 0.37 | 0.43 -> 0.44 | 0.0197 | 3474 -> 3474 |
| 1 | IVFPQ | 1 -> 1 | 1.09 -> 1.23 | 1.20 -> 1.34 | 0.0165 | 3289 -> 3289 |
| 2 | IVF | 2 -> **1** | 0.40 -> 0.37 | 0.46 -> 0.45 | 0.0196 | 3910 -> 3914 |
| 2 | IVFPQ | 2 -> **1** | 1.23 -> 1.20 | 1.35 -> 1.37 | 0.0164 | 3708 -> 3712 |
| 4 | IVF | 4 -> **1** | 0.46 -> 0.36 | 0.52 -> 0.46 | 0.0195 | 3936 -> 3940 |
| 4 | IVFPQ | 4 -> **1** | 2.37 -> 1.20 | 2.80 -> **1.35** | 0.0163 | 3734 -> 3738 |

The useful scaling result is the 4-GPU IVFPQ case: end-to-end time falls from
2.80 s to 1.35 s by removing three concurrent training passes. At two GPUs the
extra broadcast is approximately neutral. At one GPU no broadcast executes and
both arms train locally; the single IVFPQ timing happened to favor the baseline,
so the table reports it rather than claiming a one-GPU speedup. Recall is
identical at every size, and the serialized template adds about 1 MB rather
than changing peak memory materially.

The distributed benchmark already preserved the user-owned config because the
high-level entry point copied it per rank. A separate ordinary single-process
check exposed the actual mutation fixed here: the old path changed automatic
`nlist` from 100 to 894, while this PR leaves it at 100 and stores 894 only in
the constructed index.

## Correctness and maintainability

- Real 1/2/4-GPU NCCL runs exercise GPU-to-CPU serialization, NCCL broadcast,
  deserialization, and rank-local GPU restoration.
- Real two-process Gloo CI verifies one training call, byte-equivalent trained
  indexes, collective failure propagation, Flat/IVF/IVFPQ behavior, and the
  streaming DataLoader path.
- Six focused single-process cases verify automatic `nlist`, public config
  immutability, and seeded public-search reproducibility for IVF and IVFPQ.
- The review removed 11 redundant helper-level cases that restated private
  implementation details; the retained tests protect user-visible behavior or
  a distributed invariant that cannot be observed reliably from one process.

## Limitations

- Absolute recall is low because this benchmark uses unstructured Gaussian
  data with default `nprobe=1`; the relevant result is exact recall parity
  between arms, not the absolute value.
- The timing table is a single warm comparison rather than a confidence
  interval. It establishes the duplicated-work mechanism and the large 4-GPU
  IVFPQ gain, but small differences should be treated as noise.
- GPU validation is single-node and stops at four GPUs; no 8-GPU or cross-node
  performance claim is made.

## Test plan

- `pytest torchdr/tests/test_faiss_index_training.py`
- `TORCHDR_DISTRIBUTED_TEST=1 torchrun --standalone --nnodes=1 --nproc-per-node=2 -m pytest torchdr/tests/test_distributed_faiss_training.py`
- Dedicated `test-distributed-faiss-cpu` GitHub Actions job for the real Gloo
  process group.
