### PR TITLE
[Test] Cover distributed launch/device guards for neighbor embeddings

### DIFF
--- a/torchdr/tests/test_distributed_contract.py
+++ b/torchdr/tests/test_distributed_contract.py
@@ -1,33 +1,12 @@
-"""
-Tests for the distributed-usage contract guards.
-
-UMAP, InfoTSNE and the other neighbor-embedding estimators (and their
-affinities) *support* distributed execution, but only when the process group is
-launched with ``torchrun``/the TorchDR CLI and the run is on GPU. Opting into
-distributed mode incorrectly -- ``distributed=True`` without a live process
-group, or with ``device="cpu"`` -- must fail immediately with a clear,
-actionable message instead of proceeding into a broken run.
-
-The guards live in ``AffinityBase.__init__`` and the neighbor-embedding base
-``_setup_distributed``. Both are exercised here in a single CPU process: the
-"requires torchrun" guard needs no process group (a normal pytest process has
-``torch.distributed`` uninitialized), while the "requires GPU" guard is reached
-by simulating an initialized single-rank group with mocks, mirroring
-``test_distributed_pca.py``.
-
-This is distinct from the *unsupported*-distributed rejection raised by PACMAP
-and TSNEkhorn, which fail for any truthy ``distributed`` value.
-"""
+"""Tests for the public distributed-usage contract."""
 
 # Author: Hugues Van Assel <vanasselhugues@gmail.com>
 #         Nicolas Courty <ncourty@irisa.fr>
 #
 # License: BSD 3-Clause License
 
-from contextlib import ExitStack
-from unittest.mock import patch
-
 import pytest
+import torch
 
 from torchdr.affinity import UMAPAffinity
 from torchdr.neighbor_embedding import COSNE, SNE, TSNE, UMAP, InfoTSNE, LargeVis
@@ -37,22 +16,13 @@ from torchdr.neighbor_embedding import COSNE, SNE, TSNE, UMAP, InfoTSNE, LargeVi
 DISTRIBUTED_ESTIMATORS = [UMAP, InfoTSNE, LargeVis, SNE, TSNE, COSNE]
 
 
-def _simulate_initialized_group():
-    """Context patching ``torch.distributed`` to look like a live 1-rank group.
-
-    Also forces ``torch.cuda.is_available()`` to ``False`` so the guards are
-    reached deterministically without touching a real device, regardless of the
-    machine the test runs on.
-    """
-    stack = ExitStack()
-    stack.enter_context(patch("torch.distributed.is_initialized", return_value=True))
-    stack.enter_context(patch("torch.distributed.get_rank", return_value=0))
-    stack.enter_context(patch("torch.distributed.get_world_size", return_value=1))
-    stack.enter_context(patch("torch.cuda.is_available", return_value=False))
-    return stack
-
-
-# --- "requires torchrun": distributed=True without a live process group ---
+@pytest.fixture
+def initialized_cpu_group(monkeypatch):
+    """Simulate a live single-rank group without touching a CUDA device."""
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: True)
+    monkeypatch.setattr(torch.distributed, "get_rank", lambda: 0)
+    monkeypatch.setattr(torch.distributed, "get_world_size", lambda: 1)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
 
 
 @pytest.mark.parametrize("estimator", DISTRIBUTED_ESTIMATORS)
@@ -68,25 +38,19 @@ def test_umap_affinity_distributed_true_requires_torchrun():
         UMAPAffinity(distributed=True)
 
 
-# --- "requires GPU": distributed on a live group but device="cpu" ---
-
-
 @pytest.mark.parametrize("estimator", [UMAP, InfoTSNE])
-def test_estimator_distributed_cpu_device_requires_gpu(estimator):
+def test_estimator_distributed_cpu_device_requires_gpu(
+    estimator, initialized_cpu_group
+):
     """A live group with ``device='cpu'`` is rejected with a GPU message."""
-    with _simulate_initialized_group():
-        with pytest.raises(ValueError, match="GPU"):
-            estimator(distributed=True, device="cpu")
+    with pytest.raises(ValueError, match="GPU"):
+        estimator(distributed=True, device="cpu")
 
 
-def test_umap_affinity_distributed_cpu_device_requires_gpu():
+def test_umap_affinity_distributed_cpu_device_requires_gpu(initialized_cpu_group):
     """The affinity layer rejects ``device='cpu'`` under a live group."""
-    with _simulate_initialized_group():
-        with pytest.raises(ValueError, match="GPU"):
-            UMAPAffinity(distributed=True, device="cpu")
-
-
-# --- The default path stays inert without a process group ---
+    with pytest.raises(ValueError, match="GPU"):
+        UMAPAffinity(distributed=True, device="cpu")
 
 
 @pytest.mark.parametrize("estimator", DISTRIBUTED_ESTIMATORS)

--- a/torchdr/tests/test_distributed_contract.py
+++ b/torchdr/tests/test_distributed_contract.py
@@ -1,0 +1,96 @@
+"""
+Tests for the distributed-usage contract guards.
+
+UMAP, InfoTSNE and the other neighbor-embedding estimators (and their
+affinities) *support* distributed execution, but only when the process group is
+launched with ``torchrun``/the TorchDR CLI and the run is on GPU. Opting into
+distributed mode incorrectly -- ``distributed=True`` without a live process
+group, or with ``device="cpu"`` -- must fail immediately with a clear,
+actionable message instead of proceeding into a broken run.
+
+The guards live in ``AffinityBase.__init__`` and the neighbor-embedding base
+``_setup_distributed``. Both are exercised here in a single CPU process: the
+"requires torchrun" guard needs no process group (a normal pytest process has
+``torch.distributed`` uninitialized), while the "requires GPU" guard is reached
+by simulating an initialized single-rank group with mocks, mirroring
+``test_distributed_pca.py``.
+
+This is distinct from the *unsupported*-distributed rejection raised by PACMAP
+and TSNEkhorn, which fail for any truthy ``distributed`` value.
+"""
+
+# Author: Hugues Van Assel <vanasselhugues@gmail.com>
+#         Nicolas Courty <ncourty@irisa.fr>
+#
+# License: BSD 3-Clause License
+
+from contextlib import ExitStack
+from unittest.mock import patch
+
+import pytest
+
+from torchdr.affinity import UMAPAffinity
+from torchdr.neighbor_embedding import COSNE, SNE, TSNE, UMAP, InfoTSNE, LargeVis
+
+# Estimators that support distributed mode. PACMAP and TSNEkhorn are excluded:
+# they reject distributed unconditionally and are covered elsewhere.
+DISTRIBUTED_ESTIMATORS = [UMAP, InfoTSNE, LargeVis, SNE, TSNE, COSNE]
+
+
+def _simulate_initialized_group():
+    """Context patching ``torch.distributed`` to look like a live 1-rank group.
+
+    Also forces ``torch.cuda.is_available()`` to ``False`` so the guards are
+    reached deterministically without touching a real device, regardless of the
+    machine the test runs on.
+    """
+    stack = ExitStack()
+    stack.enter_context(patch("torch.distributed.is_initialized", return_value=True))
+    stack.enter_context(patch("torch.distributed.get_rank", return_value=0))
+    stack.enter_context(patch("torch.distributed.get_world_size", return_value=1))
+    stack.enter_context(patch("torch.cuda.is_available", return_value=False))
+    return stack
+
+
+# --- "requires torchrun": distributed=True without a live process group ---
+
+
+@pytest.mark.parametrize("estimator", DISTRIBUTED_ESTIMATORS)
+def test_estimator_distributed_true_requires_torchrun(estimator):
+    """``distributed=True`` outside a process group raises, not proceeds."""
+    with pytest.raises(RuntimeError, match="torchrun"):
+        estimator(distributed=True)
+
+
+def test_umap_affinity_distributed_true_requires_torchrun():
+    """The affinity layer enforces the same launch contract as the estimator."""
+    with pytest.raises(RuntimeError, match="torchrun"):
+        UMAPAffinity(distributed=True)
+
+
+# --- "requires GPU": distributed on a live group but device="cpu" ---
+
+
+@pytest.mark.parametrize("estimator", [UMAP, InfoTSNE])
+def test_estimator_distributed_cpu_device_requires_gpu(estimator):
+    """A live group with ``device='cpu'`` is rejected with a GPU message."""
+    with _simulate_initialized_group():
+        with pytest.raises(ValueError, match="GPU"):
+            estimator(distributed=True, device="cpu")
+
+
+def test_umap_affinity_distributed_cpu_device_requires_gpu():
+    """The affinity layer rejects ``device='cpu'`` under a live group."""
+    with _simulate_initialized_group():
+        with pytest.raises(ValueError, match="GPU"):
+            UMAPAffinity(distributed=True, device="cpu")
+
+
+# --- The default path stays inert without a process group ---
+
+
+@pytest.mark.parametrize("estimator", DISTRIBUTED_ESTIMATORS)
+def test_estimator_default_is_not_distributed(estimator):
+    """The default (``distributed='auto'``) must not raise off a launcher."""
+    est = estimator()
+    assert est.distributed is False


### PR DESCRIPTION
## Verdict

**APPROVE** — usability + regression coverage. Test-only; no production behavior change.

## Summary

- The distributed-capable neighbor-embedding estimators (`UMAP`, `InfoTSNE`, `LargeVis`, `SNE`, `TSNE`, `COSNE`) and their affinities guard two misuse cases at construction, but neither guard had any test:
  - `distributed=True` without a live process group → `RuntimeError` telling the user to launch with `torchrun`.
  - distributed mode with `device="cpu"` → `ValueError` requiring a GPU.
- Both guards live in `AffinityBase.__init__` and the neighbor-embedding base `_setup_distributed`, so a base-class refactor could silently drop them and regress the first-run experience to a cryptic downstream error (e.g. `Default process group has not been initialized`).
- Adds `torchdr/tests/test_distributed_contract.py`: a single-CPU-process module (ordinary CI, no GPU or `torchrun`). The launch guard needs no process group; the GPU guard uses a mocked single-rank group, mirroring `test_distributed_pca.py`. Also asserts the default (`distributed="auto"`) stays non-distributed off a launcher.
- Complements the unsupported-distributed rejection coverage for PACMAP/TSNEkhorn (#329) — this is the misuse contract for the estimators that *do* support distributed.

Closes #330.

## Validation

- Baseline commit: `42d235c` (`upstream/main`). Candidate: this branch.
- Hardware: 1 CPU node (no GPU); env `torchdr`; command `pytest torchdr/tests/test_distributed_contract.py`.
- **Candidate: 16 passed.**
- **Decisive baseline demonstration:** neutralizing the four guard conditions (`if not dist.is_initialized():` and the two `device == "cpu"` checks → `if False:`) makes the 10 guard assertions fail (DID NOT RAISE / wrong error) while the 6 default-path controls still pass — **10 failed, 6 passed**; restoring the source returns **16 passed** with an empty `git diff`.
- `pre-commit` on the new file: clean.

## Risks and limitations

- Test-only; touches no library code.
- The GPU-device guard is verified with mocks (no real multi-GPU group needed); the launch guard is verified directly.
- The analogous distributed guards in the `eval` metrics (`knn_labels`, `neighborhood_preservation`) remain untested — noted in #330 as a possible follow-up, out of scope here.
