### PR TITLE
[Fix] Prevent adjusted Rand score overflow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,8 +77,7 @@ test = [
     "numpydoc",
     "pytest-cov",
     "codecov",
-    "matplotlib",
-    "torchmetrics"
+    "matplotlib"
 ]
 
 keops = [
@@ -93,7 +92,6 @@ dev = [
     "codecov",
     "pykeops",
     "pre-commit",
-    "torchmetrics",
 ]
 
 doc = [

--- a/torchdr/eval/kmeans.py
+++ b/torchdr/eval/kmeans.py
@@ -9,16 +9,12 @@ import numpy as np
 import torch
 from contextlib import ExitStack, redirect_stdout
 from io import StringIO
+from sklearn.metrics import adjusted_rand_score
 from typing import Union, Optional
 
 from torchdr.utils import to_torch
 from torchdr.utils.faiss import faiss
 from torchdr.utils.faiss_runtime import faiss_gpu_available, get_gpu_resources
-
-try:
-    from torchmetrics.clustering import AdjustedRandScore
-except ImportError:
-    AdjustedRandScore = None
 
 
 def _fit_faiss_kmeans_tensor(
@@ -108,7 +104,8 @@ def kmeans_ari(
         Number of times to run K-means with different initializations,
         keeping the best result (lowest objective).
     device : str, optional
-        Device to use for ARI computation. If None, uses the input device.
+        Device to use for K-means and tensor outputs. If None, uses the input
+        device. ARI is evaluated on CPU with scikit-learn.
     random_state : int, optional
         Random seed for reproducibility.
     verbose : bool, default=False
@@ -128,7 +125,7 @@ def kmeans_ari(
     Raises
     ------
     ImportError
-        If FAISS or torchmetrics is not installed.
+        If FAISS is not installed.
     ValueError
         If n_clusters is less than 1 or greater than n_samples.
 
@@ -157,17 +154,13 @@ def kmeans_ari(
     GPU acceleration is automatically used if FAISS-GPU is installed and X is on GPU.
     FAISS K-means computes in float32. Tensor inputs stay as tensors on the selected
     CPU or GPU when the installed FAISS build provides tensor-native clustering.
+    ARI is evaluated with scikit-learn, whose integer-safe implementation avoids
+    overflow for large sample counts.
     """
     if faiss is False:
         raise ImportError(
             "[TorchDR] FAISS is required for kmeans_ari but not installed. "
             "Install it with: conda install -c pytorch -c nvidia faiss-gpu"
-        )
-
-    if AdjustedRandScore is None:
-        raise ImportError(
-            "[TorchDR] torchmetrics is required for kmeans_ari but not installed. "
-            "Install it with: pip install torchmetrics"
         )
 
     input_is_numpy = not isinstance(X, torch.Tensor) or not isinstance(
@@ -248,8 +241,11 @@ def kmeans_ari(
     predicted_labels_torch = predicted_labels_torch.long().to(device)
     labels_torch = labels.long().to(device)
 
-    ari_metric = AdjustedRandScore().to(device)
-    ari_score = ari_metric(predicted_labels_torch, labels_torch)
+    ari_value = adjusted_rand_score(
+        labels_torch.detach().cpu().numpy(),
+        predicted_labels_torch.detach().cpu().numpy(),
+    )
+    ari_score = torch.tensor(ari_value, dtype=torch.float32, device=device)
 
     if input_is_numpy:
         ari_score = ari_score.detach().cpu().numpy().item()

--- a/torchdr/tests/test_eval.py
+++ b/torchdr/tests/test_eval.py
@@ -11,7 +11,10 @@ import warnings
 import numpy as np
 import pytest
 import torch
-from sklearn.metrics import silhouette_score as sk_silhouette_score
+from sklearn.metrics import (
+    adjusted_rand_score as sk_adjusted_rand_score,
+    silhouette_score as sk_silhouette_score,
+)
 from torch.testing import assert_close
 
 from torchdr.eval import (
@@ -189,11 +192,6 @@ def test_silhouette_with_faiss_config(backend):
 @pytest.mark.parametrize("dtype", lst_types)
 def test_kmeans_ari_basic(dtype):
     """Test basic kmeans_ari functionality."""
-    try:
-        import torchmetrics  # noqa: F401
-    except ImportError:
-        pytest.skip("torchmetrics not installed")
-
     X, y = toy_dataset(100, dtype)
 
     # Test with numpy arrays
@@ -214,13 +212,38 @@ def test_kmeans_ari_basic(dtype):
 
 
 @pytest.mark.skipif(not faiss, reason="FAISS not installed")
+def test_kmeans_ari_large_sample_matches_sklearn():
+    """ARI stays accurate when products of pair counts exceed int64."""
+    contingency = np.array([[56_000, 1_000], [1_000, 12_000]])
+    predicted = np.concatenate(
+        [
+            np.zeros(contingency[:, 0].sum(), dtype=np.int64),
+            np.ones(contingency[:, 1].sum(), dtype=np.int64),
+        ]
+    )
+    labels = np.concatenate(
+        [
+            np.zeros(contingency[0, 0], dtype=np.int64),
+            np.ones(contingency[1, 0], dtype=np.int64),
+            np.zeros(contingency[0, 1], dtype=np.int64),
+            np.ones(contingency[1, 1], dtype=np.int64),
+        ]
+    )
+    X = predicted[:, None].astype(np.float32)
+
+    ari_score, assignments = kmeans_ari(
+        X, labels, n_clusters=2, niter=2, random_state=0
+    )
+
+    assert -1 <= ari_score <= 1
+    assert ari_score == pytest.approx(
+        sk_adjusted_rand_score(labels, assignments), abs=1e-7
+    )
+
+
+@pytest.mark.skipif(not faiss, reason="FAISS not installed")
 def test_kmeans_ari_n_clusters():
     """Test kmeans_ari with different n_clusters settings."""
-    try:
-        import torchmetrics  # noqa: F401
-    except ImportError:
-        pytest.skip("torchmetrics not installed")
-
     X, y = iris_dataset("float32")
 
     # Test with automatic n_clusters (should use number of unique labels)
@@ -244,11 +267,6 @@ def test_kmeans_ari_n_clusters():
 @pytest.mark.skipif(not faiss, reason="FAISS not installed")
 def test_kmeans_ari_reproducibility():
     """Test kmeans_ari reproducibility with random_state."""
-    try:
-        import torchmetrics  # noqa: F401
-    except ImportError:
-        pytest.skip("torchmetrics not installed")
-
     X, y = toy_dataset(100, "float32")
 
     # Test reproducibility
@@ -268,11 +286,6 @@ def test_kmeans_ari_reproducibility():
 @pytest.mark.parametrize("random_state", [None, 42])
 def test_kmeans_ari_preserves_numpy_random_state(random_state):
     """Test kmeans_ari does not mutate NumPy's global random state."""
-    try:
-        import torchmetrics  # noqa: F401
-    except ImportError:
-        pytest.skip("torchmetrics not installed")
-
     X, y = toy_dataset(100, "float32")
     np.random.seed(1234)
     state_before = np.random.get_state()
@@ -287,11 +300,6 @@ def test_kmeans_ari_preserves_numpy_random_state(random_state):
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 def test_kmeans_ari_gpu():
     """Test kmeans_ari with GPU device."""
-    try:
-        import torchmetrics  # noqa: F401
-    except ImportError:
-        pytest.skip("torchmetrics not installed")
-
     X, y = toy_dataset(100, "float32")
     X_cuda = torch.from_numpy(X).cuda()
     y_cuda = torch.from_numpy(y).cuda()
@@ -308,7 +316,6 @@ def test_kmeans_ari_gpu():
 def test_kmeans_ari_tensor_input_avoids_full_numpy_round_trip(monkeypatch):
     """Test that tensor K-means does not convert the full input to NumPy."""
     try:
-        import torchmetrics  # noqa: F401
         import faiss.contrib.torch.clustering  # noqa: F401
     except ImportError:
         pytest.skip("FAISS tensor clustering dependencies are not installed")
@@ -333,11 +340,6 @@ def test_kmeans_ari_tensor_input_avoids_full_numpy_round_trip(monkeypatch):
 @pytest.mark.skipif(not faiss, reason="FAISS not installed")
 def test_kmeans_ari_warns_on_float64():
     """Test that FAISS K-means' float32 precision boundary is explicit."""
-    try:
-        import torchmetrics  # noqa: F401
-    except ImportError:
-        pytest.skip("torchmetrics not installed")
-
     X = torch.randn(40, 6, dtype=torch.float64)
     y = torch.arange(40) % 4
 
@@ -350,11 +352,6 @@ def test_kmeans_ari_warns_on_float64():
 @pytest.mark.skipif(not faiss, reason="FAISS not installed")
 def test_kmeans_ari_perfect_clustering():
     """Test kmeans_ari with perfect clustering."""
-    try:
-        import torchmetrics  # noqa: F401
-    except ImportError:
-        pytest.skip("torchmetrics not installed")
-
     # Create well-separated clusters
     np.random.seed(42)
     X1 = np.random.randn(50, 2) + np.array([0, 0])
@@ -372,11 +369,6 @@ def test_kmeans_ari_perfect_clustering():
 @pytest.mark.skipif(not faiss, reason="FAISS not installed")
 def test_kmeans_ari_niter_nredo():
     """Test kmeans_ari with different niter and nredo values."""
-    try:
-        import torchmetrics  # noqa: F401
-    except ImportError:
-        pytest.skip("torchmetrics not installed")
-
     np.random.seed(42)
     X = np.random.randn(100, 5).astype("float32")
     y = np.array([0] * 50 + [1] * 50)
@@ -400,11 +392,6 @@ def test_kmeans_ari_niter_nredo():
 @pytest.mark.skipif(not faiss, reason="FAISS not installed")
 def test_kmeans_ari_edge_cases():
     """Test kmeans_ari edge cases."""
-    try:
-        import torchmetrics  # noqa: F401
-    except ImportError:
-        pytest.skip("torchmetrics not installed")
-
     # Edge case: n_clusters equals n_samples
     X = np.random.randn(5, 3).astype("float32")
     y = np.arange(5)
@@ -700,13 +687,8 @@ def test_eval_functions_consistency(backend):
     assert -1 <= sil_score <= 1
 
     if faiss:
-        try:
-            import torchmetrics  # noqa: F401
-
-            ari_score, _ = kmeans_ari(X, y)
-            assert -1 <= ari_score <= 1
-        except ImportError:
-            pass
+        ari_score, _ = kmeans_ari(X, y)
+        assert -1 <= ari_score <= 1
 
     # Create a simple embedding for neighborhood preservation
     Z = X[:, :2]  # Use first 2 dimensions as embedding


### PR DESCRIPTION
## Summary

- compute ARI with scikit-learn's overflow-safe implementation instead of TorchMetrics' overflowing int64 pair-count products
- preserve the existing Python-float versus tensor return contract, including returning tensor scores on the requested device
- remove the now-unused optional TorchMetrics dependency and its conditional test skips
- add a public-API regression test at 70,000 samples that verifies boundedness and agreement with scikit-learn

Closes #221.

## Reproduction

On the pre-fix code, a deterministic 100,000-sample two-cluster case returned `-1.9384879` for the same FAISS assignments that scikit-learn evaluated as `0.2138961`. The pair counts themselves fit in int64, but TorchMetrics multiplied them before conversion to floating point and overflowed. The updated implementation returns the reference value.

## Test plan

- [x] `pytest torchdr/tests/test_eval.py -k kmeans_ari -q` — 12 passed, 1 GPU-only skip
- [x] `pytest torchdr/tests/test_eval.py -q` — 85 passed, 2 skipped
- [x] real B200 `test_kmeans_ari_gpu` — passed
- [x] `pre-commit run --all-files` — passed
