### PR TITLE
[Feature] Add FaissPlanConfig execution-plan API (exact-only)

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -180,7 +180,7 @@ jobs:
       - name: Verify FAISS installation
         run: python -c "from torchdr.utils.faiss import faiss; assert faiss, 'FAISS failed to import'"
       - name: Run Tests
-        run: pytest torchdr/tests/test_utils.py torchdr/tests/test_dataloader.py torchdr/tests/test_eval.py torchdr/tests/test_faiss_index_training.py --verbose --cov=torchdr --cov-report term --cov-report xml
+        run: pytest torchdr/tests/test_utils.py torchdr/tests/test_dataloader.py torchdr/tests/test_eval.py torchdr/tests/test_faiss_index_training.py torchdr/tests/test_faiss_plan.py --verbose --cov=torchdr --cov-report term --cov-report xml
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/docs/source/torchdr.user_guide.rst
+++ b/docs/source/torchdr.user_guide.rst
@@ -331,9 +331,9 @@ For finer control, pass a :class:`~torchdr.distance.FaissPlanConfig` as the
 ``backend`` to express accuracy and resource *intent* rather than low-level FAISS
 parameters. Exact search is the default (``FaissPlanConfig(mode="exact")``) and
 never silently approximates; the resolved execution plan (index, precision,
-distribution, memory estimate) is available after fitting through the affinity's
-``faiss_plan_`` attribute. Experts can still supply low-level options through
-``FaissPlanConfig(expert=FaissConfig(...))`` or by passing a
+distribution, and index-memory estimate) is available after fitting through the
+estimator's ``faiss_plan_`` attribute. Experts can still supply low-level options
+through ``FaissPlanConfig(expert=FaissConfig(...))`` or by passing a
 :class:`~torchdr.distance.FaissConfig` directly.
 
 Alternatively, for exact computations or affinities that can't be limited to kNNs, you can use symbolic (lazy) tensors to avoid memory overflows.

--- a/docs/source/torchdr.user_guide.rst
+++ b/docs/source/torchdr.user_guide.rst
@@ -327,6 +327,15 @@ For large datasets (typically when :math:`n > 10^4`) where the full pairwise-dis
 TorchDR can offload these computations to the GPU-compatible kNN library `Faiss <https://github.com/facebookresearch/faiss>`_.
 Simply set :attr:`backend` to ``faiss`` to leverage Faiss's efficient implementations.
 
+For finer control, pass a :class:`~torchdr.distance.FaissPlanConfig` as the
+``backend`` to express accuracy and resource *intent* rather than low-level FAISS
+parameters. Exact search is the default (``FaissPlanConfig(mode="exact")``) and
+never silently approximates; the resolved execution plan (index, precision,
+distribution, memory estimate) is available after fitting through the affinity's
+``faiss_plan_`` attribute. Experts can still supply low-level options through
+``FaissPlanConfig(expert=FaissConfig(...))`` or by passing a
+:class:`~torchdr.distance.FaissConfig` directly.
+
 Alternatively, for exact computations or affinities that can't be limited to kNNs, you can use symbolic (lazy) tensors to avoid memory overflows.
 TorchDR integrates with ``pykeops``:cite:`charlier2021kernel`, representing tensors as mathematical expressions evaluated directly on your data samples.
 By computing on-the-fly formulas instead of storing full matrices, this approach removes memory constraints entirely.

--- a/torchdr/affinity/base.py
+++ b/torchdr/affinity/base.py
@@ -23,8 +23,8 @@ from torchdr.distance import (
     pairwise_distances,
     FaissConfig,
     FaissPlanConfig,
-    resolve_faiss_plan,
 )
+from torchdr.distance.faiss_plan import _resolve_faiss_plan
 
 import torch.distributed as dist
 
@@ -125,12 +125,11 @@ class Affinity(nn.Module, ABC):
         if not isinstance(backend, FaissPlanConfig):
             return backend
 
-        plan, config = resolve_faiss_plan(
+        plan, config = _resolve_faiss_plan(
             backend,
             n_samples=self._get_n_samples(X),
-            dim=self._get_n_features(X),
-            dist_ctx=getattr(self, "dist_ctx", None),
-            device=self.device,
+            n_features=self._get_n_features(X),
+            distributed_ctx=getattr(self, "dist_ctx", None),
         )
         self.faiss_plan_ = plan
         if self.verbose and getattr(self, "rank", 0) == 0:

--- a/torchdr/affinity/base.py
+++ b/torchdr/affinity/base.py
@@ -22,6 +22,8 @@ from torchdr.utils import (
 from torchdr.distance import (
     pairwise_distances,
     FaissConfig,
+    FaissPlanConfig,
+    resolve_faiss_plan,
 )
 
 import torch.distributed as dist
@@ -39,8 +41,10 @@ class Affinity(nn.Module, ABC):
     device : str, optional
         Device for computation. ``"auto"`` uses the input data's device.
         Default is "auto".
-    backend : {"keops", "faiss", None} or FaissConfig, optional
-        Backend for handling sparsity and memory efficiency.
+    backend : {"keops", "faiss", None}, FaissConfig, or FaissPlanConfig, optional
+        Backend for handling sparsity and memory efficiency. A ``FaissPlanConfig``
+        expresses high-level intent (e.g. ``mode="exact"``); the resolved plan is
+        stored as ``faiss_plan_`` after computation.
         Default is None (standard PyTorch).
     verbose : bool, optional
         Verbosity. Default is False.
@@ -56,7 +60,7 @@ class Affinity(nn.Module, ABC):
         metric: str = "sqeuclidean",
         zero_diag: bool = True,
         device: str = "auto",
-        backend: Union[str, FaissConfig] = None,
+        backend: Union[str, FaissConfig, FaissPlanConfig, None] = None,
         verbose: bool = False,
         random_state: float = None,
         compile: bool = False,
@@ -105,6 +109,34 @@ class Affinity(nn.Module, ABC):
 
     # --- Distance computation ---
 
+    def _resolve_plan_backend(self, X):
+        r"""Resolve a ``FaissPlanConfig`` backend into a low-level ``FaissConfig``.
+
+        If ``self.backend`` is a :class:`~torchdr.distance.FaissPlanConfig`,
+        resolve it into an immutable execution plan (stored as
+        ``self.faiss_plan_`` and printed on rank 0 when ``verbose=True``) and
+        return the corresponding low-level
+        :class:`~torchdr.distance.FaissConfig` to hand to ``pairwise_distances``.
+        Otherwise return ``self.backend`` unchanged. This keeps user-intent
+        configuration at the estimator boundary while the expert configuration
+        flows internally.
+        """
+        backend = self.backend
+        if not isinstance(backend, FaissPlanConfig):
+            return backend
+
+        plan, config = resolve_faiss_plan(
+            backend,
+            n_samples=self._get_n_samples(X),
+            dim=self._get_n_features(X),
+            dist_ctx=getattr(self, "dist_ctx", None),
+            device=self.device,
+        )
+        self.faiss_plan_ = plan
+        if self.verbose and getattr(self, "rank", 0) == 0:
+            self.logger.info(f"Resolved FAISS execution plan: {plan}")
+        return config
+
     def _distance_matrix(
         self, X: torch.Tensor, k: int = None, return_indices: bool = False
     ):
@@ -127,7 +159,7 @@ class Affinity(nn.Module, ABC):
         return pairwise_distances(
             X=X,
             metric=self.metric,
-            backend=self.backend,
+            backend=self._resolve_plan_backend(X),
             exclude_diag=self.zero_diag,
             k=k,
             return_indices=return_indices,
@@ -160,6 +192,17 @@ class Affinity(nn.Module, ABC):
         if isinstance(X, DataLoader):
             return len(X.dataset)
         return X.shape[0]
+
+    def _get_n_features(self, X):
+        """Return the feature dimension, or None if unknown (e.g. DataLoader)."""
+        if isinstance(X, DataLoader):
+            from torchdr.distance.faiss import get_dataloader_metadata
+
+            metadata = get_dataloader_metadata(X)
+            if metadata is not None and "n_features" in metadata:
+                return metadata["n_features"]
+            return None
+        return X.shape[1]
 
     def _get_dtype(self, X):
         """Return the dtype of the input."""
@@ -201,8 +244,10 @@ class LogAffinity(Affinity):
     device : str, optional
         Device for computation. ``"auto"`` uses the input data's device.
         Default is "auto".
-    backend : {"keops", "faiss", None} or FaissConfig, optional
-        Backend for handling sparsity and memory efficiency.
+    backend : {"keops", "faiss", None}, FaissConfig, or FaissPlanConfig, optional
+        Backend for handling sparsity and memory efficiency. A ``FaissPlanConfig``
+        expresses high-level intent (e.g. ``mode="exact"``); the resolved plan is
+        stored as ``faiss_plan_`` after computation.
         Default is None (standard PyTorch).
     verbose : bool, optional
         Verbosity. Default is False.
@@ -217,7 +262,7 @@ class LogAffinity(Affinity):
         metric: str = "sqeuclidean",
         zero_diag: bool = True,
         device: str = "auto",
-        backend: Union[str, FaissConfig] = None,
+        backend: Union[str, FaissConfig, FaissPlanConfig, None] = None,
         verbose: bool = False,
         random_state: float = None,
         compile: bool = False,
@@ -291,8 +336,10 @@ class SparseAffinity(Affinity):
     device : str, optional
         Device for computation. ``"auto"`` uses the input data's device.
         Default is "auto".
-    backend : {"keops", "faiss", None} or FaissConfig, optional
-        Backend for handling sparsity and memory efficiency.
+    backend : {"keops", "faiss", None}, FaissConfig, or FaissPlanConfig, optional
+        Backend for handling sparsity and memory efficiency. A ``FaissPlanConfig``
+        expresses high-level intent (e.g. ``mode="exact"``); the resolved plan is
+        stored as ``faiss_plan_`` after computation.
         Default is None (standard PyTorch).
     verbose : bool, optional
         Verbosity. Default is False.
@@ -312,7 +359,7 @@ class SparseAffinity(Affinity):
         metric: str = "sqeuclidean",
         zero_diag: bool = True,
         device: str = "auto",
-        backend: Union[str, FaissConfig] = None,
+        backend: Union[str, FaissConfig, FaissPlanConfig, None] = None,
         verbose: bool = False,
         compile: bool = False,
         sparsity: bool = True,
@@ -353,7 +400,7 @@ class SparseAffinity(Affinity):
             self._backend_forced = backend not in [
                 "faiss",
                 None,
-            ] and not isinstance(backend, FaissConfig)
+            ] and not isinstance(backend, (FaissConfig, FaissPlanConfig))
             if self._backend_forced:
                 self._original_backend = backend
                 backend = "faiss"
@@ -466,7 +513,7 @@ class SparseAffinity(Affinity):
         result = pairwise_distances(
             X=X,
             metric=self.metric,
-            backend=self.backend,
+            backend=self._resolve_plan_backend(X),
             exclude_diag=self.zero_diag,
             k=k,
             return_indices=return_indices,
@@ -503,8 +550,10 @@ class SparseLogAffinity(SparseAffinity, LogAffinity):
     device : str, optional
         Device for computation. ``"auto"`` uses the input data's device.
         Default is "auto".
-    backend : {"keops", "faiss", None} or FaissConfig, optional
-        Backend for handling sparsity and memory efficiency.
+    backend : {"keops", "faiss", None}, FaissConfig, or FaissPlanConfig, optional
+        Backend for handling sparsity and memory efficiency. A ``FaissPlanConfig``
+        expresses high-level intent (e.g. ``mode="exact"``); the resolved plan is
+        stored as ``faiss_plan_`` after computation.
         Default is None (standard PyTorch).
     verbose : bool, optional
         Verbosity. Default is False.

--- a/torchdr/affinity_matcher.py
+++ b/torchdr/affinity_matcher.py
@@ -17,7 +17,7 @@ from torchdr.affinity import (
     SparseAffinity,
 )
 from torchdr.base import DRModule
-from torchdr.distance import FaissConfig
+from torchdr.distance import FaissConfig, FaissPlanConfig
 from torchdr.utils import (
     check_NaNs,
     check_nonnegativity,
@@ -96,7 +96,7 @@ class AffinityMatcher(DRModule):
         Scaling factor for the initial embedding. Default is 1e-4.
     device : str, optional
         Device for computations. Default is "auto".
-    backend : {"keops", "faiss", None} or FaissConfig, optional
+    backend : {"keops", "faiss", None}, FaissConfig, or FaissPlanConfig, optional
         Backend for handling sparsity and memory efficiency.
         Default is None (standard PyTorch).
     verbose : bool, optional
@@ -133,7 +133,7 @@ class AffinityMatcher(DRModule):
         init: Union[str, torch.Tensor, np.ndarray] = "pca",
         init_scaling: float = 1e-4,
         device: str = "auto",
-        backend: Union[str, FaissConfig, None] = None,
+        backend: Union[str, FaissConfig, FaissPlanConfig, None] = None,
         verbose: bool = False,
         random_state: Optional[float] = None,
         check_interval: int = 50,
@@ -479,7 +479,8 @@ class AffinityMatcher(DRModule):
 
     def on_affinity_computation_end(self):
         """Called after computing the input affinity matrix."""
-        pass
+        if hasattr(self.affinity_in, "faiss_plan_"):
+            self.faiss_plan_ = self.affinity_in.faiss_plan_
 
     def on_training_step_start(self):
         """Called at the beginning of each optimization step."""

--- a/torchdr/distance/__init__.py
+++ b/torchdr/distance/__init__.py
@@ -7,6 +7,7 @@ from .faiss import (
     LIST_METRICS_FAISS,
     FaissConfig,
 )
+from .faiss_plan import FaissPlanConfig, resolve_faiss_plan
 
 __all__ = [
     "pairwise_distances",
@@ -16,6 +17,8 @@ __all__ = [
     "pairwise_distances_faiss",
     "pairwise_distances_faiss_from_dataloader",
     "FaissConfig",
+    "FaissPlanConfig",
+    "resolve_faiss_plan",
     "LIST_METRICS_TORCH",
     "LIST_METRICS_KEOPS",
     "LIST_METRICS_FAISS",

--- a/torchdr/distance/__init__.py
+++ b/torchdr/distance/__init__.py
@@ -7,7 +7,7 @@ from .faiss import (
     LIST_METRICS_FAISS,
     FaissConfig,
 )
-from .faiss_plan import FaissPlanConfig, resolve_faiss_plan
+from .faiss_plan import FaissPlanConfig
 
 __all__ = [
     "pairwise_distances",
@@ -18,7 +18,6 @@ __all__ = [
     "pairwise_distances_faiss_from_dataloader",
     "FaissConfig",
     "FaissPlanConfig",
-    "resolve_faiss_plan",
     "LIST_METRICS_TORCH",
     "LIST_METRICS_KEOPS",
     "LIST_METRICS_FAISS",

--- a/torchdr/distance/base.py
+++ b/torchdr/distance/base.py
@@ -16,6 +16,7 @@ from .faiss import (
     pairwise_distances_faiss_from_dataloader,
     FaissConfig,
 )
+from .faiss_plan import FaissPlanConfig, resolve_faiss_plan
 from torchdr.distributed import DistributedContext
 from torchdr.distributed.input_contract import validate_distributed_input
 
@@ -24,7 +25,7 @@ def pairwise_distances(
     X: Union[torch.Tensor, DataLoader],
     Y: Optional[torch.Tensor] = None,
     metric: str = "euclidean",
-    backend: Optional[Union[str, FaissConfig]] = None,
+    backend: Optional[Union[str, FaissConfig, FaissPlanConfig]] = None,
     exclude_diag: bool = False,
     k: Optional[int] = None,
     return_indices: bool = False,
@@ -58,12 +59,14 @@ def pairwise_distances(
         Input data. If None, Y is set to X. Not supported with DataLoader input.
     metric : str, optional
         Metric to use. Default is "euclidean".
-    backend : {'keops', 'faiss', None} or FaissConfig, optional
+    backend : {'keops', 'faiss', None}, FaissConfig, or FaissPlanConfig, optional
         Backend to use for computation. Can be:
         - "keops": Use KeOps for memory-efficient symbolic computations
         - "faiss": Use FAISS for fast k-NN computations with default settings
         - None: Use standard PyTorch operations
-        - FaissConfig object: Use FAISS with custom configuration
+        - FaissConfig object: Use FAISS with a low-level expert configuration
+        - FaissPlanConfig object: Use FAISS from a high-level execution intent
+          (e.g. ``mode="exact"``), resolved into a low-level configuration here
         If None, use standard torch operations. DataLoader input forces FAISS backend.
     exclude_diag : bool, optional
         Whether to exclude the diagonal from the distance matrix.
@@ -126,6 +129,21 @@ def pairwise_distances(
     ... )
     >>> # Each GPU gets its chunk of results
     """
+    # A FaissPlanConfig passed directly (rather than resolved by an affinity) is
+    # resolved here into its low-level FaissConfig so the dispatch below can treat
+    # it like any other FAISS backend. Estimators resolve the plan at the affinity
+    # layer and expose it as ``faiss_plan_``; direct callers just get the result.
+    if isinstance(backend, FaissPlanConfig):
+        _n = None if isinstance(X, DataLoader) else X.shape[0]
+        _dim = None if isinstance(X, DataLoader) else X.shape[1]
+        _, backend = resolve_faiss_plan(
+            backend,
+            n_samples=_n,
+            dim=_dim,
+            dist_ctx=distributed_ctx,
+            device=device,
+        )
+
     # Every rank must hold the same full dataset: each builds a complete index
     # and returns global sample ids. Check before any index is built.
     if distributed_ctx is not None and distributed_ctx.is_initialized:

--- a/torchdr/distance/base.py
+++ b/torchdr/distance/base.py
@@ -16,7 +16,7 @@ from .faiss import (
     pairwise_distances_faiss_from_dataloader,
     FaissConfig,
 )
-from .faiss_plan import FaissPlanConfig, resolve_faiss_plan
+from .faiss_plan import FaissPlanConfig, _resolve_faiss_plan
 from torchdr.distributed import DistributedContext
 from torchdr.distributed.input_contract import validate_distributed_input
 
@@ -136,12 +136,11 @@ def pairwise_distances(
     if isinstance(backend, FaissPlanConfig):
         _n = None if isinstance(X, DataLoader) else X.shape[0]
         _dim = None if isinstance(X, DataLoader) else X.shape[1]
-        _, backend = resolve_faiss_plan(
+        _, backend = _resolve_faiss_plan(
             backend,
             n_samples=_n,
-            dim=_dim,
-            dist_ctx=distributed_ctx,
-            device=device,
+            n_features=_dim,
+            distributed_ctx=distributed_ctx,
         )
 
     # Every rank must hold the same full dataset: each builds a complete index

--- a/torchdr/distance/faiss_plan.py
+++ b/torchdr/distance/faiss_plan.py
@@ -1,0 +1,275 @@
+"""Execution-plan API for FAISS-backed distance computation."""
+
+# Author: Hugues Van Assel <vanasselhugues@gmail.com>
+#
+# License: BSD 3-Clause License
+
+from dataclasses import dataclass
+from typing import Optional, Tuple, Union
+
+from .faiss import FaissConfig
+
+_VALID_MODES = ("exact", "balanced", "fast")
+_VALID_DISTRIBUTIONS = ("auto", "replicate", "shard")
+
+
+class FaissPlanConfig:
+    """High-level FAISS execution intent.
+
+    Exposes accuracy and resource *intent* instead of the many low-level FAISS
+    knobs. Exact search is the default; approximation and reduced precision are
+    explicit opt-ins. Automatic values are resolved into an immutable execution
+    plan (see :func:`resolve_faiss_plan`) that can be inspected after fitting
+    through an estimator's or affinity's ``faiss_plan_`` attribute. This object
+    is never mutated during resolution.
+
+    Pass it wherever a ``backend`` is accepted, e.g.
+    ``TSNE(backend=FaissPlanConfig(mode="exact"))``.
+
+    Parameters
+    ----------
+    mode : {"exact", "balanced", "fast"}, default="exact"
+        Accuracy/speed intent. ``"exact"`` uses a full-precision brute-force
+        (Flat) index and never silently approximates. ``"balanced"`` and
+        ``"fast"`` are explicit approximate opt-ins whose thresholds are not yet
+        benchmarked (see issue #304); they raise :class:`NotImplementedError` at
+        resolution time. For approximate search today, pass an ``expert``
+        :class:`~torchdr.distance.FaissConfig`.
+    distribution : {"auto", "replicate", "shard"}, default="auto"
+        Multi-GPU execution topology. ``"auto"`` and ``"replicate"`` build a
+        complete index on every rank (the current behavior) and do not change
+        the global k-NN result. ``"shard"`` is not yet supported (see issue
+        #301) and raises at resolution time.
+    memory_budget : "auto" or int, default="auto"
+        Target memory budget in bytes. Only ``"auto"`` is honored today; an
+        explicit budget is not yet supported (see issue #301).
+    random_state : int, optional
+        Seed for deterministic sampling/training, reusing the estimator seed.
+        The resolved plan records it.
+    expert : FaissConfig, optional
+        Expert override exposing supported low-level FAISS options. When set,
+        ``mode`` must be left at its default ``"exact"`` and the given
+        configuration is used verbatim as the resolved backend. Device ownership
+        still comes from the distributed context.
+
+    Examples
+    --------
+    >>> from torchdr.distance import FaissConfig, FaissPlanConfig
+
+    >>> # Normal user: exact, full-precision k-NN (the default).
+    >>> plan = FaissPlanConfig()
+
+    >>> # Preset intent (approximate presets are not yet available; see #304).
+    >>> plan = FaissPlanConfig(mode="exact", distribution="auto")
+
+    >>> # Expert: full control over the low-level FAISS index.
+    >>> plan = FaissPlanConfig(expert=FaissConfig(index_type="IVFPQ", nlist=1024))
+    """
+
+    def __init__(
+        self,
+        mode: str = "exact",
+        distribution: str = "auto",
+        memory_budget: Union[str, int] = "auto",
+        random_state: Optional[int] = None,
+        expert: Optional[FaissConfig] = None,
+    ):
+        if mode not in _VALID_MODES:
+            raise ValueError(
+                f"[TorchDR] Unknown mode {mode!r}; expected one of {_VALID_MODES}."
+            )
+        if distribution not in _VALID_DISTRIBUTIONS:
+            raise ValueError(
+                f"[TorchDR] Unknown distribution {distribution!r}; "
+                f"expected one of {_VALID_DISTRIBUTIONS}."
+            )
+        if not (
+            memory_budget == "auto"
+            or (
+                isinstance(memory_budget, int)
+                and not isinstance(memory_budget, bool)
+                and memory_budget > 0
+            )
+        ):
+            raise ValueError(
+                "[TorchDR] memory_budget must be 'auto' or a positive integer "
+                f"number of bytes; got {memory_budget!r}."
+            )
+        if expert is not None and not isinstance(expert, FaissConfig):
+            raise TypeError(
+                "[TorchDR] expert must be a FaissConfig or None; "
+                f"got {type(expert).__name__}."
+            )
+        if expert is not None and mode != "exact":
+            raise ValueError(
+                "[TorchDR] Cannot combine an expert override with a non-default "
+                "mode; pass either mode= (a preset) or expert= (a low-level "
+                "FaissConfig), not both."
+            )
+        self.mode = mode
+        self.distribution = distribution
+        self.memory_budget = memory_budget
+        self.random_state = random_state
+        self.expert = expert
+
+    def __repr__(self):
+        parts = [f"mode={self.mode!r}", f"distribution={self.distribution!r}"]
+        if self.memory_budget != "auto":
+            parts.append(f"memory_budget={self.memory_budget!r}")
+        if self.random_state is not None:
+            parts.append(f"random_state={self.random_state!r}")
+        if self.expert is not None:
+            parts.append(f"expert={self.expert!r}")
+        return f"FaissPlanConfig({', '.join(parts)})"
+
+
+@dataclass(frozen=True, repr=False)
+class _FaissPlan:
+    """Immutable resolved FAISS execution plan.
+
+    Recorded by an estimator/affinity as ``faiss_plan_`` and printed on rank 0
+    when ``verbose=True``. Purely diagnostic: the low-level configuration that
+    actually runs is returned separately by :func:`resolve_faiss_plan`.
+
+    Attributes
+    ----------
+    index_type : str
+        Resolved FAISS index, e.g. ``"Flat"``.
+    precision : {"float32", "reduced"}
+        ``"reduced"`` for product-quantized indexes, ``"float32"`` otherwise.
+    distribution : {"replicate"}
+        Resolved multi-GPU topology.
+    training_size : int or None
+        Number of rows used to train the index (``0`` for an untrained Flat
+        index, ``None`` when resolved downstream for approximate indexes).
+    batch_size : "auto" or int
+        Rows handed to FAISS per add/search call.
+    memory_estimate : int or None
+        Estimated index memory in bytes, or ``None`` when it cannot be
+        estimated upfront.
+    random_state : int or None
+        Seed recorded for deterministic sampling/training.
+    """
+
+    index_type: str
+    precision: str
+    distribution: str
+    training_size: Optional[int]
+    batch_size: Union[str, int]
+    memory_estimate: Optional[int]
+    random_state: Optional[int]
+
+    def __repr__(self):
+        mem = (
+            "unknown"
+            if self.memory_estimate is None
+            else f"{self.memory_estimate} bytes"
+        )
+        train = "unknown" if self.training_size is None else self.training_size
+        return (
+            "FaissPlan("
+            f"index_type={self.index_type!r}, precision={self.precision!r}, "
+            f"distribution={self.distribution!r}, training_size={train}, "
+            f"batch_size={self.batch_size!r}, memory_estimate={mem}, "
+            f"random_state={self.random_state!r})"
+        )
+
+
+def _precision_of(index_type: str) -> str:
+    """Precision label: product quantization compresses, everything else is full."""
+    return "reduced" if "PQ" in index_type else "float32"
+
+
+def resolve_faiss_plan(
+    config: FaissPlanConfig,
+    *,
+    n_samples: Optional[int] = None,
+    dim: Optional[int] = None,
+    dist_ctx=None,
+    device=None,
+) -> Tuple[_FaissPlan, FaissConfig]:
+    """Resolve a :class:`FaissPlanConfig` into a plan and a low-level FaissConfig.
+
+    Pure and non-mutating: returns a new immutable :class:`_FaissPlan` and a new
+    :class:`~torchdr.distance.FaissConfig`; the input ``config`` (and any
+    ``expert`` it carries) are left untouched. Raises
+    :class:`NotImplementedError` for intent that cannot yet be honored honestly.
+
+    Parameters
+    ----------
+    config : FaissPlanConfig
+        High-level execution intent.
+    n_samples, dim : int, optional
+        Dataset shape, used only to estimate index memory when available.
+    dist_ctx : DistributedContext, optional
+        Present for interface symmetry; device ownership in distributed mode is
+        applied later via ``DistributedContext.get_faiss_config``.
+    device : optional
+        Present for interface symmetry; unused for the exact plan.
+
+    Returns
+    -------
+    plan : _FaissPlan
+        Immutable diagnostic plan (assign to ``faiss_plan_``).
+    resolved : FaissConfig
+        Low-level configuration to hand to ``pairwise_distances``.
+    """
+    # Distribution intent (independent of mode/expert).
+    if config.distribution == "shard":
+        raise NotImplementedError(
+            "[TorchDR] distribution='shard' is not yet supported; see issue #301. "
+            "Use 'auto' or 'replicate'."
+        )
+    resolved_distribution = "replicate"
+
+    # Memory budget.
+    if config.memory_budget != "auto":
+        raise NotImplementedError(
+            "[TorchDR] An explicit memory_budget is not yet supported; see issue "
+            "#301. Use memory_budget='auto'."
+        )
+
+    # Resolve the low-level FAISS configuration.
+    if config.expert is not None:
+        # Expert override: copy the given config field-by-field so the user's
+        # object is never mutated by downstream device handling.
+        src = config.expert
+        resolved = FaissConfig(
+            temp_memory=src.temp_memory,
+            device=src.device,
+            index_type=src.index_type,
+            nprobe=src.nprobe,
+            nlist=src.nlist,
+            M=src.M,
+            nbits=src.nbits,
+            stream_batch_size=src.stream_batch_size,
+            **src.faiss_kwargs,
+        )
+    elif config.mode == "exact":
+        resolved = FaissConfig(index_type="Flat")
+    else:
+        raise NotImplementedError(
+            f"[TorchDR] mode={config.mode!r} is not yet supported; see issue #304. "
+            "Only mode='exact' is available today. For approximate search, pass an "
+            "expert FaissConfig, e.g. expert=FaissConfig(index_type='IVFPQ')."
+        )
+
+    index_type = resolved.index_type
+    # A Flat index is untrained; approximate indexes train downstream on a
+    # bounded sample whose size this plan does not fix.
+    training_size = 0 if index_type == "Flat" else None
+    if index_type == "Flat" and n_samples is not None and dim is not None:
+        memory_estimate = int(n_samples) * int(dim) * 4  # float32 storage
+    else:
+        memory_estimate = None
+
+    plan = _FaissPlan(
+        index_type=index_type,
+        precision=_precision_of(index_type),
+        distribution=resolved_distribution,
+        training_size=training_size,
+        batch_size=resolved.stream_batch_size,
+        memory_estimate=memory_estimate,
+        random_state=config.random_state,
+    )
+    return plan, resolved

--- a/torchdr/distance/faiss_plan.py
+++ b/torchdr/distance/faiss_plan.py
@@ -1,4 +1,4 @@
-"""Execution-plan API for FAISS-backed distance computation."""
+"""High-level execution plans for FAISS-backed distance computation."""
 
 # Author: Hugues Van Assel <vanasselhugues@gmail.com>
 #
@@ -13,263 +13,147 @@ _VALID_MODES = ("exact", "balanced", "fast")
 _VALID_DISTRIBUTIONS = ("auto", "replicate", "shard")
 
 
+@dataclass(frozen=True)
 class FaissPlanConfig:
-    """High-level FAISS execution intent.
+    """Describe high-level intent for a FAISS execution.
 
-    Exposes accuracy and resource *intent* instead of the many low-level FAISS
-    knobs. Exact search is the default; approximation and reduced precision are
-    explicit opt-ins. Automatic values are resolved into an immutable execution
-    plan (see :func:`resolve_faiss_plan`) that can be inspected after fitting
-    through an estimator's or affinity's ``faiss_plan_`` attribute. This object
-    is never mutated during resolution.
-
-    Pass it wherever a ``backend`` is accepted, e.g.
-    ``TSNE(backend=FaissPlanConfig(mode="exact"))``.
+    This is the small, user-facing alternative to :class:`FaissConfig`. The
+    default always resolves to exact, full-precision Flat search. Approximate
+    presets and sharded indexes are represented now so their eventual behavior
+    has a stable home, but fail explicitly until their benchmarked
+    implementations land.
 
     Parameters
     ----------
     mode : {"exact", "balanced", "fast"}, default="exact"
-        Accuracy/speed intent. ``"exact"`` uses a full-precision brute-force
-        (Flat) index and never silently approximates. ``"balanced"`` and
-        ``"fast"`` are explicit approximate opt-ins whose thresholds are not yet
-        benchmarked (see issue #304); they raise :class:`NotImplementedError` at
-        resolution time. For approximate search today, pass an ``expert``
-        :class:`~torchdr.distance.FaissConfig`.
+        Accuracy/speed intent. Only ``"exact"`` is currently implemented;
+        ``"balanced"`` and ``"fast"`` raise :class:`NotImplementedError`.
     distribution : {"auto", "replicate", "shard"}, default="auto"
-        Multi-GPU execution topology. ``"auto"`` and ``"replicate"`` build a
-        complete index on every rank (the current behavior) and do not change
-        the global k-NN result. ``"shard"`` is not yet supported (see issue
-        #301) and raises at resolution time.
-    memory_budget : "auto" or int, default="auto"
-        Target memory budget in bytes. Only ``"auto"`` is honored today; an
-        explicit budget is not yet supported (see issue #301).
-    random_state : int, optional
-        Seed for deterministic sampling/training, reusing the estimator seed.
-        The resolved plan records it.
+        Multi-GPU topology. ``"auto"`` currently resolves to the existing
+        replicated-index strategy in distributed runs. ``"shard"`` is not yet
+        implemented and raises :class:`NotImplementedError`.
     expert : FaissConfig, optional
-        Expert override exposing supported low-level FAISS options. When set,
-        ``mode`` must be left at its default ``"exact"`` and the given
-        configuration is used verbatim as the resolved backend. Device ownership
-        still comes from the distributed context.
+        Explicit low-level override for advanced users. It cannot be combined
+        with a non-default mode. The object is copied during resolution.
 
     Examples
     --------
     >>> from torchdr.distance import FaissConfig, FaissPlanConfig
-
-    >>> # Normal user: exact, full-precision k-NN (the default).
-    >>> plan = FaissPlanConfig()
-
-    >>> # Preset intent (approximate presets are not yet available; see #304).
-    >>> plan = FaissPlanConfig(mode="exact", distribution="auto")
-
-    >>> # Expert: full control over the low-level FAISS index.
-    >>> plan = FaissPlanConfig(expert=FaissConfig(index_type="IVFPQ", nlist=1024))
+    >>> exact = FaissPlanConfig()
+    >>> replicated = FaissPlanConfig(distribution="replicate")
+    >>> expert = FaissPlanConfig(expert=FaissConfig(index_type="IVF", nprobe=8))
     """
 
-    def __init__(
-        self,
-        mode: str = "exact",
-        distribution: str = "auto",
-        memory_budget: Union[str, int] = "auto",
-        random_state: Optional[int] = None,
-        expert: Optional[FaissConfig] = None,
-    ):
-        if mode not in _VALID_MODES:
+    mode: str = "exact"
+    distribution: str = "auto"
+    expert: Optional[FaissConfig] = None
+
+    def __post_init__(self):
+        if self.mode not in _VALID_MODES:
             raise ValueError(
-                f"[TorchDR] Unknown mode {mode!r}; expected one of {_VALID_MODES}."
+                f"[TorchDR] Unknown mode {self.mode!r}; expected one of {_VALID_MODES}."
             )
-        if distribution not in _VALID_DISTRIBUTIONS:
+        if self.distribution not in _VALID_DISTRIBUTIONS:
             raise ValueError(
-                f"[TorchDR] Unknown distribution {distribution!r}; "
+                f"[TorchDR] Unknown distribution {self.distribution!r}; "
                 f"expected one of {_VALID_DISTRIBUTIONS}."
             )
-        if not (
-            memory_budget == "auto"
-            or (
-                isinstance(memory_budget, int)
-                and not isinstance(memory_budget, bool)
-                and memory_budget > 0
-            )
-        ):
-            raise ValueError(
-                "[TorchDR] memory_budget must be 'auto' or a positive integer "
-                f"number of bytes; got {memory_budget!r}."
-            )
-        if expert is not None and not isinstance(expert, FaissConfig):
+        if self.expert is not None and not isinstance(self.expert, FaissConfig):
             raise TypeError(
                 "[TorchDR] expert must be a FaissConfig or None; "
-                f"got {type(expert).__name__}."
+                f"got {type(self.expert).__name__}."
             )
-        if expert is not None and mode != "exact":
+        if self.expert is not None and self.mode != "exact":
             raise ValueError(
                 "[TorchDR] Cannot combine an expert override with a non-default "
-                "mode; pass either mode= (a preset) or expert= (a low-level "
-                "FaissConfig), not both."
+                "mode. Pass either mode= or expert=."
             )
-        self.mode = mode
-        self.distribution = distribution
-        self.memory_budget = memory_budget
-        self.random_state = random_state
-        self.expert = expert
-
-    def __repr__(self):
-        parts = [f"mode={self.mode!r}", f"distribution={self.distribution!r}"]
-        if self.memory_budget != "auto":
-            parts.append(f"memory_budget={self.memory_budget!r}")
-        if self.random_state is not None:
-            parts.append(f"random_state={self.random_state!r}")
-        if self.expert is not None:
-            parts.append(f"expert={self.expert!r}")
-        return f"FaissPlanConfig({', '.join(parts)})"
 
 
 @dataclass(frozen=True, repr=False)
 class _FaissPlan:
-    """Immutable resolved FAISS execution plan.
+    """Resolved, immutable diagnostics exposed as ``faiss_plan_``.
 
-    Recorded by an estimator/affinity as ``faiss_plan_`` and printed on rank 0
-    when ``verbose=True``. Purely diagnostic: the low-level configuration that
-    actually runs is returned separately by :func:`resolve_faiss_plan`.
-
-    Attributes
-    ----------
-    index_type : str
-        Resolved FAISS index, e.g. ``"Flat"``.
-    precision : {"float32", "reduced"}
-        ``"reduced"`` for product-quantized indexes, ``"float32"`` otherwise.
-    distribution : {"replicate"}
-        Resolved multi-GPU topology.
-    training_size : int or None
-        Number of rows used to train the index (``0`` for an untrained Flat
-        index, ``None`` when resolved downstream for approximate indexes).
-    batch_size : "auto" or int
-        Rows handed to FAISS per add/search call.
-    memory_estimate : int or None
-        Estimated index memory in bytes, or ``None`` when it cannot be
-        estimated upfront.
-    random_state : int or None
-        Seed recorded for deterministic sampling/training.
+    ``index_memory_bytes`` estimates only FAISS's stored database vectors on
+    each rank. It deliberately excludes inputs, outputs, and temporary scratch
+    rather than presenting a partial estimate as total peak memory.
     """
 
+    mode: str
     index_type: str
     precision: str
     distribution: str
     training_size: Optional[int]
-    batch_size: Union[str, int]
-    memory_estimate: Optional[int]
-    random_state: Optional[int]
+    stream_batch_size: Union[str, int]
+    index_memory_bytes: Optional[int]
 
     def __repr__(self):
-        mem = (
-            "unknown"
-            if self.memory_estimate is None
-            else f"{self.memory_estimate} bytes"
-        )
-        train = "unknown" if self.training_size is None else self.training_size
         return (
-            "FaissPlan("
-            f"index_type={self.index_type!r}, precision={self.precision!r}, "
-            f"distribution={self.distribution!r}, training_size={train}, "
-            f"batch_size={self.batch_size!r}, memory_estimate={mem}, "
-            f"random_state={self.random_state!r})"
+            f"FaissPlan(mode={self.mode!r}, index_type={self.index_type!r}, "
+            f"precision={self.precision!r}, distribution={self.distribution!r}, "
+            f"training_size={self.training_size!r}, "
+            f"stream_batch_size={self.stream_batch_size!r}, "
+            f"index_memory_bytes={self.index_memory_bytes!r})"
         )
 
 
-def _precision_of(index_type: str) -> str:
-    """Precision label: product quantization compresses, everything else is full."""
-    return "reduced" if "PQ" in index_type else "float32"
+def _copy_config(config: FaissConfig) -> FaissConfig:
+    """Copy a low-level config without retaining its mutable kwargs mapping."""
+    return FaissConfig(
+        temp_memory=config.temp_memory,
+        device=config.device,
+        index_type=config.index_type,
+        nprobe=config.nprobe,
+        nlist=config.nlist,
+        M=config.M,
+        nbits=config.nbits,
+        stream_batch_size=config.stream_batch_size,
+        **config.faiss_kwargs,
+    )
 
 
-def resolve_faiss_plan(
+def _resolve_faiss_plan(
     config: FaissPlanConfig,
     *,
     n_samples: Optional[int] = None,
-    dim: Optional[int] = None,
-    dist_ctx=None,
-    device=None,
+    n_features: Optional[int] = None,
+    distributed_ctx=None,
 ) -> Tuple[_FaissPlan, FaissConfig]:
-    """Resolve a :class:`FaissPlanConfig` into a plan and a low-level FaissConfig.
-
-    Pure and non-mutating: returns a new immutable :class:`_FaissPlan` and a new
-    :class:`~torchdr.distance.FaissConfig`; the input ``config`` (and any
-    ``expert`` it carries) are left untouched. Raises
-    :class:`NotImplementedError` for intent that cannot yet be honored honestly.
-
-    Parameters
-    ----------
-    config : FaissPlanConfig
-        High-level execution intent.
-    n_samples, dim : int, optional
-        Dataset shape, used only to estimate index memory when available.
-    dist_ctx : DistributedContext, optional
-        Present for interface symmetry; device ownership in distributed mode is
-        applied later via ``DistributedContext.get_faiss_config``.
-    device : optional
-        Present for interface symmetry; unused for the exact plan.
-
-    Returns
-    -------
-    plan : _FaissPlan
-        Immutable diagnostic plan (assign to ``faiss_plan_``).
-    resolved : FaissConfig
-        Low-level configuration to hand to ``pairwise_distances``.
-    """
-    # Distribution intent (independent of mode/expert).
+    """Resolve user intent into diagnostics and a fresh low-level config."""
     if config.distribution == "shard":
         raise NotImplementedError(
-            "[TorchDR] distribution='shard' is not yet supported; see issue #301. "
-            "Use 'auto' or 'replicate'."
-        )
-    resolved_distribution = "replicate"
-
-    # Memory budget.
-    if config.memory_budget != "auto":
-        raise NotImplementedError(
-            "[TorchDR] An explicit memory_budget is not yet supported; see issue "
-            "#301. Use memory_budget='auto'."
+            "[TorchDR] distribution='shard' is not yet supported; see issue #301."
         )
 
-    # Resolve the low-level FAISS configuration.
     if config.expert is not None:
-        # Expert override: copy the given config field-by-field so the user's
-        # object is never mutated by downstream device handling.
-        src = config.expert
-        resolved = FaissConfig(
-            temp_memory=src.temp_memory,
-            device=src.device,
-            index_type=src.index_type,
-            nprobe=src.nprobe,
-            nlist=src.nlist,
-            M=src.M,
-            nbits=src.nbits,
-            stream_batch_size=src.stream_batch_size,
-            **src.faiss_kwargs,
-        )
+        resolved = _copy_config(config.expert)
+        mode = "expert"
     elif config.mode == "exact":
         resolved = FaissConfig(index_type="Flat")
+        mode = "exact"
     else:
         raise NotImplementedError(
-            f"[TorchDR] mode={config.mode!r} is not yet supported; see issue #304. "
-            "Only mode='exact' is available today. For approximate search, pass an "
-            "expert FaissConfig, e.g. expert=FaissConfig(index_type='IVFPQ')."
+            f"[TorchDR] mode={config.mode!r} is not yet supported; see issue #304."
         )
 
-    index_type = resolved.index_type
-    # A Flat index is untrained; approximate indexes train downstream on a
-    # bounded sample whose size this plan does not fix.
-    training_size = 0 if index_type == "Flat" else None
-    if index_type == "Flat" and n_samples is not None and dim is not None:
-        memory_estimate = int(n_samples) * int(dim) * 4  # float32 storage
-    else:
-        memory_estimate = None
-
-    plan = _FaissPlan(
-        index_type=index_type,
-        precision=_precision_of(index_type),
-        distribution=resolved_distribution,
-        training_size=training_size,
-        batch_size=resolved.stream_batch_size,
-        memory_estimate=memory_estimate,
-        random_state=config.random_state,
+    is_distributed = bool(
+        distributed_ctx is not None and distributed_ctx.is_initialized
     )
-    return plan, resolved
+    distribution = "replicate" if is_distributed else "single"
+    training_size = 0 if resolved.index_type == "Flat" else None
+    index_memory_bytes = None
+    if training_size == 0 and n_samples is not None and n_features is not None:
+        index_memory_bytes = int(n_samples) * int(n_features) * 4
+
+    return (
+        _FaissPlan(
+            mode=mode,
+            index_type=resolved.index_type,
+            precision="reduced" if resolved.index_type == "IVFPQ" else "float32",
+            distribution=distribution,
+            training_size=training_size,
+            stream_batch_size=resolved.stream_batch_size,
+            index_memory_bytes=index_memory_bytes,
+        ),
+        resolved,
+    )

--- a/torchdr/neighbor_embedding/base.py
+++ b/torchdr/neighbor_embedding/base.py
@@ -14,7 +14,7 @@ from torch.utils.data import DataLoader
 
 from torchdr.affinity import Affinity
 from torchdr.affinity.entropic import _log_Pe
-from torchdr.distance import FaissConfig, pairwise_distances
+from torchdr.distance import FaissConfig, FaissPlanConfig, pairwise_distances
 from torchdr.affinity_matcher import AffinityMatcher
 from torchdr.utils import (
     binary_search,
@@ -105,13 +105,15 @@ class NeighborEmbedding(AffinityMatcher):
         Scaling factor for the initial embedding. Default is 1e-4.
     device : str, optional
         Device to use for computations. Default is "auto".
-    backend : {"keops", "faiss", None} or FaissConfig, optional
+    backend : {"keops", "faiss", None}, FaissConfig, or FaissPlanConfig, optional
         Which backend to use for handling sparsity and memory efficiency.
         Can be:
         - "keops": Use KeOps for memory-efficient symbolic computations
         - "faiss": Use FAISS for fast k-NN computations with default settings
         - None: Use standard PyTorch operations
-        - FaissConfig object: Use FAISS with custom configuration
+        - FaissConfig object: Use FAISS with a low-level expert configuration
+        - FaissPlanConfig object: Use FAISS from a high-level execution intent
+          (e.g. ``mode="exact"``); the resolved plan is exposed as ``faiss_plan_``
         Default is None.
     verbose : bool, optional
         Verbosity of the optimization process. Default is False.
@@ -154,7 +156,7 @@ class NeighborEmbedding(AffinityMatcher):
         init: Union[str, torch.Tensor, np.ndarray] = "pca",
         init_scaling: float = 1e-4,
         device: str = "auto",
-        backend: Union[str, FaissConfig, None] = None,
+        backend: Union[str, FaissConfig, FaissPlanConfig, None] = None,
         verbose: bool = False,
         random_state: Optional[float] = None,
         early_exaggeration_coeff: Optional[float] = None,
@@ -516,13 +518,15 @@ class NegativeSamplingNeighborEmbedding(NeighborEmbedding):
         Scaling factor for the initial embedding. Default is 1e-4.
     device : str, optional
         Device to use for computations. Default is "auto".
-    backend : {"keops", "faiss", None} or FaissConfig, optional
+    backend : {"keops", "faiss", None}, FaissConfig, or FaissPlanConfig, optional
         Which backend to use for handling sparsity and memory efficiency.
         Can be:
         - "keops": Use KeOps for memory-efficient symbolic computations
         - "faiss": Use FAISS for fast k-NN computations with default settings
         - None: Use standard PyTorch operations
-        - FaissConfig object: Use FAISS with custom configuration
+        - FaissConfig object: Use FAISS with a low-level expert configuration
+        - FaissPlanConfig object: Use FAISS from a high-level execution intent
+          (e.g. ``mode="exact"``); the resolved plan is exposed as ``faiss_plan_``
         Default is None.
     verbose : bool, optional
         Verbosity of the optimization process. Default is False.
@@ -569,7 +573,7 @@ class NegativeSamplingNeighborEmbedding(NeighborEmbedding):
         init: str = "pca",
         init_scaling: float = 1e-4,
         device: str = "auto",
-        backend: Union[str, FaissConfig, None] = None,
+        backend: Union[str, FaissConfig, FaissPlanConfig, None] = None,
         verbose: bool = False,
         random_state: Optional[float] = None,
         early_exaggeration_coeff: float = 1.0,

--- a/torchdr/tests/test_distributed_faiss_training.py
+++ b/torchdr/tests/test_distributed_faiss_training.py
@@ -21,6 +21,7 @@ from torchdr.distance.faiss import (
     _create_index,
     _train_index,
 )
+from torchdr.distance.faiss_plan import _resolve_faiss_plan
 from torchdr.distributed import DistributedContext
 from torchdr.utils import faiss
 
@@ -146,6 +147,8 @@ class TestSharedTraining:
 
         start, end = context.compute_chunk_bounds(N_SAMPLES)
         assert torch.equal(chunk, exact[start:end])
+        plan, _ = _resolve_faiss_plan(FaissPlanConfig(), distributed_ctx=context)
+        assert plan.distribution == "replicate"
 
     # Probing every list makes IVF exact, so only ties keep it below one. IVFPQ
     # answers from its codes, and the loose bound is there to catch an index

--- a/torchdr/tests/test_distributed_faiss_training.py
+++ b/torchdr/tests/test_distributed_faiss_training.py
@@ -15,7 +15,7 @@ import torch
 import torch.distributed as dist
 from torch.utils.data import DataLoader, TensorDataset
 
-from torchdr.distance import FaissConfig, pairwise_distances
+from torchdr.distance import FaissConfig, FaissPlanConfig, pairwise_distances
 from torchdr.distance.faiss import (
     _build_index_from_dataloader,
     _create_index,
@@ -122,6 +122,24 @@ class TestSharedTraining:
             data,
             k=5,
             backend=FaissConfig(),
+            return_indices=True,
+            distributed_ctx=context,
+        )
+
+        start, end = context.compute_chunk_bounds(N_SAMPLES)
+        assert torch.equal(chunk, exact[start:end])
+
+    def test_an_exact_plan_resolves_to_flat_per_chunk(self, data, context):
+        # The high-level FaissPlanConfig(mode="exact") must resolve to the same
+        # Flat backend inside the distributed path, so every rank still answers
+        # its own chunk exactly, identical to passing a plain FaissConfig().
+        _, exact = pairwise_distances(
+            data, k=5, backend=FaissConfig(), return_indices=True
+        )
+        _, chunk = pairwise_distances(
+            data,
+            k=5,
+            backend=FaissPlanConfig(mode="exact"),
             return_indices=True,
             distributed_ctx=context,
         )

--- a/torchdr/tests/test_distributed_neighbor_embedding_gpu.py
+++ b/torchdr/tests/test_distributed_neighbor_embedding_gpu.py
@@ -31,6 +31,7 @@ import torch.distributed as dist
 
 from torchdr import InfoTSNE, UMAP
 from torchdr.affinity import UMAPAffinity
+from torchdr.distance import FaissPlanConfig
 from torchdr.distributed import init_distributed, shutdown_distributed
 
 
@@ -106,14 +107,18 @@ def test_distributed_umap_affinity_matches_single_process(dtype):
     n_samples, n_features = 128, 16
     X = _identical_data(n_samples, n_features, dtype)
 
-    distributed = UMAPAffinity(n_neighbors=15, distributed=True, backend="faiss")
+    distributed = UMAPAffinity(
+        n_neighbors=15, distributed=True, backend=FaissPlanConfig()
+    )
     local_values, local_indices = distributed(X.cuda())
+    assert distributed.faiss_plan_.distribution == "replicate"
     local_dense = _rowwise_to_dense(local_values.cpu(), local_indices.cpu(), n_samples)
     assert local_dense.shape[0] == distributed.chunk_size_
     full = _gather_full_matrix(local_dense)
 
-    single = UMAPAffinity(n_neighbors=15, distributed=False, backend="faiss")
+    single = UMAPAffinity(n_neighbors=15, distributed=False, backend=FaissPlanConfig())
     ref_values, ref_indices = single(X.cuda())
+    assert single.faiss_plan_.distribution == "single"
     reference = _rowwise_to_dense(ref_values.cpu(), ref_indices.cpu(), n_samples)
 
     assert full.shape == (n_samples, n_samples)

--- a/torchdr/tests/test_faiss_plan.py
+++ b/torchdr/tests/test_faiss_plan.py
@@ -1,4 +1,4 @@
-"""Tests for the high-level FAISS execution-plan API (FaissPlanConfig)."""
+"""Tests for the high-level FAISS execution-plan API."""
 
 # Author: Hugues Van Assel <vanasselhugues@gmail.com>
 #
@@ -9,236 +9,132 @@ from dataclasses import FrozenInstanceError
 
 import pytest
 import torch
+from torch.utils.data import DataLoader, TensorDataset
 
-from torchdr import EntropicAffinity
+from torchdr import EntropicAffinity, TSNE
 from torchdr.distance import FaissConfig, FaissPlanConfig, pairwise_distances
-from torchdr.distance.faiss_plan import _FaissPlan, resolve_faiss_plan
+from torchdr.distance.faiss_plan import _resolve_faiss_plan
 from torchdr.utils import faiss
 
 
-pytestmark = pytest.mark.skipif(
+requires_faiss = pytest.mark.skipif(
     faiss is None or faiss is False, reason="faiss not installed"
 )
-
-N_SAMPLES = 200
-N_FEATURES = 8
 
 
 @pytest.fixture(scope="module")
 def data():
-    generator = torch.Generator().manual_seed(0)
-    return torch.randn(N_SAMPLES, N_FEATURES, generator=generator)
+    return torch.randn(200, 8, generator=torch.Generator().manual_seed(0))
 
 
-class TestFaissPlanConfigValidation:
-    """Construction-time validation of the public intent config."""
-
-    def test_defaults(self):
-        cfg = FaissPlanConfig()
-        assert cfg.mode == "exact"
-        assert cfg.distribution == "auto"
-        assert cfg.memory_budget == "auto"
-        assert cfg.random_state is None
-        assert cfg.expert is None
-
-    def test_repr_is_readable(self):
-        text = repr(FaissPlanConfig(random_state=3, expert=FaissConfig()))
-        assert text.startswith("FaissPlanConfig(")
-        assert "random_state=3" in text
-
-    @pytest.mark.parametrize("mode", ["turbo", "Exact", "", None])
-    def test_invalid_mode_raises(self, mode):
-        with pytest.raises(ValueError, match="mode"):
-            FaissPlanConfig(mode=mode)
-
-    @pytest.mark.parametrize("distribution", ["sharded", "single", None])
-    def test_invalid_distribution_raises(self, distribution):
-        with pytest.raises(ValueError, match="distribution"):
-            FaissPlanConfig(distribution=distribution)
-
-    @pytest.mark.parametrize("budget", ["huge", -1, 0, 1.5, True])
-    def test_invalid_memory_budget_raises(self, budget):
-        with pytest.raises(ValueError, match="memory_budget"):
-            FaissPlanConfig(memory_budget=budget)
-
-    def test_valid_explicit_memory_budget_constructs(self):
-        # A positive integer budget is a valid *field* (resolution raises later).
-        cfg = FaissPlanConfig(memory_budget=2**30)
-        assert cfg.memory_budget == 2**30
-
-    def test_expert_must_be_faissconfig(self):
-        with pytest.raises(TypeError, match="expert"):
-            FaissPlanConfig(expert="not-a-config")
-
-    def test_expert_with_nondefault_mode_raises(self):
-        with pytest.raises(ValueError, match="expert override"):
-            FaissPlanConfig(mode="fast", expert=FaissConfig())
+def test_config_defaults_are_exact_and_immutable():
+    config = FaissPlanConfig()
+    assert (config.mode, config.distribution, config.expert) == (
+        "exact",
+        "auto",
+        None,
+    )
+    with pytest.raises(FrozenInstanceError):
+        config.mode = "fast"
+    assert pickle.loads(pickle.dumps(config)) == config
 
 
-class TestResolveFaissPlan:
-    """Resolution of intent into an immutable plan + low-level FaissConfig."""
-
-    def test_exact_resolves_to_flat_full_precision(self):
-        plan, resolved = resolve_faiss_plan(FaissPlanConfig(mode="exact"))
-        assert isinstance(plan, _FaissPlan)
-        assert plan.index_type == "Flat"
-        assert plan.precision == "float32"
-        assert plan.distribution == "replicate"
-        assert plan.training_size == 0
-        assert isinstance(resolved, FaissConfig)
-        assert resolved.index_type == "Flat"
-
-    def test_auto_distribution_resolves_to_replicate(self):
-        plan, _ = resolve_faiss_plan(FaissPlanConfig(distribution="auto"))
-        assert plan.distribution == "replicate"
-        plan2, _ = resolve_faiss_plan(FaissPlanConfig(distribution="replicate"))
-        assert plan2.distribution == "replicate"
-
-    def test_memory_estimate_when_shape_known(self):
-        plan, _ = resolve_faiss_plan(FaissPlanConfig(), n_samples=1000, dim=N_FEATURES)
-        assert plan.memory_estimate == 1000 * N_FEATURES * 4
-
-    def test_memory_estimate_unknown_without_shape(self):
-        plan, _ = resolve_faiss_plan(FaissPlanConfig())
-        assert plan.memory_estimate is None
-
-    def test_random_state_recorded(self):
-        plan, _ = resolve_faiss_plan(FaissPlanConfig(random_state=7))
-        assert plan.random_state == 7
-
-    def test_expert_override_used_verbatim(self):
-        expert = FaissConfig(index_type="IVFPQ", nlist=50, M=8, nbits=8, nprobe=4)
-        plan, resolved = resolve_faiss_plan(FaissPlanConfig(expert=expert))
-        assert resolved.index_type == "IVFPQ"
-        assert resolved.nlist == 50
-        assert resolved.M == 8
-        assert resolved.nprobe == 4
-        assert plan.index_type == "IVFPQ"
-        assert plan.precision == "reduced"  # PQ compresses
-        assert plan.training_size is None  # resolved downstream
-
-    def test_expert_ivf_is_full_precision(self):
-        plan, _ = resolve_faiss_plan(
-            FaissPlanConfig(expert=FaissConfig(index_type="IVF"))
-        )
-        assert plan.precision == "float32"
-
-    @pytest.mark.parametrize("mode", ["balanced", "fast"])
-    def test_presets_not_yet_supported(self, mode):
-        with pytest.raises(NotImplementedError, match="#304"):
-            resolve_faiss_plan(FaissPlanConfig(mode=mode))
-
-    def test_shard_not_yet_supported(self):
-        with pytest.raises(NotImplementedError, match="#301"):
-            resolve_faiss_plan(FaissPlanConfig(distribution="shard"))
-
-    def test_explicit_memory_budget_not_yet_supported(self):
-        with pytest.raises(NotImplementedError, match="#301"):
-            resolve_faiss_plan(FaissPlanConfig(memory_budget=2**30))
-
-    def test_exact_never_approximates(self):
-        # No combination of the supported knobs may resolve to an approximate
-        # index unless the user explicitly supplied an approximate expert config.
-        for cfg in (
-            FaissPlanConfig(),
-            FaissPlanConfig(distribution="replicate"),
-            FaissPlanConfig(random_state=1),
-        ):
-            _, resolved = resolve_faiss_plan(cfg)
-            assert resolved.index_type == "Flat"
-
-    def test_non_mutation_of_user_config(self):
-        expert = FaissConfig(index_type="IVFPQ", nlist=42, M=8)
-        cfg = FaissPlanConfig(random_state=1, expert=expert)
-        before_cfg, before_expert = repr(cfg), repr(expert)
-
-        _, resolved = resolve_faiss_plan(cfg, n_samples=100, dim=N_FEATURES)
-
-        assert repr(cfg) == before_cfg
-        assert repr(expert) == before_expert
-        # The resolved config is a fresh object, not the user's expert instance.
-        assert resolved is not expert
+@pytest.mark.parametrize(
+    ("kwargs", "error"),
+    [
+        ({"mode": "turbo"}, ValueError),
+        ({"distribution": "single"}, ValueError),
+        ({"expert": "not-a-config"}, TypeError),
+        (
+            {"mode": "fast", "expert": FaissConfig(index_type="IVF")},
+            ValueError,
+        ),
+    ],
+)
+def test_config_rejects_invalid_combinations(kwargs, error):
+    with pytest.raises(error):
+        FaissPlanConfig(**kwargs)
 
 
-class TestFaissPlanImmutabilityAndSerialization:
-    """The resolved plan is frozen, reproducibly represented, and picklable."""
-
-    def test_plan_is_frozen(self):
-        plan, _ = resolve_faiss_plan(FaissPlanConfig())
-        with pytest.raises(FrozenInstanceError):
-            plan.index_type = "IVF"
-
-    def test_plan_repr(self):
-        plan, _ = resolve_faiss_plan(FaissPlanConfig(), n_samples=10, dim=4)
-        text = repr(plan)
-        assert text.startswith("FaissPlan(")
-        assert "index_type='Flat'" in text
-        assert "memory_estimate=160 bytes" in text
-
-    def test_plan_repr_unknown_fields(self):
-        plan, _ = resolve_faiss_plan(FaissPlanConfig())
-        text = repr(plan)
-        assert "memory_estimate=unknown" in text
-
-    def test_plan_is_picklable(self):
-        plan, _ = resolve_faiss_plan(FaissPlanConfig(), n_samples=10, dim=4)
-        restored = pickle.loads(pickle.dumps(plan))
-        assert restored == plan
-        assert repr(restored) == repr(plan)
+@pytest.mark.parametrize(
+    "config",
+    [
+        FaissPlanConfig(mode="balanced"),
+        FaissPlanConfig(mode="fast"),
+        FaissPlanConfig(distribution="shard"),
+    ],
+)
+def test_unimplemented_intents_fail_explicitly(config):
+    with pytest.raises(NotImplementedError):
+        _resolve_faiss_plan(config)
 
 
-class TestFaissPlanIntegration:
-    """End-to-end behavior through pairwise_distances and an affinity (CPU)."""
+def test_exact_plan_reports_resolved_execution():
+    plan, resolved = _resolve_faiss_plan(
+        FaissPlanConfig(), n_samples=1_000, n_features=8
+    )
+    assert plan.mode == "exact"
+    assert plan.index_type == resolved.index_type == "Flat"
+    assert plan.precision == "float32"
+    assert plan.distribution == "single"
+    assert plan.training_size == 0
+    assert plan.index_memory_bytes == 1_000 * 8 * 4
 
-    def test_pairwise_distances_accepts_plan_config(self, data):
-        # Direct-call guard: a plan config resolves to the exact Flat backend and
-        # returns the same neighbors as backend="faiss" (CPU-only fallback).
-        d_ref, i_ref = pairwise_distances(
-            data, k=5, backend="faiss", return_indices=True
-        )
-        d_plan, i_plan = pairwise_distances(
-            data, k=5, backend=FaissPlanConfig(mode="exact"), return_indices=True
-        )
-        assert torch.equal(i_ref, i_plan)
-        assert torch.allclose(d_ref, d_plan)
+    restored = pickle.loads(pickle.dumps(plan))
+    assert restored == plan
+    assert "index_memory_bytes=32000" in repr(restored)
 
-    def test_pairwise_distances_reproducible(self, data):
-        _, i_a = pairwise_distances(
-            data, k=5, backend=FaissPlanConfig(mode="exact"), return_indices=True
-        )
-        _, i_b = pairwise_distances(
-            data, k=5, backend=FaissPlanConfig(mode="exact"), return_indices=True
-        )
-        assert torch.equal(i_a, i_b)
 
-    def test_affinity_records_plan_and_matches_faiss(self, data):
-        aff_plan = EntropicAffinity(
-            perplexity=15,
-            backend=FaissPlanConfig(mode="exact"),
-            sparsity=True,
-            verbose=False,
-        )
-        _, idx_plan = aff_plan(data)
+def test_expert_resolution_is_non_mutating():
+    expert = FaissConfig(
+        index_type="IVFPQ", nlist=50, M=8, nbits=8, nprobe=4, custom_option=1
+    )
+    config = FaissPlanConfig(expert=expert)
+    before = repr(expert)
 
-        # The resolved plan is exposed for inspection after computation.
-        assert hasattr(aff_plan, "faiss_plan_")
-        assert aff_plan.faiss_plan_.index_type == "Flat"
-        assert aff_plan.faiss_plan_.precision == "float32"
+    plan, resolved = _resolve_faiss_plan(config)
 
-        aff_faiss = EntropicAffinity(
-            perplexity=15,
-            backend="faiss",
-            sparsity=True,
-            verbose=False,
-        )
-        _, idx_faiss = aff_faiss(data)
+    assert repr(expert) == before
+    assert resolved is not expert
+    assert resolved.faiss_kwargs is not expert.faiss_kwargs
+    assert resolved.faiss_kwargs == expert.faiss_kwargs
+    assert plan.mode == "expert"
+    assert plan.index_type == "IVFPQ"
+    assert plan.precision == "reduced"
+    assert plan.training_size is None
 
-        # Exact plan == plain FAISS Flat: identical k-NN structure.
-        assert torch.equal(idx_plan, idx_faiss)
 
-    def test_affinity_without_plan_has_no_attr(self, data):
-        aff = EntropicAffinity(
-            perplexity=15, backend="faiss", sparsity=True, verbose=False
-        )
-        aff(data)
-        assert not hasattr(aff, "faiss_plan_")
+@requires_faiss
+def test_exact_plan_matches_existing_faiss_backend(data):
+    distances, indices = pairwise_distances(
+        data, k=5, backend=FaissPlanConfig(), return_indices=True
+    )
+    reference_distances, reference_indices = pairwise_distances(
+        data, k=5, backend="faiss", return_indices=True
+    )
+    assert torch.equal(indices, reference_indices)
+    assert torch.allclose(distances, reference_distances)
+
+
+@requires_faiss
+def test_plan_accepts_dataloader_input(data):
+    loader = DataLoader(TensorDataset(data), batch_size=32, shuffle=False)
+    distances, indices = pairwise_distances(
+        loader, k=5, backend=FaissPlanConfig(), return_indices=True
+    )
+    assert distances.shape == indices.shape == (len(data), 5)
+
+
+@requires_faiss
+def test_plan_is_exposed_by_affinity_and_estimator(data):
+    affinity = EntropicAffinity(perplexity=15, backend=FaissPlanConfig(), sparsity=True)
+    affinity(data)
+    assert affinity.faiss_plan_.index_type == "Flat"
+
+    estimator = TSNE(
+        perplexity=15,
+        backend=FaissPlanConfig(),
+        max_iter=0,
+        random_state=0,
+    ).fit(data)
+    assert estimator.faiss_plan_ == estimator.affinity_in.faiss_plan_

--- a/torchdr/tests/test_faiss_plan.py
+++ b/torchdr/tests/test_faiss_plan.py
@@ -1,0 +1,244 @@
+"""Tests for the high-level FAISS execution-plan API (FaissPlanConfig)."""
+
+# Author: Hugues Van Assel <vanasselhugues@gmail.com>
+#
+# License: BSD 3-Clause License
+
+import pickle
+from dataclasses import FrozenInstanceError
+
+import pytest
+import torch
+
+from torchdr import EntropicAffinity
+from torchdr.distance import FaissConfig, FaissPlanConfig, pairwise_distances
+from torchdr.distance.faiss_plan import _FaissPlan, resolve_faiss_plan
+from torchdr.utils import faiss
+
+
+pytestmark = pytest.mark.skipif(
+    faiss is None or faiss is False, reason="faiss not installed"
+)
+
+N_SAMPLES = 200
+N_FEATURES = 8
+
+
+@pytest.fixture(scope="module")
+def data():
+    generator = torch.Generator().manual_seed(0)
+    return torch.randn(N_SAMPLES, N_FEATURES, generator=generator)
+
+
+class TestFaissPlanConfigValidation:
+    """Construction-time validation of the public intent config."""
+
+    def test_defaults(self):
+        cfg = FaissPlanConfig()
+        assert cfg.mode == "exact"
+        assert cfg.distribution == "auto"
+        assert cfg.memory_budget == "auto"
+        assert cfg.random_state is None
+        assert cfg.expert is None
+
+    def test_repr_is_readable(self):
+        text = repr(FaissPlanConfig(random_state=3, expert=FaissConfig()))
+        assert text.startswith("FaissPlanConfig(")
+        assert "random_state=3" in text
+
+    @pytest.mark.parametrize("mode", ["turbo", "Exact", "", None])
+    def test_invalid_mode_raises(self, mode):
+        with pytest.raises(ValueError, match="mode"):
+            FaissPlanConfig(mode=mode)
+
+    @pytest.mark.parametrize("distribution", ["sharded", "single", None])
+    def test_invalid_distribution_raises(self, distribution):
+        with pytest.raises(ValueError, match="distribution"):
+            FaissPlanConfig(distribution=distribution)
+
+    @pytest.mark.parametrize("budget", ["huge", -1, 0, 1.5, True])
+    def test_invalid_memory_budget_raises(self, budget):
+        with pytest.raises(ValueError, match="memory_budget"):
+            FaissPlanConfig(memory_budget=budget)
+
+    def test_valid_explicit_memory_budget_constructs(self):
+        # A positive integer budget is a valid *field* (resolution raises later).
+        cfg = FaissPlanConfig(memory_budget=2**30)
+        assert cfg.memory_budget == 2**30
+
+    def test_expert_must_be_faissconfig(self):
+        with pytest.raises(TypeError, match="expert"):
+            FaissPlanConfig(expert="not-a-config")
+
+    def test_expert_with_nondefault_mode_raises(self):
+        with pytest.raises(ValueError, match="expert override"):
+            FaissPlanConfig(mode="fast", expert=FaissConfig())
+
+
+class TestResolveFaissPlan:
+    """Resolution of intent into an immutable plan + low-level FaissConfig."""
+
+    def test_exact_resolves_to_flat_full_precision(self):
+        plan, resolved = resolve_faiss_plan(FaissPlanConfig(mode="exact"))
+        assert isinstance(plan, _FaissPlan)
+        assert plan.index_type == "Flat"
+        assert plan.precision == "float32"
+        assert plan.distribution == "replicate"
+        assert plan.training_size == 0
+        assert isinstance(resolved, FaissConfig)
+        assert resolved.index_type == "Flat"
+
+    def test_auto_distribution_resolves_to_replicate(self):
+        plan, _ = resolve_faiss_plan(FaissPlanConfig(distribution="auto"))
+        assert plan.distribution == "replicate"
+        plan2, _ = resolve_faiss_plan(FaissPlanConfig(distribution="replicate"))
+        assert plan2.distribution == "replicate"
+
+    def test_memory_estimate_when_shape_known(self):
+        plan, _ = resolve_faiss_plan(FaissPlanConfig(), n_samples=1000, dim=N_FEATURES)
+        assert plan.memory_estimate == 1000 * N_FEATURES * 4
+
+    def test_memory_estimate_unknown_without_shape(self):
+        plan, _ = resolve_faiss_plan(FaissPlanConfig())
+        assert plan.memory_estimate is None
+
+    def test_random_state_recorded(self):
+        plan, _ = resolve_faiss_plan(FaissPlanConfig(random_state=7))
+        assert plan.random_state == 7
+
+    def test_expert_override_used_verbatim(self):
+        expert = FaissConfig(index_type="IVFPQ", nlist=50, M=8, nbits=8, nprobe=4)
+        plan, resolved = resolve_faiss_plan(FaissPlanConfig(expert=expert))
+        assert resolved.index_type == "IVFPQ"
+        assert resolved.nlist == 50
+        assert resolved.M == 8
+        assert resolved.nprobe == 4
+        assert plan.index_type == "IVFPQ"
+        assert plan.precision == "reduced"  # PQ compresses
+        assert plan.training_size is None  # resolved downstream
+
+    def test_expert_ivf_is_full_precision(self):
+        plan, _ = resolve_faiss_plan(
+            FaissPlanConfig(expert=FaissConfig(index_type="IVF"))
+        )
+        assert plan.precision == "float32"
+
+    @pytest.mark.parametrize("mode", ["balanced", "fast"])
+    def test_presets_not_yet_supported(self, mode):
+        with pytest.raises(NotImplementedError, match="#304"):
+            resolve_faiss_plan(FaissPlanConfig(mode=mode))
+
+    def test_shard_not_yet_supported(self):
+        with pytest.raises(NotImplementedError, match="#301"):
+            resolve_faiss_plan(FaissPlanConfig(distribution="shard"))
+
+    def test_explicit_memory_budget_not_yet_supported(self):
+        with pytest.raises(NotImplementedError, match="#301"):
+            resolve_faiss_plan(FaissPlanConfig(memory_budget=2**30))
+
+    def test_exact_never_approximates(self):
+        # No combination of the supported knobs may resolve to an approximate
+        # index unless the user explicitly supplied an approximate expert config.
+        for cfg in (
+            FaissPlanConfig(),
+            FaissPlanConfig(distribution="replicate"),
+            FaissPlanConfig(random_state=1),
+        ):
+            _, resolved = resolve_faiss_plan(cfg)
+            assert resolved.index_type == "Flat"
+
+    def test_non_mutation_of_user_config(self):
+        expert = FaissConfig(index_type="IVFPQ", nlist=42, M=8)
+        cfg = FaissPlanConfig(random_state=1, expert=expert)
+        before_cfg, before_expert = repr(cfg), repr(expert)
+
+        _, resolved = resolve_faiss_plan(cfg, n_samples=100, dim=N_FEATURES)
+
+        assert repr(cfg) == before_cfg
+        assert repr(expert) == before_expert
+        # The resolved config is a fresh object, not the user's expert instance.
+        assert resolved is not expert
+
+
+class TestFaissPlanImmutabilityAndSerialization:
+    """The resolved plan is frozen, reproducibly represented, and picklable."""
+
+    def test_plan_is_frozen(self):
+        plan, _ = resolve_faiss_plan(FaissPlanConfig())
+        with pytest.raises(FrozenInstanceError):
+            plan.index_type = "IVF"
+
+    def test_plan_repr(self):
+        plan, _ = resolve_faiss_plan(FaissPlanConfig(), n_samples=10, dim=4)
+        text = repr(plan)
+        assert text.startswith("FaissPlan(")
+        assert "index_type='Flat'" in text
+        assert "memory_estimate=160 bytes" in text
+
+    def test_plan_repr_unknown_fields(self):
+        plan, _ = resolve_faiss_plan(FaissPlanConfig())
+        text = repr(plan)
+        assert "memory_estimate=unknown" in text
+
+    def test_plan_is_picklable(self):
+        plan, _ = resolve_faiss_plan(FaissPlanConfig(), n_samples=10, dim=4)
+        restored = pickle.loads(pickle.dumps(plan))
+        assert restored == plan
+        assert repr(restored) == repr(plan)
+
+
+class TestFaissPlanIntegration:
+    """End-to-end behavior through pairwise_distances and an affinity (CPU)."""
+
+    def test_pairwise_distances_accepts_plan_config(self, data):
+        # Direct-call guard: a plan config resolves to the exact Flat backend and
+        # returns the same neighbors as backend="faiss" (CPU-only fallback).
+        d_ref, i_ref = pairwise_distances(
+            data, k=5, backend="faiss", return_indices=True
+        )
+        d_plan, i_plan = pairwise_distances(
+            data, k=5, backend=FaissPlanConfig(mode="exact"), return_indices=True
+        )
+        assert torch.equal(i_ref, i_plan)
+        assert torch.allclose(d_ref, d_plan)
+
+    def test_pairwise_distances_reproducible(self, data):
+        _, i_a = pairwise_distances(
+            data, k=5, backend=FaissPlanConfig(mode="exact"), return_indices=True
+        )
+        _, i_b = pairwise_distances(
+            data, k=5, backend=FaissPlanConfig(mode="exact"), return_indices=True
+        )
+        assert torch.equal(i_a, i_b)
+
+    def test_affinity_records_plan_and_matches_faiss(self, data):
+        aff_plan = EntropicAffinity(
+            perplexity=15,
+            backend=FaissPlanConfig(mode="exact"),
+            sparsity=True,
+            verbose=False,
+        )
+        _, idx_plan = aff_plan(data)
+
+        # The resolved plan is exposed for inspection after computation.
+        assert hasattr(aff_plan, "faiss_plan_")
+        assert aff_plan.faiss_plan_.index_type == "Flat"
+        assert aff_plan.faiss_plan_.precision == "float32"
+
+        aff_faiss = EntropicAffinity(
+            perplexity=15,
+            backend="faiss",
+            sparsity=True,
+            verbose=False,
+        )
+        _, idx_faiss = aff_faiss(data)
+
+        # Exact plan == plain FAISS Flat: identical k-NN structure.
+        assert torch.equal(idx_plan, idx_faiss)
+
+    def test_affinity_without_plan_has_no_attr(self, data):
+        aff = EntropicAffinity(
+            perplexity=15, backend="faiss", sparsity=True, verbose=False
+        )
+        aff(data)
+        assert not hasattr(aff, "faiss_plan_")


### PR DESCRIPTION
## Summary

Introduces the minimal, exact-only slice of the FAISS execution-plan API from #307.

- `FaissPlanConfig()` is an immutable high-level backend configuration whose default always resolves to exact, full-precision Flat search.
- The resolved, immutable `faiss_plan_` records the actual mode, index type, precision, topology, training state, stream batch size, and per-rank index-storage estimate.
- Fitted affinities and neighbor-embedding estimators expose `faiss_plan_`; direct `pairwise_distances` calls also accept the configuration.
- Existing `backend="faiss"` and direct `FaissConfig` calls remain unchanged.
- Expert overrides are copied before device ownership is applied, so the caller's object is not mutated.
- `balanced`, `fast`, and `shard` are reserved but raise explicit not-yet-supported errors until #304 and #301 provide measured implementations.

The review pass deliberately removed `memory_budget` and `random_state` from this first API slice because neither affected execution yet, kept the resolver private, distinguished single-process from replicated execution, and reduced the new implementation and test modules from 519 to 299 lines. FAISS-specific tests are now included in the FAISS CI job instead of being skipped by the normal no-FAISS environment.

## Verdict

**APPROVE** — this establishes the small configuration boundary needed by the remaining roadmap without changing current search behavior or exposing nonfunctional options.

## Validation

| Check | Result |
|---|---|
| Focused plan API tests, including CPU FAISS and DataLoader input | 13 passed |
| FAISS + affinity + neighbor-embedding CPU suite | 79 passed |
| Two-process Gloo distributed FAISS suite | 7 passed per rank |
| Two-B200 NCCL UMAP affinity, float32 and float64 | 2 passed per rank; distributed result matched single-GPU and reported `replicate` vs `single` correctly |
| Pre-commit, all files plus final changed-file rerun | passed |

This PR does not claim a speedup and therefore does not introduce preset performance thresholds. The build/search/memory/recall/trustworthiness benchmarks for approximate presets remain part of #304; replicated-versus-sharded benchmarks remain part of #301.

Closes #307.
