### PR TITLE
[Feature] Add explicit exact-index sharded multi-GPU FAISS search

### DIFF
--- a/.github/workflows/distributed-integration.yml
+++ b/.github/workflows/distributed-integration.yml
@@ -10,8 +10,10 @@ on:
     paths:
       - ".github/workflows/distributed-integration.yml"
       - "torchdr/affinity_matcher.py"
+      - "torchdr/affinity/base.py"
       - "torchdr/distance/base.py"
       - "torchdr/distance/faiss.py"
+      - "torchdr/distance/faiss_plan.py"
       - "torchdr/distributed/**"
       - "torchdr/neighbor_embedding/**"
       - "torchdr/spectral_embedding/pca.py"
@@ -27,8 +29,10 @@ on:
     paths:
       - ".github/workflows/distributed-integration.yml"
       - "torchdr/affinity_matcher.py"
+      - "torchdr/affinity/base.py"
       - "torchdr/distance/base.py"
       - "torchdr/distance/faiss.py"
+      - "torchdr/distance/faiss_plan.py"
       - "torchdr/distributed/**"
       - "torchdr/neighbor_embedding/**"
       - "torchdr/spectral_embedding/pca.py"

--- a/.github/workflows/distributed-integration.yml
+++ b/.github/workflows/distributed-integration.yml
@@ -16,6 +16,7 @@ on:
       - "torchdr/neighbor_embedding/**"
       - "torchdr/spectral_embedding/pca.py"
       - "torchdr/tests/test_distributed_faiss_training.py"
+      - "torchdr/tests/test_distributed_faiss_shard.py"
       - "torchdr/tests/test_distributed_integration.py"
       - "torchdr/tests/test_distributed_neighbor_embedding.py"
       - "torchdr/tests/test_distributed_sparse.py"
@@ -32,6 +33,7 @@ on:
       - "torchdr/neighbor_embedding/**"
       - "torchdr/spectral_embedding/pca.py"
       - "torchdr/tests/test_distributed_faiss_training.py"
+      - "torchdr/tests/test_distributed_faiss_shard.py"
       - "torchdr/tests/test_distributed_integration.py"
       - "torchdr/tests/test_distributed_neighbor_embedding.py"
       - "torchdr/tests/test_distributed_sparse.py"
@@ -100,3 +102,17 @@ jobs:
           python -m torch.distributed.run --standalone --nnodes=1
           --nproc-per-node=2 -m pytest
           torchdr/tests/test_distributed_faiss_training.py -q
+      - name: Run two-process sharded search test
+        env:
+          TORCHDR_DISTRIBUTED_TEST: "1"
+        run: >-
+          python -m torch.distributed.run --standalone --nnodes=1
+          --nproc-per-node=2 -m pytest
+          torchdr/tests/test_distributed_faiss_shard.py -q
+      - name: Run four-process sharded search test
+        env:
+          TORCHDR_DISTRIBUTED_TEST: "1"
+        run: >-
+          python -m torch.distributed.run --standalone --nnodes=1
+          --nproc-per-node=4 -m pytest
+          torchdr/tests/test_distributed_faiss_shard.py -q

--- a/torchdr/affinity/base.py
+++ b/torchdr/affinity/base.py
@@ -110,22 +110,19 @@ class Affinity(nn.Module, ABC):
     # --- Distance computation ---
 
     def _resolve_plan_backend(self, X):
-        r"""Resolve a ``FaissPlanConfig`` backend into a low-level ``FaissConfig``.
+        r"""Resolve and expose diagnostics for a ``FaissPlanConfig`` backend.
 
         If ``self.backend`` is a :class:`~torchdr.distance.FaissPlanConfig`,
         resolve it into an immutable execution plan (stored as
         ``self.faiss_plan_`` and printed on rank 0 when ``verbose=True``) and
-        return the corresponding low-level
-        :class:`~torchdr.distance.FaissConfig` to hand to ``pairwise_distances``.
-        Otherwise return ``self.backend`` unchanged. This keeps user-intent
-        configuration at the estimator boundary while the expert configuration
-        flows internally.
+        return the original high-level configuration for ``pairwise_distances``
+        to dispatch. Otherwise return ``self.backend`` unchanged.
         """
         backend = self.backend
         if not isinstance(backend, FaissPlanConfig):
             return backend
 
-        plan, config = _resolve_faiss_plan(
+        plan, _ = _resolve_faiss_plan(
             backend,
             n_samples=self._get_n_samples(X),
             n_features=self._get_n_features(X),
@@ -134,7 +131,7 @@ class Affinity(nn.Module, ABC):
         self.faiss_plan_ = plan
         if self.verbose and getattr(self, "rank", 0) == 0:
             self.logger.info(f"Resolved FAISS execution plan: {plan}")
-        return config
+        return backend
 
     def _distance_matrix(
         self, X: torch.Tensor, k: int = None, return_indices: bool = False
@@ -509,24 +506,16 @@ class SparseAffinity(Affinity):
         indices : torch.Tensor, optional
             Indices if ``return_indices=True``.
         """
-        resolved_backend = self._resolve_plan_backend(X)
-        # A resolved plan also decides the multi-GPU topology; forward it so the
-        # distributed search shards or replicates as the plan determined.
-        distribution = (
-            self.faiss_plan_.distribution
-            if isinstance(self.backend, FaissPlanConfig)
-            else None
-        )
+        backend = self._resolve_plan_backend(X)
         result = pairwise_distances(
             X=X,
             metric=self.metric,
-            backend=resolved_backend,
+            backend=backend,
             exclude_diag=self.zero_diag,
             k=k,
             return_indices=return_indices,
             device=self.device,
             distributed_ctx=self.dist_ctx if self.distributed else None,
-            distribution=distribution,
         )
 
         # Store chunk bounds for downstream use (e.g. distributed symmetrization)

--- a/torchdr/affinity/base.py
+++ b/torchdr/affinity/base.py
@@ -509,15 +509,24 @@ class SparseAffinity(Affinity):
         indices : torch.Tensor, optional
             Indices if ``return_indices=True``.
         """
+        resolved_backend = self._resolve_plan_backend(X)
+        # A resolved plan also decides the multi-GPU topology; forward it so the
+        # distributed search shards or replicates as the plan determined.
+        distribution = (
+            self.faiss_plan_.distribution
+            if isinstance(self.backend, FaissPlanConfig)
+            else None
+        )
         result = pairwise_distances(
             X=X,
             metric=self.metric,
-            backend=self._resolve_plan_backend(X),
+            backend=resolved_backend,
             exclude_diag=self.zero_diag,
             k=k,
             return_indices=return_indices,
             device=self.device,
             distributed_ctx=self.dist_ctx if self.distributed else None,
+            distribution=distribution,
         )
 
         # Store chunk bounds for downstream use (e.g. distributed symmetrization)

--- a/torchdr/distance/base.py
+++ b/torchdr/distance/base.py
@@ -145,8 +145,8 @@ def pairwise_distances(
         )
         distribution = _plan.distribution
 
-    # Every rank must hold the same full dataset: each builds a complete index
-    # and returns global sample ids. Check before any index is built.
+    # The current distributed contract requires the same full input on every
+    # rank, whether the FAISS index is replicated or sharded.
     if distributed_ctx is not None and distributed_ctx.is_initialized:
         validate_distributed_input(X, distributed_ctx)
 

--- a/torchdr/distance/base.py
+++ b/torchdr/distance/base.py
@@ -14,6 +14,7 @@ from .keops import pairwise_distances_keops
 from .faiss import (
     pairwise_distances_faiss,
     pairwise_distances_faiss_from_dataloader,
+    sharded_pairwise_distances_faiss,
     FaissConfig,
 )
 from .faiss_plan import FaissPlanConfig, _resolve_faiss_plan
@@ -31,6 +32,7 @@ def pairwise_distances(
     return_indices: bool = False,
     device: str = "auto",
     distributed_ctx: Optional[DistributedContext] = None,
+    distribution: Optional[str] = None,
 ):
     r"""Compute pairwise distances between two tensors or from a DataLoader.
 
@@ -90,6 +92,13 @@ def pairwise_distances(
         - Every rank must pass the same full dataset; detectable metadata
           mismatches and sharded DataLoaders are rejected before indexing
         Default is None (single GPU computation).
+    distribution : str, optional
+        Resolved multi-GPU topology for the distributed FAISS search, one of
+        ``"replicate"`` or ``"shard"``. Normally left as None: it is set from a
+        ``FaissPlanConfig`` passed as ``backend`` here, or by an affinity that
+        resolved the plan and forwards its decision. ``"shard"`` indexes only
+        each rank's chunk and merges the exact global neighbors; anything else
+        replicates the full index on every rank.
 
     Returns
     -------
@@ -136,12 +145,15 @@ def pairwise_distances(
     if isinstance(backend, FaissPlanConfig):
         _n = None if isinstance(X, DataLoader) else X.shape[0]
         _dim = None if isinstance(X, DataLoader) else X.shape[1]
-        _, backend = _resolve_faiss_plan(
+        _plan, backend = _resolve_faiss_plan(
             backend,
             n_samples=_n,
             n_features=_dim,
             distributed_ctx=distributed_ctx,
         )
+        # The plan carries the resolved multi-GPU topology; the distributed
+        # branch below routes on it, so a direct caller need not pass it.
+        distribution = _plan.distribution
 
     # Every rank must hold the same full dataset: each builds a complete index
     # and returns global sample ids. Check before any index is built.
@@ -208,25 +220,40 @@ def pairwise_distances(
             # maps this base configuration to the rank-local GPU.
             config = FaissConfig()
 
-        # Compute chunk bounds for this rank
-        n_samples = X.shape[0]
-        chunk_start, chunk_end = distributed_ctx.compute_chunk_bounds(n_samples)
-        X_chunk = X[chunk_start:chunk_end]
+        if distribution == "shard":
+            # Each rank indexes only its chunk; the exact global neighbors are
+            # merged across ranks. Every rank still passes the full dataset and
+            # answers its own chunk, so the result matches the replicated path.
+            C, indices = sharded_pairwise_distances_faiss(
+                X=X,
+                k=k,
+                metric=metric,
+                exclude_diag=exclude_diag,
+                config=config,
+                device=device,
+                distributed_ctx=distributed_ctx,
+            )
+        else:
+            # Compute chunk bounds for this rank
+            n_samples = X.shape[0]
+            chunk_start, chunk_end = distributed_ctx.compute_chunk_bounds(n_samples)
+            X_chunk = X[chunk_start:chunk_end]
 
-        # Compute k-NN: queries=chunk, database=full dataset. Query row j of the
-        # chunk is global row chunk_start + j, which is what lets exclude_diag
-        # identify the self-neighbor even though X_chunk is a subset of X.
-        C, indices = pairwise_distances_faiss(
-            X=X_chunk,
-            Y=X,  # Full dataset as database
-            metric=metric,
-            k=k,
-            exclude_diag=exclude_diag,
-            config=config,
-            device=device,
-            query_ids=torch.arange(chunk_start, chunk_end, device=X.device),
-            distributed_ctx=distributed_ctx,
-        )
+            # Compute k-NN: queries=chunk, database=full dataset. Query row j of
+            # the chunk is global row chunk_start + j, which is what lets
+            # exclude_diag identify the self-neighbor even though X_chunk is a
+            # subset of X.
+            C, indices = pairwise_distances_faiss(
+                X=X_chunk,
+                Y=X,  # Full dataset as database
+                metric=metric,
+                k=k,
+                exclude_diag=exclude_diag,
+                config=config,
+                device=device,
+                query_ids=torch.arange(chunk_start, chunk_end, device=X.device),
+                distributed_ctx=distributed_ctx,
+            )
 
         if return_indices:
             return C, indices

--- a/torchdr/distance/base.py
+++ b/torchdr/distance/base.py
@@ -32,7 +32,6 @@ def pairwise_distances(
     return_indices: bool = False,
     device: str = "auto",
     distributed_ctx: Optional[DistributedContext] = None,
-    distribution: Optional[str] = None,
 ):
     r"""Compute pairwise distances between two tensors or from a DataLoader.
 
@@ -92,14 +91,6 @@ def pairwise_distances(
         - Every rank must pass the same full dataset; detectable metadata
           mismatches and sharded DataLoaders are rejected before indexing
         Default is None (single GPU computation).
-    distribution : str, optional
-        Resolved multi-GPU topology for the distributed FAISS search, one of
-        ``"replicate"`` or ``"shard"``. Normally left as None: it is set from a
-        ``FaissPlanConfig`` passed as ``backend`` here, or by an affinity that
-        resolved the plan and forwards its decision. ``"shard"`` indexes only
-        each rank's chunk and merges the exact global neighbors; anything else
-        replicates the full index on every rank.
-
     Returns
     -------
     C : torch.Tensor
@@ -142,6 +133,7 @@ def pairwise_distances(
     # resolved here into its low-level FaissConfig so the dispatch below can treat
     # it like any other FAISS backend. Estimators resolve the plan at the affinity
     # layer and expose it as ``faiss_plan_``; direct callers just get the result.
+    distribution = "replicate"
     if isinstance(backend, FaissPlanConfig):
         _n = None if isinstance(X, DataLoader) else X.shape[0]
         _dim = None if isinstance(X, DataLoader) else X.shape[1]
@@ -151,8 +143,6 @@ def pairwise_distances(
             n_features=_dim,
             distributed_ctx=distributed_ctx,
         )
-        # The plan carries the resolved multi-GPU topology; the distributed
-        # branch below routes on it, so a direct caller need not pass it.
         distribution = _plan.distribution
 
     # Every rank must hold the same full dataset: each builds a complete index
@@ -162,6 +152,11 @@ def pairwise_distances(
 
     # Handle DataLoader input
     if isinstance(X, DataLoader):
+        if distribution == "shard":
+            raise NotImplementedError(
+                "[TorchDR] distribution='shard' does not yet support DataLoader "
+                "input. Use distribution='replicate'."
+            )
         if k is None:
             raise ValueError(
                 "[TorchDR] DataLoader input requires k-NN computation. "

--- a/torchdr/distance/faiss.py
+++ b/torchdr/distance/faiss.py
@@ -535,15 +535,13 @@ def sharded_pairwise_distances_faiss(
 ):
     r"""Exact k-NN over a database sharded across the ranks of a group.
 
-    Every rank holds the full dataset ``X`` (the TorchDR distributed contract)
-    but indexes only its own contiguous shard, so the stored database vectors are
-    divided across the group instead of replicated on every rank. Each rank
-    answers the queries in its own chunk. For each source rank in turn, its query
-    sub-batch is broadcast, every rank searches its local shard, the per-shard
-    candidates are gathered, and the source merges them into the exact global
-    top-k. The result on each rank is identical to the single-process Flat search
-    restricted to that rank's chunk, which is the same contract the replicated
-    path satisfies.
+    Every rank holds the full input ``X`` under TorchDR's current distributed
+    contract, but the additional FAISS index stores only that rank's contiguous
+    database shard. Each rank answers the queries in its own chunk. For each
+    source rank in turn, its query sub-batch is broadcast, every rank searches
+    its local shard, and the source merges the gathered candidates into the exact
+    global top-k. The result matches replicated Flat search for that rank's
+    query chunk.
 
     Only ``broadcast`` and ``all_gather`` collectives are used, so the same code
     path runs on the Gloo (CPU) and NCCL (GPU) backends. Peak memory for the
@@ -555,8 +553,9 @@ def sharded_pairwise_distances_faiss(
     Parameters
     ----------
     X : torch.Tensor of shape (n, d)
-        The full dataset, identical on every rank. Rank ``r`` indexes and answers
-        the contiguous chunk given by ``distributed_ctx.compute_chunk_bounds``.
+        The full input, identical on every rank. Rank ``r`` adds only its
+        contiguous chunk to the FAISS index. Sharding therefore reduces index
+        memory, not the memory occupied by this input tensor.
     k : int or torch.Tensor
         Number of nearest neighbors to return.
     metric : str, default "sqeuclidean"

--- a/torchdr/distance/faiss.py
+++ b/torchdr/distance/faiss.py
@@ -522,6 +522,218 @@ def pairwise_distances_faiss(
     return distances, indices
 
 
+@torch.compiler.disable
+def sharded_pairwise_distances_faiss(
+    X: torch.Tensor,
+    k: Union[int, torch.Tensor],
+    metric: str = "sqeuclidean",
+    exclude_diag: bool = False,
+    config: Optional[FaissConfig] = None,
+    device: str = "auto",
+    distributed_ctx: Optional[Any] = None,
+    query_batch_size: Optional[int] = None,
+):
+    r"""Exact k-NN over a database sharded across the ranks of a group.
+
+    Every rank holds the full dataset ``X`` (the TorchDR distributed contract)
+    but indexes only its own contiguous shard, so the stored database vectors are
+    divided across the group instead of replicated on every rank. Each rank
+    answers the queries in its own chunk. For each source rank in turn, its query
+    sub-batch is broadcast, every rank searches its local shard, the per-shard
+    candidates are gathered, and the source merges them into the exact global
+    top-k. The result on each rank is identical to the single-process Flat search
+    restricted to that rank's chunk, which is the same contract the replicated
+    path satisfies.
+
+    Only ``broadcast`` and ``all_gather`` collectives are used, so the same code
+    path runs on the Gloo (CPU) and NCCL (GPU) backends. Peak memory for the
+    merge is bounded by one query sub-batch, not by the dataset.
+
+    Only exact ``Flat`` search is supported here; approximate sharded indexes,
+    which need a shared trained quantizer, are a separate follow-up.
+
+    Parameters
+    ----------
+    X : torch.Tensor of shape (n, d)
+        The full dataset, identical on every rank. Rank ``r`` indexes and answers
+        the contiguous chunk given by ``distributed_ctx.compute_chunk_bounds``.
+    k : int or torch.Tensor
+        Number of nearest neighbors to return.
+    metric : str, default "sqeuclidean"
+        One of "euclidean", "sqeuclidean", or "angular".
+    exclude_diag : bool, default False
+        When True, each query's own database row is removed from its results,
+        matched by global index so it is correct across shard boundaries.
+    config : FaissConfig, optional
+        Low-level FAISS configuration. Must resolve to ``index_type="Flat"``.
+        The device is mapped to the context's local rank.
+    device : str, default "auto"
+        Compute device. If "auto", uses the input device.
+    distributed_ctx : DistributedContext
+        The group whose ranks share the sharded database. Required and must be
+        initialized.
+    query_batch_size : int, optional
+        Rows of queries broadcast and merged at a time. Defaults to the config's
+        ``stream_batch_size`` when set, otherwise a built-in cap. Lower it to
+        bound the merge memory further.
+
+    Returns
+    -------
+    distances : torch.Tensor of shape (n_local, k)
+        Neighbor distances for this rank's chunk, in the same convention as
+        :func:`pairwise_distances_faiss`.
+    indices : torch.Tensor of shape (n_local, k)
+        Global database indices of those neighbors.
+    """
+    if metric not in LIST_METRICS_FAISS:
+        raise ValueError(
+            "[TorchDR] Only 'euclidean', 'sqeuclidean', and 'angular' metrics "
+            "are supported for FAISS."
+        )
+    if distributed_ctx is None or not distributed_ctx.is_initialized:
+        raise ValueError(
+            "[TorchDR] sharded search requires an initialized distributed context."
+        )
+
+    config = FaissConfig() if config is None else config
+    if config.index_type != "Flat":
+        raise NotImplementedError(
+            "[TorchDR] distribution='shard' currently supports only exact 'Flat' "
+            "search; approximate sharded indexes are a separate follow-up."
+        )
+    # A default config names GPU 0; each rank must build on its own local rank.
+    config = distributed_ctx.get_faiss_config(config)
+
+    k = int(k.item()) if isinstance(k, torch.Tensor) else int(k)
+
+    dtype = X.dtype
+    n_samples, d = X.shape
+    world_size = distributed_ctx.world_size
+    rank = distributed_ctx.rank
+
+    if X.dtype != torch.float32:
+        warnings.warn(
+            "[TorchDR] FAISS computes distances in float32; input values will "
+            "be converted and results cast back to the input dtype.",
+            UserWarning,
+            stacklevel=2,
+        )
+
+    compute_device = X.device if device == "auto" else torch.device(device)
+    index_device, use_gpu_index = _index_input_device(config, compute_device)
+    if compute_device.type == "cuda" and not use_gpu_index:
+        warnings.warn(
+            "[TorchDR] WARNING: `faiss-gpu` not installed, using CPU for Faiss computations. "
+            "This may be slow. For faster performance, install `faiss-gpu`."
+        )
+    faiss_device = (
+        torch.device("cuda", _index_device_id(config)) if use_gpu_index else None
+    )
+    # Collectives run on cuda:local_rank for NCCL and on the host for Gloo.
+    comm_device = collective_device(distributed_ctx)
+
+    k_search = k + 1 if exclude_diag else k
+
+    # This rank's shard and its query chunk are the same contiguous partition, so
+    # a local FAISS row i is global database id db_offset + i.
+    shard_start, shard_end = distributed_ctx.compute_chunk_bounds(n_samples)
+    db_offset = shard_start
+    shard = (
+        X[shard_start:shard_end]
+        .detach()
+        .to(device=index_device, dtype=torch.float32)
+        .contiguous()
+    )
+    shard_faiss = shard if faiss_torch_interop else shard.cpu().numpy()
+
+    index = _create_index(metric, config, d, shard.shape[0], use_gpu_index)
+    with faiss_device_scope(faiss_device):
+        index.add(shard_faiss)
+
+    if query_batch_size is not None:
+        batch_rows = int(query_batch_size)
+    elif config.stream_batch_size != "auto":
+        batch_rows = int(config.stream_batch_size)
+    else:
+        batch_rows = _AUTO_STREAM_ROWS
+    if batch_rows < 1:
+        raise ValueError(
+            f"[TorchDR] query_batch_size must be a positive number of rows, "
+            f"got {batch_rows}."
+        )
+
+    largest = metric == "angular"
+    result_D: List[torch.Tensor] = []
+    result_I: List[torch.Tensor] = []
+
+    # Fixed source order 0..world_size-1 and a shared batch size make every rank
+    # issue the same broadcast/all_gather sequence, so the collectives never
+    # deadlock even though only the source rank keeps each merged result.
+    for source in range(world_size):
+        src_start, src_end = distributed_ctx.chunk_bounds(n_samples, source, world_size)
+        n_src = src_end - src_start
+        for offset in range(0, n_src, batch_rows):
+            m = min(batch_rows, n_src - offset)
+            buf = torch.empty((m, d), dtype=torch.float32, device=comm_device)
+            if rank == source:
+                rows = X[src_start + offset : src_start + offset + m]
+                buf.copy_(rows.detach().to(device=comm_device, dtype=torch.float32))
+            dist.broadcast(buf, src=source)
+
+            queries = buf.to(device=index_device, dtype=torch.float32).contiguous()
+            queries_faiss = queries if faiss_torch_interop else queries.cpu().numpy()
+            with faiss_device_scope(faiss_device):
+                local_D, local_I = index.search(queries_faiss, k_search)
+            if not isinstance(local_D, torch.Tensor):
+                local_D = torch.from_numpy(local_D)
+                local_I = torch.from_numpy(local_I)
+            local_D = local_D.to(device=comm_device, dtype=torch.float32)
+            local_I = local_I.to(device=comm_device, dtype=torch.long)
+            # Map local FAISS ids to global database ids; -1 marks a missing
+            # neighbor (k_search larger than this shard) and stays -1.
+            global_I = torch.where(local_I >= 0, local_I + db_offset, local_I)
+
+            D_parts = [torch.empty_like(local_D) for _ in range(world_size)]
+            I_parts = [torch.empty_like(global_I) for _ in range(world_size)]
+            dist.all_gather(D_parts, local_D.contiguous())
+            dist.all_gather(I_parts, global_I.contiguous())
+
+            if rank == source:
+                # Concatenate every shard's candidates per query row, then take
+                # the exact global top-k. Missing entries carry FAISS's sentinel
+                # distance (+inf for L2, -inf for inner product), so they lose the
+                # selection unless fewer than k neighbors exist globally.
+                D_all = torch.stack(D_parts, dim=1).reshape(m, world_size * k_search)
+                I_all = torch.stack(I_parts, dim=1).reshape(m, world_size * k_search)
+                merged_D, selection = torch.topk(
+                    D_all, k_search, dim=1, largest=largest, sorted=True
+                )
+                merged_I = torch.gather(I_all, 1, selection)
+                result_D.append(merged_D)
+                result_I.append(merged_I)
+
+    if result_D:
+        D = torch.cat(result_D, dim=0)
+        Ind = torch.cat(result_I, dim=0)
+    else:
+        D = torch.empty((0, k_search), dtype=torch.float32, device=comm_device)
+        Ind = torch.empty((0, k_search), dtype=torch.long, device=comm_device)
+
+    if metric == "euclidean":
+        D = torch.sqrt(D)
+    elif metric == "angular":
+        D = -D
+
+    if exclude_diag:
+        query_ids = torch.arange(shard_start, shard_end, device=Ind.device)
+        D, Ind = remove_self_neighbors(D, Ind, query_ids)
+
+    distances = D.to(device=compute_device, dtype=dtype)
+    indices = Ind.to(device=compute_device, dtype=torch.long)
+
+    return distances, indices
+
+
 def _setup_gpu_index(index, config: FaissConfig, d: int):
     """Set up GPU index with configuration options.
 

--- a/torchdr/distance/faiss_plan.py
+++ b/torchdr/distance/faiss_plan.py
@@ -19,9 +19,8 @@ class FaissPlanConfig:
 
     This is the small, user-facing alternative to :class:`FaissConfig`. The
     default always resolves to exact, full-precision Flat search. Approximate
-    presets and sharded indexes are represented now so their eventual behavior
-    has a stable home, but fail explicitly until their benchmarked
-    implementations land.
+    presets are represented now so their eventual behavior has a stable home,
+    but fail explicitly until their benchmarked implementations land.
 
     Parameters
     ----------
@@ -30,10 +29,10 @@ class FaissPlanConfig:
         ``"balanced"`` and ``"fast"`` raise :class:`NotImplementedError`.
     distribution : {"auto", "replicate", "shard"}, default="auto"
         Multi-GPU topology. ``"replicate"`` builds the full index on every rank.
-        ``"shard"`` splits the database across ranks so its aggregate size can
-        exceed one rank's memory (exact ``Flat`` search). ``"auto"`` replicates
-        when the full index fits per rank and shards otherwise, falling back to
-        replication when no per-rank memory budget is available.
+        ``"shard"`` splits an exact ``Flat`` index across ranks. The input tensor
+        remains replicated under TorchDR's current distributed-input contract.
+        ``"auto"`` currently preserves the existing replicated-index strategy;
+        automatic memory-aware selection is not yet implemented.
     expert : FaissConfig, optional
         Explicit low-level override for advanced users. It cannot be combined
         with a non-default mode. The object is copied during resolution.
@@ -99,51 +98,6 @@ class _FaissPlan:
         )
 
 
-def _choose_distribution(
-    *,
-    index_memory_bytes: Optional[int],
-    available_memory_bytes: Optional[int],
-    world_size: int,
-    query_bytes: int = 0,
-    output_bytes: int = 0,
-    safety_fraction: float = 0.2,
-) -> str:
-    """Pick ``"replicate"`` or ``"shard"`` for an ``"auto"`` distributed plan.
-
-    Replication keeps the full index on every rank, so it is chosen only when
-    that index, the query and output buffers, and a safety margin for scratch
-    all fit within the per-rank memory budget. Otherwise the database is sharded
-    so its aggregate size can exceed a single rank. With no budget information,
-    or a single rank, replication is the safe default and never hides an index
-    that would not fit.
-
-    Parameters
-    ----------
-    index_memory_bytes : int, optional
-        Bytes the full replicated index would occupy on one rank.
-    available_memory_bytes : int, optional
-        Per-rank memory budget. ``None`` means unknown.
-    world_size : int
-        Number of ranks in the group.
-    query_bytes, output_bytes : int, default 0
-        Bytes for the query batch and the neighbor output on one rank.
-    safety_fraction : float, default 0.2
-        Fraction of the estimate reserved for scratch and fragmentation.
-
-    Returns
-    -------
-    str
-        ``"replicate"`` or ``"shard"``.
-    """
-    if world_size <= 1:
-        return "replicate"
-    if index_memory_bytes is None or available_memory_bytes is None:
-        return "replicate"
-    needed = index_memory_bytes + query_bytes + output_bytes
-    needed += int(needed * safety_fraction)
-    return "replicate" if needed <= available_memory_bytes else "shard"
-
-
 def _copy_config(config: FaissConfig) -> FaissConfig:
     """Copy a low-level config without retaining its mutable kwargs mapping."""
     return FaissConfig(
@@ -165,7 +119,6 @@ def _resolve_faiss_plan(
     n_samples: Optional[int] = None,
     n_features: Optional[int] = None,
     distributed_ctx=None,
-    available_memory_bytes: Optional[int] = None,
 ) -> Tuple[_FaissPlan, FaissConfig]:
     """Resolve user intent into diagnostics and a fresh low-level config."""
     if config.expert is not None:
@@ -184,28 +137,27 @@ def _resolve_faiss_plan(
     )
     world_size = int(getattr(distributed_ctx, "world_size", 1)) if is_distributed else 1
     training_size = 0 if resolved.index_type == "Flat" else None
-    index_memory_bytes = None
-    if training_size == 0 and n_samples is not None and n_features is not None:
-        index_memory_bytes = int(n_samples) * int(n_features) * 4
-
-    # A single rank never shards, so distribution is only meaningful across a
-    # group. Sharding is currently exact-Flat only; an approximate expert index
-    # still resolves to replication until the shared-quantizer path lands.
-    can_shard = world_size > 1 and resolved.index_type == "Flat"
     if not is_distributed or world_size <= 1:
         distribution = "single"
-    elif config.distribution == "replicate":
-        distribution = "replicate"
     elif config.distribution == "shard":
-        distribution = "shard" if can_shard else "replicate"
-    else:  # auto
-        distribution = _choose_distribution(
-            index_memory_bytes=index_memory_bytes,
-            available_memory_bytes=available_memory_bytes,
-            world_size=world_size,
-        )
-        if distribution == "shard" and not can_shard:
-            distribution = "replicate"
+        if resolved.index_type != "Flat":
+            raise NotImplementedError(
+                "[TorchDR] distribution='shard' currently supports only exact "
+                "Flat indexes. Use distribution='replicate' for an expert "
+                "approximate index."
+            )
+        distribution = "shard"
+    else:
+        # Automatic memory-aware selection needs a trustworthy total peak-memory
+        # estimate. Until that exists, preserve the established fast path.
+        distribution = "replicate"
+
+    index_memory_bytes = None
+    if training_size == 0 and n_samples is not None and n_features is not None:
+        indexed_rows = int(n_samples)
+        if distribution == "shard":
+            indexed_rows = (indexed_rows + world_size - 1) // world_size
+        index_memory_bytes = indexed_rows * int(n_features) * 4
 
     return (
         _FaissPlan(

--- a/torchdr/distance/faiss_plan.py
+++ b/torchdr/distance/faiss_plan.py
@@ -29,9 +29,11 @@ class FaissPlanConfig:
         Accuracy/speed intent. Only ``"exact"`` is currently implemented;
         ``"balanced"`` and ``"fast"`` raise :class:`NotImplementedError`.
     distribution : {"auto", "replicate", "shard"}, default="auto"
-        Multi-GPU topology. ``"auto"`` currently resolves to the existing
-        replicated-index strategy in distributed runs. ``"shard"`` is not yet
-        implemented and raises :class:`NotImplementedError`.
+        Multi-GPU topology. ``"replicate"`` builds the full index on every rank.
+        ``"shard"`` splits the database across ranks so its aggregate size can
+        exceed one rank's memory (exact ``Flat`` search). ``"auto"`` replicates
+        when the full index fits per rank and shards otherwise, falling back to
+        replication when no per-rank memory budget is available.
     expert : FaissConfig, optional
         Explicit low-level override for advanced users. It cannot be combined
         with a non-default mode. The object is copied during resolution.
@@ -97,6 +99,51 @@ class _FaissPlan:
         )
 
 
+def _choose_distribution(
+    *,
+    index_memory_bytes: Optional[int],
+    available_memory_bytes: Optional[int],
+    world_size: int,
+    query_bytes: int = 0,
+    output_bytes: int = 0,
+    safety_fraction: float = 0.2,
+) -> str:
+    """Pick ``"replicate"`` or ``"shard"`` for an ``"auto"`` distributed plan.
+
+    Replication keeps the full index on every rank, so it is chosen only when
+    that index, the query and output buffers, and a safety margin for scratch
+    all fit within the per-rank memory budget. Otherwise the database is sharded
+    so its aggregate size can exceed a single rank. With no budget information,
+    or a single rank, replication is the safe default and never hides an index
+    that would not fit.
+
+    Parameters
+    ----------
+    index_memory_bytes : int, optional
+        Bytes the full replicated index would occupy on one rank.
+    available_memory_bytes : int, optional
+        Per-rank memory budget. ``None`` means unknown.
+    world_size : int
+        Number of ranks in the group.
+    query_bytes, output_bytes : int, default 0
+        Bytes for the query batch and the neighbor output on one rank.
+    safety_fraction : float, default 0.2
+        Fraction of the estimate reserved for scratch and fragmentation.
+
+    Returns
+    -------
+    str
+        ``"replicate"`` or ``"shard"``.
+    """
+    if world_size <= 1:
+        return "replicate"
+    if index_memory_bytes is None or available_memory_bytes is None:
+        return "replicate"
+    needed = index_memory_bytes + query_bytes + output_bytes
+    needed += int(needed * safety_fraction)
+    return "replicate" if needed <= available_memory_bytes else "shard"
+
+
 def _copy_config(config: FaissConfig) -> FaissConfig:
     """Copy a low-level config without retaining its mutable kwargs mapping."""
     return FaissConfig(
@@ -118,13 +165,9 @@ def _resolve_faiss_plan(
     n_samples: Optional[int] = None,
     n_features: Optional[int] = None,
     distributed_ctx=None,
+    available_memory_bytes: Optional[int] = None,
 ) -> Tuple[_FaissPlan, FaissConfig]:
     """Resolve user intent into diagnostics and a fresh low-level config."""
-    if config.distribution == "shard":
-        raise NotImplementedError(
-            "[TorchDR] distribution='shard' is not yet supported; see issue #301."
-        )
-
     if config.expert is not None:
         resolved = _copy_config(config.expert)
         mode = "expert"
@@ -139,11 +182,30 @@ def _resolve_faiss_plan(
     is_distributed = bool(
         distributed_ctx is not None and distributed_ctx.is_initialized
     )
-    distribution = "replicate" if is_distributed else "single"
+    world_size = int(getattr(distributed_ctx, "world_size", 1)) if is_distributed else 1
     training_size = 0 if resolved.index_type == "Flat" else None
     index_memory_bytes = None
     if training_size == 0 and n_samples is not None and n_features is not None:
         index_memory_bytes = int(n_samples) * int(n_features) * 4
+
+    # A single rank never shards, so distribution is only meaningful across a
+    # group. Sharding is currently exact-Flat only; an approximate expert index
+    # still resolves to replication until the shared-quantizer path lands.
+    can_shard = world_size > 1 and resolved.index_type == "Flat"
+    if not is_distributed or world_size <= 1:
+        distribution = "single"
+    elif config.distribution == "replicate":
+        distribution = "replicate"
+    elif config.distribution == "shard":
+        distribution = "shard" if can_shard else "replicate"
+    else:  # auto
+        distribution = _choose_distribution(
+            index_memory_bytes=index_memory_bytes,
+            available_memory_bytes=available_memory_bytes,
+            world_size=world_size,
+        )
+        if distribution == "shard" and not can_shard:
+            distribution = "replicate"
 
     return (
         _FaissPlan(

--- a/torchdr/distributed/__init__.py
+++ b/torchdr/distributed/__init__.py
@@ -271,6 +271,45 @@ class DistributedContext:
             self.world_size = 1
             self.local_rank = 0
 
+    @staticmethod
+    def chunk_bounds(n_samples: int, rank: int, world_size: int) -> Tuple[int, int]:
+        """Compute start and end indices for an arbitrary rank's chunk.
+
+        Divides n_samples as evenly as possible across all ranks.
+        If n_samples is not evenly divisible, the first (n_samples % world_size)
+        ranks get one extra sample. This is the partitioner behind
+        :meth:`compute_chunk_bounds`; it takes an explicit rank so a process can
+        also locate another rank's chunk, as sharded search does when it walks
+        every source rank in turn.
+
+        Parameters
+        ----------
+        n_samples : int
+            Total number of samples to divide.
+        rank : int
+            Rank whose chunk bounds to compute.
+        world_size : int
+            Number of ranks the samples are divided across.
+
+        Returns
+        -------
+        chunk_start : int
+            Starting index (inclusive) for the rank.
+        chunk_end : int
+            Ending index (exclusive) for the rank.
+        """
+        chunk_size = n_samples // world_size
+        remainder = n_samples % world_size
+
+        if rank < remainder:
+            chunk_start = rank * (chunk_size + 1)
+            chunk_end = chunk_start + chunk_size + 1
+        else:
+            chunk_start = rank * chunk_size + remainder
+            chunk_end = chunk_start + chunk_size
+
+        return chunk_start, chunk_end
+
     def compute_chunk_bounds(self, n_samples: int) -> Tuple[int, int]:
         """Compute start and end indices for this rank's chunk.
 
@@ -297,17 +336,7 @@ class DistributedContext:
         >>> # Rank 0: [0:25], Rank 1: [25:50], Rank 2: [50:75], Rank 3: [75:100]
         >>> start, end = dist_ctx.compute_chunk_bounds(100)
         """
-        chunk_size = n_samples // self.world_size
-        remainder = n_samples % self.world_size
-
-        if self.rank < remainder:
-            chunk_start = self.rank * (chunk_size + 1)
-            chunk_end = chunk_start + chunk_size + 1
-        else:
-            chunk_start = self.rank * chunk_size + remainder
-            chunk_end = chunk_start + chunk_size
-
-        return chunk_start, chunk_end
+        return self.chunk_bounds(n_samples, self.rank, self.world_size)
 
     @staticmethod
     def get_rank_for_indices(

--- a/torchdr/distributed/input_contract.py
+++ b/torchdr/distributed/input_contract.py
@@ -19,8 +19,8 @@ _SHARDED_IDX = len(_FIELDS)
 _VECTOR_LEN = _SHARDED_IDX + 1
 
 _CONTRACT = (
-    "TorchDR builds a complete nearest-neighbor index on every rank and "
-    "partitions only the query rows. Pass the same full dataset to every rank."
+    "TorchDR's distributed nearest-neighbor search currently requires the same "
+    "full dataset on every rank."
 )
 
 

--- a/torchdr/tests/test_distributed_faiss_shard.py
+++ b/torchdr/tests/test_distributed_faiss_shard.py
@@ -1,10 +1,9 @@
 """Real-process tests for exact k-NN over a database sharded across ranks.
 
-These run on the Gloo CPU backend against a CPU FAISS index, so ordinary CI
-runners cover the broadcast/all_gather merge that lets each rank index only its
-own shard yet still return the exact global neighbors for its chunk. The
-contract mirrors the replicated path: every rank's result equals the
-single-process Flat search restricted to that rank's chunk.
+Ordinary CI runs these against Gloo and CPU FAISS. The same module can run with
+NCCL and GPU FAISS, because TorchDR selects the process-group backend from the
+available device. Each rank's result must equal replicated Flat search for its
+query chunk.
 """
 
 # Author: Hugues Van Assel <vanasselhugues@gmail.com>
@@ -19,7 +18,11 @@ import torch.distributed as dist
 
 from torchdr.distance import FaissConfig, FaissPlanConfig, pairwise_distances
 from torchdr.distance.faiss import sharded_pairwise_distances_faiss
-from torchdr.distributed import DistributedContext
+from torchdr.distributed import (
+    DistributedContext,
+    init_distributed,
+    shutdown_distributed,
+)
 from torchdr.utils import faiss
 
 
@@ -44,14 +47,14 @@ def distributed_process_group():
     only shard and the merge never crosses a rank boundary, so a silent one-rank
     run would report green while exercising none of the sharded search.
     """
-    dist.init_process_group(backend="gloo")
+    init_distributed()
     world_size = dist.get_world_size()
     if world_size < 2:
-        dist.destroy_process_group()
+        shutdown_distributed()
         pytest.fail(f"launch this module with at least two processes, got {world_size}")
     yield
     dist.barrier()
-    dist.destroy_process_group()
+    shutdown_distributed()
 
 
 @pytest.fixture(scope="module")
@@ -105,27 +108,6 @@ def _assert_matches_chunk(data, context, k, metric, exclude_diag=False):
     assert torch.allclose(sh_D, ref_D[start:end])
 
 
-def _assert_neighbor_set_matches_chunk(data, context, k, metric):
-    """Compare neighbor sets and distances without requiring a tie-break order.
-
-    When ``k`` reaches deep into the ranking, equal-distance neighbors appear and
-    neither FAISS nor the merge defines their relative order. The exact result is
-    then the neighbor *set* and the sorted distances; any index that differs
-    between the two must sit at an exactly tied distance, so a genuinely wrong
-    neighbor still fails this check.
-    """
-    ref_D, ref_I = _reference(data, k, metric)
-    sh_D, sh_I = _sharded(data, k, metric, context)
-    start, end = context.compute_chunk_bounds(data.shape[0])
-    ref_I, ref_D = ref_I[start:end], ref_D[start:end]
-    assert sh_I.shape == (end - start, k)
-    assert torch.allclose(sh_D, ref_D)
-    differs = sh_I != ref_I
-    assert torch.equal(sh_D[differs], ref_D[differs])  # every difference is a tie
-    for row_sh, row_ref in zip(sh_I.tolist(), ref_I.tolist()):
-        assert set(row_sh) == set(row_ref)
-
-
 class TestShardedSearch:
     @pytest.mark.parametrize("metric", ["sqeuclidean", "euclidean", "angular"])
     def test_shard_matches_single_process_flat(self, data, context, metric):
@@ -154,16 +136,6 @@ class TestShardedSearch:
         _assert_matches_chunk(small, context, 5, "sqeuclidean")
         _assert_matches_chunk(small, context, 5, "sqeuclidean", exclude_diag=True)
 
-    def test_shard_matches_at_k_one(self, data, context):
-        # k=1 is the smallest merge: a single nearest neighbor per query.
-        _assert_matches_chunk(data, context, 1, "sqeuclidean")
-
-    def test_shard_matches_full_neighborhood(self, data, context):
-        # k just below the dataset size returns nearly every point, so each shard
-        # contributes far more than k_search candidates and the merge spans the
-        # tied tail. The neighbor set and distances must still be exact.
-        _assert_neighbor_set_matches_chunk(data, context, N_SAMPLES - 1, "sqeuclidean")
-
     def test_bounded_query_batch_matches(self, data, context):
         # A tiny query batch forces many broadcast/all_gather rounds; the neighbor
         # identities must be identical, which is what keeps the merge memory bounded
@@ -178,28 +150,6 @@ class TestShardedSearch:
             metric="sqeuclidean",
             distributed_ctx=context,
             query_batch_size=7,
-        )
-        start, end = context.compute_chunk_bounds(N_SAMPLES)
-        assert torch.equal(sh_I, ref_I[start:end])
-        assert torch.allclose(sh_D, ref_D[start:end], rtol=1e-4, atol=1e-4)
-
-    def test_small_batch_through_the_plan_matches(self, data, context):
-        # The same bound reached end-to-end: an expert Flat config with a small
-        # stream_batch_size drives the batching from the public plan API. As above,
-        # the neighbor indices are exact and the distances match up to FAISS's
-        # batch-tiling rounding.
-        ref_D, ref_I = _reference(data, K, "sqeuclidean")
-        plan = FaissPlanConfig(
-            distribution="shard",
-            expert=FaissConfig(index_type="Flat", stream_batch_size=11),
-        )
-        sh_D, sh_I = pairwise_distances(
-            data,
-            k=K,
-            metric="sqeuclidean",
-            backend=plan,
-            return_indices=True,
-            distributed_ctx=context,
         )
         start, end = context.compute_chunk_bounds(N_SAMPLES)
         assert torch.equal(sh_I, ref_I[start:end])

--- a/torchdr/tests/test_distributed_faiss_shard.py
+++ b/torchdr/tests/test_distributed_faiss_shard.py
@@ -1,0 +1,206 @@
+"""Real-process tests for exact k-NN over a database sharded across ranks.
+
+These run on the Gloo CPU backend against a CPU FAISS index, so ordinary CI
+runners cover the broadcast/all_gather merge that lets each rank index only its
+own shard yet still return the exact global neighbors for its chunk. The
+contract mirrors the replicated path: every rank's result equals the
+single-process Flat search restricted to that rank's chunk.
+"""
+
+# Author: Hugues Van Assel <vanasselhugues@gmail.com>
+#
+# License: BSD 3-Clause License
+
+import os
+
+import pytest
+import torch
+import torch.distributed as dist
+
+from torchdr.distance import FaissConfig, FaissPlanConfig, pairwise_distances
+from torchdr.distance.faiss import sharded_pairwise_distances_faiss
+from torchdr.distributed import DistributedContext
+from torchdr.utils import faiss
+
+
+pytestmark = [
+    pytest.mark.skipif(
+        os.environ.get("TORCHDR_DISTRIBUTED_TEST") != "1",
+        reason="run through the dedicated multi-process integration workflow",
+    ),
+    pytest.mark.skipif(faiss is None or faiss is False, reason="faiss not installed"),
+]
+
+N_SAMPLES = 4000
+N_FEATURES = 8
+K = 5
+
+
+@pytest.fixture(scope="module", autouse=True)
+def distributed_process_group():
+    """Initialize the process group created by torchrun.
+
+    Fails loudly on a single process: with one rank the whole database is the
+    only shard and the merge never crosses a rank boundary, so a silent one-rank
+    run would report green while exercising none of the sharded search.
+    """
+    dist.init_process_group(backend="gloo")
+    world_size = dist.get_world_size()
+    if world_size < 2:
+        dist.destroy_process_group()
+        pytest.fail(f"launch this module with at least two processes, got {world_size}")
+    yield
+    dist.barrier()
+    dist.destroy_process_group()
+
+
+@pytest.fixture(scope="module")
+def context(distributed_process_group):
+    return DistributedContext()
+
+
+@pytest.fixture(scope="module")
+def data():
+    """The same dataset on every rank, which is the contract TorchDR expects."""
+    generator = torch.Generator().manual_seed(0)
+    return torch.randn(N_SAMPLES, N_FEATURES, generator=generator)
+
+
+def _dataset(n_samples, seed=0):
+    generator = torch.Generator().manual_seed(seed)
+    return torch.randn(n_samples, N_FEATURES, generator=generator)
+
+
+def _reference(data, k, metric, exclude_diag=False):
+    """Single-process exact Flat neighbors over the full database."""
+    return pairwise_distances(
+        data,
+        k=k,
+        metric=metric,
+        backend=FaissConfig(),
+        exclude_diag=exclude_diag,
+        return_indices=True,
+    )
+
+
+def _sharded(data, k, metric, context, exclude_diag=False):
+    """Sharded neighbors for this rank's chunk, through the plan API."""
+    return pairwise_distances(
+        data,
+        k=k,
+        metric=metric,
+        backend=FaissPlanConfig(distribution="shard"),
+        exclude_diag=exclude_diag,
+        return_indices=True,
+        distributed_ctx=context,
+    )
+
+
+def _assert_matches_chunk(data, context, k, metric, exclude_diag=False):
+    ref_D, ref_I = _reference(data, k, metric, exclude_diag)
+    sh_D, sh_I = _sharded(data, k, metric, context, exclude_diag)
+    start, end = context.compute_chunk_bounds(data.shape[0])
+    assert sh_I.shape == (end - start, k)
+    assert torch.equal(sh_I, ref_I[start:end])
+    assert torch.allclose(sh_D, ref_D[start:end])
+
+
+def _assert_neighbor_set_matches_chunk(data, context, k, metric):
+    """Compare neighbor sets and distances without requiring a tie-break order.
+
+    When ``k`` reaches deep into the ranking, equal-distance neighbors appear and
+    neither FAISS nor the merge defines their relative order. The exact result is
+    then the neighbor *set* and the sorted distances; any index that differs
+    between the two must sit at an exactly tied distance, so a genuinely wrong
+    neighbor still fails this check.
+    """
+    ref_D, ref_I = _reference(data, k, metric)
+    sh_D, sh_I = _sharded(data, k, metric, context)
+    start, end = context.compute_chunk_bounds(data.shape[0])
+    ref_I, ref_D = ref_I[start:end], ref_D[start:end]
+    assert sh_I.shape == (end - start, k)
+    assert torch.allclose(sh_D, ref_D)
+    differs = sh_I != ref_I
+    assert torch.equal(sh_D[differs], ref_D[differs])  # every difference is a tie
+    for row_sh, row_ref in zip(sh_I.tolist(), ref_I.tolist()):
+        assert set(row_sh) == set(row_ref)
+
+
+class TestShardedSearch:
+    @pytest.mark.parametrize("metric", ["sqeuclidean", "euclidean", "angular"])
+    def test_shard_matches_single_process_flat(self, data, context, metric):
+        # The heart of #301: sharding the database and merging the per-shard
+        # candidates must reproduce the single-process neighbors exactly, for
+        # both the L2 metrics and the inner-product (angular) ordering.
+        _assert_matches_chunk(data, context, K, metric)
+
+    def test_shard_excludes_self_neighbor(self, data, context):
+        # exclude_diag removes each query's own row, matched by global index so
+        # it is correct even though the query sits in a different rank's shard.
+        _assert_matches_chunk(data, context, K, "sqeuclidean", exclude_diag=True)
+
+    def test_shard_handles_uneven_partitions(self, context):
+        # A sample count divisible by neither two nor four gives ranks chunks of
+        # different sizes; the merge must still line up with the global result.
+        uneven = _dataset(4003)
+        _assert_matches_chunk(uneven, context, K, "sqeuclidean")
+        _assert_matches_chunk(uneven, context, K, "angular")
+
+    def test_shard_handles_k_larger_than_a_shard(self, context):
+        # With few samples each shard holds fewer than k rows, so every local
+        # search returns padding (-1) that the merge must discard while still
+        # assembling the correct k global neighbors.
+        small = _dataset(9)
+        _assert_matches_chunk(small, context, 5, "sqeuclidean")
+        _assert_matches_chunk(small, context, 5, "sqeuclidean", exclude_diag=True)
+
+    def test_shard_matches_at_k_one(self, data, context):
+        # k=1 is the smallest merge: a single nearest neighbor per query.
+        _assert_matches_chunk(data, context, 1, "sqeuclidean")
+
+    def test_shard_matches_full_neighborhood(self, data, context):
+        # k just below the dataset size returns nearly every point, so each shard
+        # contributes far more than k_search candidates and the merge spans the
+        # tied tail. The neighbor set and distances must still be exact.
+        _assert_neighbor_set_matches_chunk(data, context, N_SAMPLES - 1, "sqeuclidean")
+
+    def test_bounded_query_batch_matches(self, data, context):
+        # A tiny query batch forces many broadcast/all_gather rounds; the neighbor
+        # identities must be identical, which is what keeps the merge memory bounded
+        # by the batch rather than the dataset. FAISS computes ``||q-p||^2`` with a
+        # blocked matmul whose last-bit rounding depends on the query-batch size, so
+        # the indices are exact while the raw distances match only up to that
+        # ~1e-6 wobble.
+        ref_D, ref_I = _reference(data, K, "sqeuclidean")
+        sh_D, sh_I = sharded_pairwise_distances_faiss(
+            data,
+            k=K,
+            metric="sqeuclidean",
+            distributed_ctx=context,
+            query_batch_size=7,
+        )
+        start, end = context.compute_chunk_bounds(N_SAMPLES)
+        assert torch.equal(sh_I, ref_I[start:end])
+        assert torch.allclose(sh_D, ref_D[start:end], rtol=1e-4, atol=1e-4)
+
+    def test_small_batch_through_the_plan_matches(self, data, context):
+        # The same bound reached end-to-end: an expert Flat config with a small
+        # stream_batch_size drives the batching from the public plan API. As above,
+        # the neighbor indices are exact and the distances match up to FAISS's
+        # batch-tiling rounding.
+        ref_D, ref_I = _reference(data, K, "sqeuclidean")
+        plan = FaissPlanConfig(
+            distribution="shard",
+            expert=FaissConfig(index_type="Flat", stream_batch_size=11),
+        )
+        sh_D, sh_I = pairwise_distances(
+            data,
+            k=K,
+            metric="sqeuclidean",
+            backend=plan,
+            return_indices=True,
+            distributed_ctx=context,
+        )
+        start, end = context.compute_chunk_bounds(N_SAMPLES)
+        assert torch.equal(sh_I, ref_I[start:end])
+        assert torch.allclose(sh_D, ref_D[start:end], rtol=1e-4, atol=1e-4)

--- a/torchdr/tests/test_faiss_plan.py
+++ b/torchdr/tests/test_faiss_plan.py
@@ -13,7 +13,7 @@ from torch.utils.data import DataLoader, TensorDataset
 
 from torchdr import EntropicAffinity, TSNE
 from torchdr.distance import FaissConfig, FaissPlanConfig, pairwise_distances
-from torchdr.distance.faiss_plan import _choose_distribution, _resolve_faiss_plan
+from torchdr.distance.faiss_plan import _resolve_faiss_plan
 from torchdr.utils import faiss
 
 
@@ -93,6 +93,7 @@ def test_shard_and_replicate_resolve_across_a_group():
     )
     assert plan.distribution == "shard"
     assert plan.index_type == resolved.index_type == "Flat"
+    assert plan.index_memory_bytes == 250 * 8 * 4
 
     plan, _ = _resolve_faiss_plan(
         FaissPlanConfig(distribution="replicate"),
@@ -115,66 +116,23 @@ def test_shard_without_a_group_resolves_to_single():
     assert plan.distribution == "single"
 
 
-def test_auto_shards_only_when_the_index_will_not_fit():
+def test_auto_preserves_replication_until_memory_selection_is_implemented():
     ctx = _FakeContext(world_size=2)
-    common = dict(n_samples=1_000, n_features=8, distributed_ctx=ctx)
-
-    fits, _ = _resolve_faiss_plan(
+    plan, _ = _resolve_faiss_plan(
         FaissPlanConfig(distribution="auto"),
-        available_memory_bytes=10**9,
-        **common,
+        n_samples=1_000,
+        n_features=8,
+        distributed_ctx=ctx,
     )
-    assert fits.distribution == "replicate"
-
-    too_big, _ = _resolve_faiss_plan(
-        FaissPlanConfig(distribution="auto"),
-        available_memory_bytes=1_000,
-        **common,
-    )
-    assert too_big.distribution == "shard"
-
-    # Without a per-rank budget the safe default is replication.
-    unknown, _ = _resolve_faiss_plan(FaissPlanConfig(distribution="auto"), **common)
-    assert unknown.distribution == "replicate"
+    assert plan.distribution == "replicate"
 
 
-def test_choose_distribution_never_replicates_an_index_that_will_not_fit():
-    assert (
-        _choose_distribution(
-            index_memory_bytes=100, available_memory_bytes=1_000, world_size=2
+def test_explicit_shard_rejects_unsupported_expert_index():
+    with pytest.raises(NotImplementedError, match="supports only exact Flat"):
+        _resolve_faiss_plan(
+            FaissPlanConfig(distribution="shard", expert=FaissConfig(index_type="IVF")),
+            distributed_ctx=_FakeContext(world_size=2),
         )
-        == "replicate"
-    )
-    assert (
-        _choose_distribution(
-            index_memory_bytes=2_000, available_memory_bytes=1_000, world_size=2
-        )
-        == "shard"
-    )
-    # A missing budget or a single rank falls back to replication rather than
-    # silently sharding, and never claims a giant index fits.
-    assert (
-        _choose_distribution(
-            index_memory_bytes=10**12, available_memory_bytes=None, world_size=8
-        )
-        == "replicate"
-    )
-    assert (
-        _choose_distribution(
-            index_memory_bytes=10**12, available_memory_bytes=1, world_size=1
-        )
-        == "replicate"
-    )
-    # The safety margin tips a just-barely-fitting index into sharding.
-    assert (
-        _choose_distribution(
-            index_memory_bytes=1_000,
-            available_memory_bytes=1_000,
-            world_size=2,
-            safety_fraction=0.2,
-        )
-        == "shard"
-    )
 
 
 def test_exact_plan_reports_resolved_execution():
@@ -231,6 +189,17 @@ def test_plan_accepts_dataloader_input(data):
         loader, k=5, backend=FaissPlanConfig(), return_indices=True
     )
     assert distances.shape == indices.shape == (len(data), 5)
+
+
+def test_shard_plan_rejects_dataloader_instead_of_silently_replicating(data):
+    loader = DataLoader(TensorDataset(data), batch_size=32, shuffle=False)
+    with pytest.raises(NotImplementedError, match="does not yet support DataLoader"):
+        pairwise_distances(
+            loader,
+            k=5,
+            backend=FaissPlanConfig(distribution="shard"),
+            distributed_ctx=_FakeContext(world_size=2),
+        )
 
 
 @requires_faiss

--- a/torchdr/tests/test_faiss_plan.py
+++ b/torchdr/tests/test_faiss_plan.py
@@ -13,13 +13,28 @@ from torch.utils.data import DataLoader, TensorDataset
 
 from torchdr import EntropicAffinity, TSNE
 from torchdr.distance import FaissConfig, FaissPlanConfig, pairwise_distances
-from torchdr.distance.faiss_plan import _resolve_faiss_plan
+from torchdr.distance.faiss_plan import _choose_distribution, _resolve_faiss_plan
 from torchdr.utils import faiss
 
 
 requires_faiss = pytest.mark.skipif(
     faiss is None or faiss is False, reason="faiss not installed"
 )
+
+
+class _FakeContext:
+    """Minimal stand-in for DistributedContext during plan resolution.
+
+    ``_resolve_faiss_plan`` only reads ``is_initialized`` and ``world_size``, so
+    the topology decision can be exercised on a single process without a real
+    process group.
+    """
+
+    def __init__(self, world_size, is_initialized=True):
+        self.is_initialized = is_initialized
+        self.world_size = world_size
+        self.rank = 0
+        self.local_rank = 0
 
 
 @pytest.fixture(scope="module")
@@ -61,12 +76,105 @@ def test_config_rejects_invalid_combinations(kwargs, error):
     [
         FaissPlanConfig(mode="balanced"),
         FaissPlanConfig(mode="fast"),
-        FaissPlanConfig(distribution="shard"),
     ],
 )
 def test_unimplemented_intents_fail_explicitly(config):
     with pytest.raises(NotImplementedError):
         _resolve_faiss_plan(config)
+
+
+def test_shard_and_replicate_resolve_across_a_group():
+    ctx = _FakeContext(world_size=4)
+    plan, resolved = _resolve_faiss_plan(
+        FaissPlanConfig(distribution="shard"),
+        n_samples=1_000,
+        n_features=8,
+        distributed_ctx=ctx,
+    )
+    assert plan.distribution == "shard"
+    assert plan.index_type == resolved.index_type == "Flat"
+
+    plan, _ = _resolve_faiss_plan(
+        FaissPlanConfig(distribution="replicate"),
+        n_samples=1_000,
+        n_features=8,
+        distributed_ctx=ctx,
+    )
+    assert plan.distribution == "replicate"
+
+
+def test_shard_without_a_group_resolves_to_single():
+    # Sharding needs more than one rank; a lone process just searches directly.
+    plan, _ = _resolve_faiss_plan(FaissPlanConfig(distribution="shard"))
+    assert plan.distribution == "single"
+
+    plan, _ = _resolve_faiss_plan(
+        FaissPlanConfig(distribution="shard"),
+        distributed_ctx=_FakeContext(world_size=1),
+    )
+    assert plan.distribution == "single"
+
+
+def test_auto_shards_only_when_the_index_will_not_fit():
+    ctx = _FakeContext(world_size=2)
+    common = dict(n_samples=1_000, n_features=8, distributed_ctx=ctx)
+
+    fits, _ = _resolve_faiss_plan(
+        FaissPlanConfig(distribution="auto"),
+        available_memory_bytes=10**9,
+        **common,
+    )
+    assert fits.distribution == "replicate"
+
+    too_big, _ = _resolve_faiss_plan(
+        FaissPlanConfig(distribution="auto"),
+        available_memory_bytes=1_000,
+        **common,
+    )
+    assert too_big.distribution == "shard"
+
+    # Without a per-rank budget the safe default is replication.
+    unknown, _ = _resolve_faiss_plan(FaissPlanConfig(distribution="auto"), **common)
+    assert unknown.distribution == "replicate"
+
+
+def test_choose_distribution_never_replicates_an_index_that_will_not_fit():
+    assert (
+        _choose_distribution(
+            index_memory_bytes=100, available_memory_bytes=1_000, world_size=2
+        )
+        == "replicate"
+    )
+    assert (
+        _choose_distribution(
+            index_memory_bytes=2_000, available_memory_bytes=1_000, world_size=2
+        )
+        == "shard"
+    )
+    # A missing budget or a single rank falls back to replication rather than
+    # silently sharding, and never claims a giant index fits.
+    assert (
+        _choose_distribution(
+            index_memory_bytes=10**12, available_memory_bytes=None, world_size=8
+        )
+        == "replicate"
+    )
+    assert (
+        _choose_distribution(
+            index_memory_bytes=10**12, available_memory_bytes=1, world_size=1
+        )
+        == "replicate"
+    )
+    # The safety margin tips a just-barely-fitting index into sharding.
+    assert (
+        _choose_distribution(
+            index_memory_bytes=1_000,
+            available_memory_bytes=1_000,
+            world_size=2,
+            safety_fraction=0.2,
+        )
+        == "shard"
+    )
 
 
 def test_exact_plan_reports_resolved_execution():


### PR DESCRIPTION
## Summary

Add an explicit `FaissPlanConfig(distribution="shard")` topology for distributed exact `Flat` search.

- Each rank builds a FAISS index for only its contiguous database shard.
- Query batches visit every shard; per-shard candidates are merged into the exact global top-k with global row IDs.
- The current replicated-input contract is unchanged: every rank still holds the full input tensor. This reduces the additional FAISS index storage, not input-tensor memory.
- `distribution="auto"` continues to select the established replicated path. Automatic memory-aware selection is deferred until TorchDR can estimate total peak memory reliably.
- Explicit sharding fails clearly for approximate expert indexes and distributed DataLoader input instead of silently using replication.

The review also removed the unused memory heuristic and public low-level routing argument, and reduced the integration suite to durable correctness, partitioning, self-neighbor, edge-k, and bounded-batch invariants.

## Validation

- Pre-commit: passed.
- Focused plan and affinity suite: 59 passed.
- Real-process Gloo/CPU suite: 7 passed per rank at both 2 and 4 processes.
- Existing GitHub matrix on the original implementation: all checks passed; CI is rerunning on the simplified commit.
- Real 2×B200 and 4×B200 NCCL runs: sharded neighbor indices exactly matched replication and distances matched within the existing FAISS tolerance.

Paired 2×B200 benchmark, exact Flat, `n=20,000`, `d=64`, `k=15`, two alternating repetitions:

| Topology | End-to-end runs | Mean |
|---|---:|---:|
| replicate | 6.16 ms, 5.08 ms | 5.62 ms |
| shard | 6.20 ms, 6.07 ms | 6.13 ms |

With a separate resident-index probe (`n=2,000,000`, `d=128`), the per-rank Flat-index allocation fell from about 986 MiB replicated to 494 MiB sharded. Thus this is a capacity option, not a speed optimization: at this small search size, communication made sharding about 9% slower on average.

On 4×B200, the same resident-index probe fell from about 986 MiB to 248 MiB per rank, the expected fourfold reduction. The two timing repetitions were noisy (replicate: 4.76/13.17 ms; shard: 8.24/7.89 ms), so they do not support a speed claim. Together, the 2- and 4-GPU results support only the explicit capacity-oriented topology exposed here.

## Scope

This partially addresses #301. Remaining work includes trustworthy automatic peak-memory selection, genuinely sharded/streamed inputs, approximate indexes with shared training, collective failure propagation, and a largest-safe-dataset capacity benchmark. The issue should remain open.
