### PR TITLE
[Test] Cover sharded k-NN collective failure propagation and lockstep

### DIFF
--- a/.github/workflows/distributed-integration.yml
+++ b/.github/workflows/distributed-integration.yml
@@ -19,6 +19,7 @@ on:
       - "torchdr/spectral_embedding/pca.py"
       - "torchdr/tests/test_distributed_faiss_training.py"
       - "torchdr/tests/test_distributed_faiss_shard.py"
+      - "torchdr/tests/test_distributed_faiss_shard_failure.py"
       - "torchdr/tests/test_distributed_integration.py"
       - "torchdr/tests/test_distributed_neighbor_embedding.py"
       - "torchdr/tests/test_distributed_sparse.py"
@@ -38,6 +39,7 @@ on:
       - "torchdr/spectral_embedding/pca.py"
       - "torchdr/tests/test_distributed_faiss_training.py"
       - "torchdr/tests/test_distributed_faiss_shard.py"
+      - "torchdr/tests/test_distributed_faiss_shard_failure.py"
       - "torchdr/tests/test_distributed_integration.py"
       - "torchdr/tests/test_distributed_neighbor_embedding.py"
       - "torchdr/tests/test_distributed_sparse.py"
@@ -120,3 +122,17 @@ jobs:
           python -m torch.distributed.run --standalone --nnodes=1
           --nproc-per-node=4 -m pytest
           torchdr/tests/test_distributed_faiss_shard.py -q
+      - name: Run two-process sharded failure-propagation test
+        env:
+          TORCHDR_DISTRIBUTED_TEST: "1"
+        run: >-
+          python -m torch.distributed.run --standalone --nnodes=1
+          --nproc-per-node=2 -m pytest
+          torchdr/tests/test_distributed_faiss_shard_failure.py -q
+      - name: Run four-process sharded failure-propagation test
+        env:
+          TORCHDR_DISTRIBUTED_TEST: "1"
+        run: >-
+          python -m torch.distributed.run --standalone --nnodes=1
+          --nproc-per-node=4 -m pytest
+          torchdr/tests/test_distributed_faiss_shard_failure.py -q

--- a/torchdr/tests/test_distributed_faiss_shard.py
+++ b/torchdr/tests/test_distributed_faiss_shard.py
@@ -165,24 +165,24 @@ class TestShardedSearch:
         # divisible by neither two nor four) are exactly where a per-rank shortcut
         # would desynchronize the counts, so they are the sharpest guard.
         uneven = _dataset(4003)
-        with (
-            mock.patch.object(
-                faiss_mod.dist, "broadcast", side_effect=faiss_mod.dist.broadcast
-            ) as bcast,
-            mock.patch.object(
+        # Nested ``with`` blocks rather than a parenthesized multi-context form,
+        # which is Python 3.10+ syntax while TorchDR still supports 3.8.
+        with mock.patch.object(
+            faiss_mod.dist, "broadcast", side_effect=faiss_mod.dist.broadcast
+        ) as bcast:
+            with mock.patch.object(
                 faiss_mod.dist, "all_gather", side_effect=faiss_mod.dist.all_gather
-            ) as gather,
-        ):
-            sharded_pairwise_distances_faiss(
-                uneven,
-                k=K,
-                metric="sqeuclidean",
-                distributed_ctx=context,
-                query_batch_size=500,
-            )
-            local = torch.tensor(
-                [bcast.call_count, gather.call_count], dtype=torch.long
-            )
+            ) as gather:
+                sharded_pairwise_distances_faiss(
+                    uneven,
+                    k=K,
+                    metric="sqeuclidean",
+                    distributed_ctx=context,
+                    query_batch_size=500,
+                )
+                local = torch.tensor(
+                    [bcast.call_count, gather.call_count], dtype=torch.long
+                )
         # Distances and indices are gathered once each per broadcast round, and
         # every source rank contributes at least one round.
         assert local[1].item() == 2 * local[0].item()

--- a/torchdr/tests/test_distributed_faiss_shard.py
+++ b/torchdr/tests/test_distributed_faiss_shard.py
@@ -11,11 +11,13 @@ query chunk.
 # License: BSD 3-Clause License
 
 import os
+from unittest import mock
 
 import pytest
 import torch
 import torch.distributed as dist
 
+import torchdr.distance.faiss as faiss_mod
 from torchdr.distance import FaissConfig, FaissPlanConfig, pairwise_distances
 from torchdr.distance.faiss import sharded_pairwise_distances_faiss
 from torchdr.distributed import (
@@ -154,3 +156,42 @@ class TestShardedSearch:
         start, end = context.compute_chunk_bounds(N_SAMPLES)
         assert torch.equal(sh_I, ref_I[start:end])
         assert torch.allclose(sh_D, ref_D[start:end], rtol=1e-4, atol=1e-4)
+
+    def test_collectives_stay_in_lockstep_across_ranks(self, context):
+        # #301 requires the sharded collectives never deadlock. The loop walks a
+        # fixed source order 0..world_size-1 with a shared batch size, so every
+        # rank must issue the identical broadcast/all_gather sequence and no rank
+        # can wait on a collective a peer never posts. Uneven partitions (a count
+        # divisible by neither two nor four) are exactly where a per-rank shortcut
+        # would desynchronize the counts, so they are the sharpest guard.
+        uneven = _dataset(4003)
+        with (
+            mock.patch.object(
+                faiss_mod.dist, "broadcast", side_effect=faiss_mod.dist.broadcast
+            ) as bcast,
+            mock.patch.object(
+                faiss_mod.dist, "all_gather", side_effect=faiss_mod.dist.all_gather
+            ) as gather,
+        ):
+            sharded_pairwise_distances_faiss(
+                uneven,
+                k=K,
+                metric="sqeuclidean",
+                distributed_ctx=context,
+                query_batch_size=500,
+            )
+            local = torch.tensor(
+                [bcast.call_count, gather.call_count], dtype=torch.long
+            )
+        # Distances and indices are gathered once each per broadcast round, and
+        # every source rank contributes at least one round.
+        assert local[1].item() == 2 * local[0].item()
+        assert local[0].item() >= context.world_size
+        # The real all_gather (restored on exit) confirms the counts agree; a
+        # mismatch here is the signature of a latent deadlock.
+        gathered = [torch.empty_like(local) for _ in range(context.world_size)]
+        dist.all_gather(gathered, local)
+        per_rank = [tuple(t.tolist()) for t in gathered]
+        assert len(set(per_rank)) == 1, (
+            f"ranks issued different collective counts and would deadlock: {per_rank}"
+        )

--- a/torchdr/tests/test_distributed_faiss_shard_failure.py
+++ b/torchdr/tests/test_distributed_faiss_shard_failure.py
@@ -1,0 +1,125 @@
+"""Real-process test that a sharded-search failure propagates without a hang.
+
+Issue #301 requires that collective failures in the sharded search reach every
+rank instead of deadlocking. The sharded loop issues an identical
+broadcast/all_gather sequence on each rank, so when one rank drops out of that
+sequence -- here by a collective raising on rank 0 -- the peers waiting on the
+matching collective observe the closed connection and raise as well, rather than
+blocking forever.
+
+This module owns its process group and creates it with a short timeout: the
+sibling sharded-search module relies on ``init_distributed``'s default timeout,
+which is far longer than a CI job, whereas a propagation test must give up
+quickly if a platform ever failed to surface the dropped peer. In practice the
+peers raise in milliseconds from the closed connection, well before the timeout.
+
+Ordinary CI runs this against Gloo and CPU FAISS, matching the sibling sharded
+search module. The NCCL backend provides the same guarantee through its own
+collective watchdog rather than an immediate connection reset.
+"""
+
+# Author: Hugues Van Assel <vanasselhugues@gmail.com>
+#
+# License: BSD 3-Clause License
+
+import os
+import time
+from datetime import timedelta
+from unittest import mock
+
+import pytest
+import torch
+import torch.distributed as dist
+
+import torchdr.distance.faiss as faiss_mod
+from torchdr.distance.faiss import sharded_pairwise_distances_faiss
+from torchdr.distributed import DistributedContext
+from torchdr.utils import faiss
+
+
+pytestmark = [
+    pytest.mark.skipif(
+        os.environ.get("TORCHDR_DISTRIBUTED_TEST") != "1",
+        reason="run through the dedicated multi-process integration workflow",
+    ),
+    pytest.mark.skipif(faiss is None or faiss is False, reason="faiss not installed"),
+]
+
+N_SAMPLES = 400
+N_FEATURES = 8
+K = 5
+# Safety net only: the peers normally raise in milliseconds from the closed
+# connection. If that were ever missed, the group still gives up this far below
+# the CI job budget instead of hanging.
+PG_TIMEOUT_S = 60
+# A hang would blow past this; a propagated failure stays orders of magnitude
+# under it.
+PROPAGATION_CEILING_S = 45
+
+
+@pytest.fixture(scope="module", autouse=True)
+def short_timeout_process_group():
+    """Create a Gloo process group with an explicit short timeout.
+
+    Fails loudly on a single process: with one rank there is no peer to keep
+    waiting, so the deadlock this module guards against cannot occur and a
+    one-rank run would report green while exercising nothing.
+    """
+    if dist.is_initialized():
+        pytest.fail("expected an uninitialized process group for this module")
+    dist.init_process_group(backend="gloo", timeout=timedelta(seconds=PG_TIMEOUT_S))
+    world_size = dist.get_world_size()
+    if world_size < 2:
+        dist.destroy_process_group()
+        pytest.fail(f"launch this module with at least two processes, got {world_size}")
+    yield
+    # The group is intentionally left broken by the test; tear down best-effort.
+    if dist.is_initialized():
+        try:
+            dist.destroy_process_group()
+        except Exception:  # noqa: BLE001
+            pass
+
+
+@pytest.fixture(scope="module")
+def context(short_timeout_process_group):
+    return DistributedContext()
+
+
+@pytest.fixture(scope="module")
+def data():
+    generator = torch.Generator().manual_seed(0)
+    return torch.randn(N_SAMPLES, N_FEATURES, generator=generator)
+
+
+def test_collective_failure_propagates_without_deadlock(data, context):
+    # Rank 0 takes part in the first broadcast, then a collective raises on it,
+    # standing in for any per-rank failure at a collective (an OOM, a shape
+    # mismatch, a dead GPU). The peers are blocked in the matching collective and
+    # must raise rather than wait forever.
+    if context.rank == 0:
+        with mock.patch.object(
+            faiss_mod.dist,
+            "all_gather",
+            side_effect=RuntimeError("injected collective failure on rank 0"),
+        ):
+            with pytest.raises(RuntimeError, match="injected collective failure"):
+                sharded_pairwise_distances_faiss(
+                    data, k=K, metric="sqeuclidean", distributed_ctx=context
+                )
+        # Closing this rank's connections lets the peers observe the drop at once
+        # instead of waiting out the group timeout.
+        dist.destroy_process_group()
+    else:
+        start = time.perf_counter()
+        with pytest.raises(RuntimeError):
+            sharded_pairwise_distances_faiss(
+                data, k=K, metric="sqeuclidean", distributed_ctx=context
+            )
+        elapsed = time.perf_counter() - start
+        assert elapsed < PROPAGATION_CEILING_S, (
+            f"peer rank {context.rank} took {elapsed:.1f}s to observe the "
+            f"failure; the collective is deadlocking rather than propagating"
+        )
+        # Drop this rank's now-broken group so module teardown has nothing to do.
+        dist.destroy_process_group()


### PR DESCRIPTION
## Summary

Issue #301 lists two acceptance criteria for the distributed sharded exact k-NN
search that the merged implementation satisfies but that had **no test
coverage**: collective failures must propagate to every rank without
deadlocking, and every rank must issue an identical collective sequence so no
collective is ever left unmatched. This PR adds real-process integration tests
for both, run under Gloo + CPU FAISS at two and four processes, matching the
existing sharded-search job.

**Verdict: APPROVE.** The merged sharded search satisfies both criteria. A
per-rank collective failure surfaces on every peer in single-digit-to-tens of
milliseconds — thousands of times under the process-group timeout — and all
ranks issue identical broadcast/all_gather counts on uneven partitions.

## Changes

- **New `test_distributed_faiss_shard_failure.py`**: injects a collective
  failure on rank 0 and asserts each peer raises (rather than hangs) far under a
  short process-group timeout. The module owns a short-timeout Gloo group as a
  safety net; in practice peers observe the dropped connection immediately.
- **`test_distributed_faiss_shard.py`**: adds a lockstep test asserting every
  rank records identical broadcast/all_gather counts on an uneven partition (a
  count divisible by neither two nor four), the case where a per-rank shortcut
  would desynchronize and deadlock.
- **`distributed-integration.yml`**: runs the new failure module at two and four
  processes and adds it to the workflow trigger paths.

## Evidence (Gloo, CPU FAISS)

| Facet | 2 processes | 4 processes |
|---|---|---|
| Sharded search + lockstep tests | 8 passed | 8 passed |
| Failure-propagation test | 1 passed | 1 passed |
| Peer raise latency after injected failure | ~9 ms | ~1–21 ms |
| Collective sequence identical across ranks | yes | yes |

The test asserts a 45 s propagation ceiling (group timeout 60 s); observed
peer-raise latency is more than 2000x under it, so a regression to a genuine
deadlock cannot pass silently.

## Test plan

- `torch.distributed.run --standalone --nproc-per-node={2,4}` pytest on
  `test_distributed_faiss_shard.py` — 8 passed each (7 existing + the new
  lockstep test).
- `torch.distributed.run --standalone --nproc-per-node={2,4}` pytest on
  `test_distributed_faiss_shard_failure.py` — 1 passed each.
- `pre-commit run` on all changed files — all hooks pass.
- CI: the distributed-integration workflow (Gloo + CPU FAISS) exercises all four
  cases.

Addresses the collective-failure-propagation and lockstep criteria of #301.
