### PR TITLE
[Feature] Memory-aware distribution='auto' for distributed FAISS k-NN

### DIFF
--- a/torchdr/distance/base.py
+++ b/torchdr/distance/base.py
@@ -5,6 +5,7 @@
 # License: BSD 3-Clause License
 
 import torch
+import torch.distributed as dist
 from typing import Optional, Union
 
 from torch.utils.data import DataLoader
@@ -17,9 +18,51 @@ from .faiss import (
     sharded_pairwise_distances_faiss,
     FaissConfig,
 )
-from .faiss_plan import FaissPlanConfig, _resolve_faiss_plan
+from .faiss_plan import (
+    FaissPlanConfig,
+    _resolve_faiss_plan,
+    _estimate_search_peak_bytes,
+)
 from torchdr.distributed import DistributedContext
-from torchdr.distributed.input_contract import validate_distributed_input
+from torchdr.distributed.input_contract import (
+    validate_distributed_input,
+    collective_device,
+)
+
+
+def _available_gpu_memory_bytes(distributed_ctx) -> Optional[int]:
+    """Total memory of this rank's GPU in bytes, or ``None`` when unmeasurable.
+
+    Isolated as a seam so multi-process tests can inject a per-rank budget
+    without a real GPU. Reports total (not free) device memory because the
+    peak-memory model in ``faiss_plan`` is an absolute footprint calibrated
+    against total HBM.
+    """
+    if not torch.cuda.is_available():
+        return None
+    local_rank = getattr(distributed_ctx, "local_rank", 0) or 0
+    return int(torch.cuda.mem_get_info(local_rank)[1])
+
+
+def _min_available_memory_across_ranks(distributed_ctx) -> Optional[int]:
+    """Smallest per-GPU memory across ranks, so every rank decides identically.
+
+    Reducing with ``MIN`` both guarantees a single cross-rank budget -- ranks
+    must agree on the topology or they deadlock on mismatched collectives -- and
+    is safe on a heterogeneous cluster, where the tightest GPU sets the budget.
+    A rank that cannot measure its memory contributes ``+inf`` so it never lowers
+    the minimum; if no rank can measure, the result is ``None`` and ``auto``
+    stays on the replicated path.
+    """
+    local = _available_gpu_memory_bytes(distributed_ctx)
+    value = float("inf") if local is None else float(local)
+    device = collective_device(distributed_ctx)
+    reduced = torch.tensor([value], dtype=torch.float64, device=device)
+    dist.all_reduce(reduced, op=dist.ReduceOp.MIN)
+    result = reduced.item()
+    if result == float("inf"):
+        return None
+    return int(result)
 
 
 def pairwise_distances(
@@ -135,15 +178,59 @@ def pairwise_distances(
     # layer and expose it as ``faiss_plan_``; direct callers just get the result.
     distribution = "replicate"
     if isinstance(backend, FaissPlanConfig):
-        _n = None if isinstance(X, DataLoader) else X.shape[0]
-        _dim = None if isinstance(X, DataLoader) else X.shape[1]
+        is_tensor = not isinstance(X, DataLoader)
+        _n = X.shape[0] if is_tensor else None
+        _dim = X.shape[1] if is_tensor else None
+        requested_distribution = backend.distribution
+
+        # For 'auto' on tensor input across a real process group, measure the
+        # per-GPU memory and reduce it to one cross-rank budget so the resolver
+        # (a pure function of that budget) picks the same topology on every rank
+        # -- or refuses in lockstep. Other cases pass no budget, which keeps
+        # 'auto' on the replicated fast path.
+        _budget = None
+        if (
+            is_tensor
+            and requested_distribution == "auto"
+            and distributed_ctx is not None
+            and distributed_ctx.is_initialized
+            and dist.is_initialized()
+            and distributed_ctx.world_size > 1
+        ):
+            _budget = _min_available_memory_across_ranks(distributed_ctx)
+
         _plan, backend = _resolve_faiss_plan(
             backend,
             n_samples=_n,
             n_features=_dim,
             distributed_ctx=distributed_ctx,
+            available_memory_bytes=_budget,
         )
         distribution = _plan.distribution
+
+        if (
+            requested_distribution == "auto"
+            and distribution == "shard"
+            and _budget is not None
+            and distributed_ctx is not None
+            and distributed_ctx.rank == 0
+        ):
+            from torchdr.utils import set_logger
+
+            replicate_gb = _estimate_search_peak_bytes(_n, _dim, _n) / 1e9
+            shard_rows = (_n + distributed_ctx.world_size - 1) // (
+                distributed_ctx.world_size
+            )
+            shard_gb = _estimate_search_peak_bytes(_n, _dim, shard_rows) / 1e9
+            set_logger("torchdr").warning(
+                "distribution='auto' selected 'shard' across "
+                f"{distributed_ctx.world_size} ranks: a replicated index needs "
+                f"~{replicate_gb:.1f} GB per GPU (over the ~"
+                f"{_budget / 1e9:.1f} GB measured budget), so the exact Flat "
+                f"index is sharded to ~{shard_gb:.1f} GB per GPU. Set "
+                "distribution='replicate' or 'shard' to select the topology "
+                "explicitly and silence this notice."
+            )
 
     # The current distributed contract requires the same full input on every
     # rank, whether the FAISS index is replicated or sharded.

--- a/torchdr/distance/faiss_plan.py
+++ b/torchdr/distance/faiss_plan.py
@@ -12,6 +12,19 @@ from .faiss import FaissConfig
 _VALID_MODES = ("exact", "balanced", "fast")
 _VALID_DISTRIBUTIONS = ("auto", "replicate", "shard")
 
+# Empirical per-GPU peak-memory model for exact ``Flat`` self k-NN, calibrated
+# on the issue #301 memory-scaling sweep (single node, B200, FAISS 1.11.0).
+# Under TorchDR's distributed-input contract the input ``X`` is replicated on
+# every rank regardless of topology, so the resident footprint is: the
+# replicated input, plus a ``Flat`` index whose per-row storage matches the
+# input's, plus a fixed FAISS temporary-pool/context overhead. The calibrated
+# boundary (replicate OOMs while shard fits at the predicted crossover) held to
+# within a few percent, which the safety margin below absorbs along with the
+# unmodeled k-NN output arrays and framework scratch.
+_INPUT_BYTES_PER_ROW_PER_DIM = 4  # float32 input and Flat index storage
+_FAISS_FIXED_OVERHEAD_BYTES = int(0.66 * 1024**3)  # ~0.66 GiB pool + context
+_AUTO_MEMORY_SAFETY = 0.90  # fraction of per-GPU memory 'auto' will commit to
+
 
 @dataclass(frozen=True)
 class FaissPlanConfig:
@@ -31,8 +44,11 @@ class FaissPlanConfig:
         Multi-GPU topology. ``"replicate"`` builds the full index on every rank.
         ``"shard"`` splits an exact ``Flat`` index across ranks. The input tensor
         remains replicated under TorchDR's current distributed-input contract.
-        ``"auto"`` currently preserves the existing replicated-index strategy;
-        automatic memory-aware selection is not yet implemented.
+        ``"auto"`` keeps the replicated fast path when a full index fits the
+        measured per-GPU memory, shards an exact ``Flat`` index when it does not,
+        and raises rather than launch a run estimated to run out of memory. It
+        falls back to ``"replicate"`` for an expert (non-Flat) index, which
+        cannot be sharded.
     expert : FaissConfig, optional
         Explicit low-level override for advanced users. It cannot be combined
         with a non-default mode. The object is copied during resolution.
@@ -113,14 +129,90 @@ def _copy_config(config: FaissConfig) -> FaissConfig:
     )
 
 
+def _estimate_search_peak_bytes(
+    n_samples: int, n_features: int, index_rows: int
+) -> int:
+    """Estimate peak per-GPU bytes for exact ``Flat`` self k-NN.
+
+    See the calibrated model documented alongside the module constants: a fixed
+    FAISS overhead, plus the replicated input, plus ``index_rows`` of Flat index
+    storage. ``index_rows`` equals ``n_samples`` when the index is replicated and
+    the per-rank shard size when it is sharded.
+    """
+    row_bytes = _INPUT_BYTES_PER_ROW_PER_DIM * int(n_features)
+    input_bytes = row_bytes * int(n_samples)  # replicated on every rank
+    index_bytes = row_bytes * int(index_rows)  # Flat index storage
+    return _FAISS_FIXED_OVERHEAD_BYTES + input_bytes + index_bytes
+
+
+def _select_auto_distribution(
+    *,
+    n_samples: Optional[int],
+    n_features: Optional[int],
+    world_size: Optional[int],
+    available_memory_bytes: Optional[int],
+    safety_margin: float = _AUTO_MEMORY_SAFETY,
+) -> str:
+    """Choose ``replicate`` or ``shard`` under a per-GPU memory budget.
+
+    Returns ``"replicate"`` when a full index fits per rank (the faster path with
+    no per-query collectives), ``"shard"`` when only a sharded index fits, and
+    raises :class:`RuntimeError` rather than launch a run estimated to run out of
+    memory. When the budget or the input size is unknown, or there is a single
+    rank, it preserves the replicated fast path so callers that cannot measure
+    memory (e.g. the diagnostic ``faiss_plan_`` pass) keep the established
+    behavior.
+
+    The selection is a pure function of its arguments so every rank that is given
+    the same budget reaches the same decision; the caller is responsible for
+    reducing the budget to a single cross-rank value before calling.
+    """
+    if (
+        available_memory_bytes is None
+        or n_samples is None
+        or n_features is None
+        or world_size is None
+        or int(world_size) <= 1
+    ):
+        return "replicate"
+
+    budget = safety_margin * float(available_memory_bytes)
+    replicate_peak = _estimate_search_peak_bytes(n_samples, n_features, n_samples)
+    if replicate_peak <= budget:
+        return "replicate"
+
+    world_size = int(world_size)
+    shard_rows = (int(n_samples) + world_size - 1) // world_size
+    shard_peak = _estimate_search_peak_bytes(n_samples, n_features, shard_rows)
+    if shard_peak <= budget:
+        return "shard"
+
+    raise RuntimeError(
+        "[TorchDR] distribution='auto' estimates ~"
+        f"{replicate_peak / 1e9:.1f} GB per GPU for a replicated index and ~"
+        f"{shard_peak / 1e9:.1f} GB even when sharded across {world_size} ranks, "
+        f"but only ~{budget / 1e9:.1f} GB is safely usable per GPU. Reduce the "
+        "dataset, add ranks, or use an approximate expert index. 'auto' refuses "
+        "rather than start a run that is estimated to run out of memory."
+    )
+
+
 def _resolve_faiss_plan(
     config: FaissPlanConfig,
     *,
     n_samples: Optional[int] = None,
     n_features: Optional[int] = None,
     distributed_ctx=None,
+    available_memory_bytes: Optional[int] = None,
 ) -> Tuple[_FaissPlan, FaissConfig]:
-    """Resolve user intent into diagnostics and a fresh low-level config."""
+    """Resolve user intent into diagnostics and a fresh low-level config.
+
+    ``available_memory_bytes`` is the single cross-rank per-GPU budget used to
+    resolve ``distribution='auto'``. It is ``None`` on the diagnostic path (no
+    measurement), which keeps ``auto`` on the replicated fast path; the
+    distributed dispatcher passes a measured, reduced value so ``auto`` can
+    select sharding or refuse an over-budget run.
+    """
     if config.expert is not None:
         resolved = _copy_config(config.expert)
         mode = "expert"
@@ -139,6 +231,8 @@ def _resolve_faiss_plan(
     training_size = 0 if resolved.index_type == "Flat" else None
     if not is_distributed or world_size <= 1:
         distribution = "single"
+    elif config.distribution == "replicate":
+        distribution = "replicate"
     elif config.distribution == "shard":
         if resolved.index_type != "Flat":
             raise NotImplementedError(
@@ -147,10 +241,20 @@ def _resolve_faiss_plan(
                 "approximate index."
             )
         distribution = "shard"
-    else:
-        # Automatic memory-aware selection needs a trustworthy total peak-memory
-        # estimate. Until that exists, preserve the established fast path.
+    elif resolved.index_type != "Flat":
+        # 'auto' can only shard exact Flat indexes; an expert approximate index
+        # stays replicated because sharding it is not implemented.
         distribution = "replicate"
+    else:
+        # 'auto': pick the fastest topology that fits the measured per-GPU
+        # budget, or refuse. Without a budget (diagnostic pass) this is a no-op
+        # that keeps the established replicated fast path.
+        distribution = _select_auto_distribution(
+            n_samples=n_samples,
+            n_features=n_features,
+            world_size=world_size,
+            available_memory_bytes=available_memory_bytes,
+        )
 
     index_memory_bytes = None
     if training_size == 0 and n_samples is not None and n_features is not None:

--- a/torchdr/tests/test_distributed_faiss_shard.py
+++ b/torchdr/tests/test_distributed_faiss_shard.py
@@ -17,7 +17,12 @@ import torch
 import torch.distributed as dist
 
 from torchdr.distance import FaissConfig, FaissPlanConfig, pairwise_distances
+from torchdr.distance import base as distance_base
 from torchdr.distance.faiss import sharded_pairwise_distances_faiss
+from torchdr.distance.faiss_plan import (
+    _AUTO_MEMORY_SAFETY,
+    _estimate_search_peak_bytes,
+)
 from torchdr.distributed import (
     DistributedContext,
     init_distributed,
@@ -154,3 +159,138 @@ class TestShardedSearch:
         start, end = context.compute_chunk_bounds(N_SAMPLES)
         assert torch.equal(sh_I, ref_I[start:end])
         assert torch.allclose(sh_D, ref_D[start:end], rtol=1e-4, atol=1e-4)
+
+
+def _budget_forcing(target, world_size, n_samples=N_SAMPLES, n_features=N_FEATURES):
+    """Per-GPU 'available' bytes that drives ``auto`` into ``target``.
+
+    Computed from the peak-memory model the selector uses so the tests track the
+    model rather than a hard-coded byte count.
+    """
+    replicate_peak = _estimate_search_peak_bytes(n_samples, n_features, n_samples)
+    shard_rows = (n_samples + world_size - 1) // world_size
+    shard_peak = _estimate_search_peak_bytes(n_samples, n_features, shard_rows)
+    if target == "replicate":
+        return int(replicate_peak / _AUTO_MEMORY_SAFETY) + 10**9
+    if target == "shard":
+        return int((shard_peak + replicate_peak) / 2 / _AUTO_MEMORY_SAFETY)
+    if target == "refuse":
+        return int(shard_peak / _AUTO_MEMORY_SAFETY) - 10**6
+    raise ValueError(target)
+
+
+def _auto(data, context, exclude_diag=False):
+    return pairwise_distances(
+        data,
+        k=K,
+        metric="sqeuclidean",
+        backend=FaissPlanConfig(distribution="auto"),
+        exclude_diag=exclude_diag,
+        return_indices=True,
+        distributed_ctx=context,
+    )
+
+
+def _spy_on_shard(monkeypatch):
+    """Count how often this rank routes through the sharded search."""
+    calls = {"n": 0}
+    real = distance_base.sharded_pairwise_distances_faiss
+
+    def counting(*args, **kwargs):
+        calls["n"] += 1
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(distance_base, "sharded_pairwise_distances_faiss", counting)
+    return calls
+
+
+def _all_gather_int(value, world_size):
+    local = torch.tensor([int(value)], dtype=torch.int64)
+    gathered = [torch.zeros(1, dtype=torch.int64) for _ in range(world_size)]
+    dist.all_gather(gathered, local)
+    return [int(t.item()) for t in gathered]
+
+
+class TestAutoDistribution:
+    """End-to-end memory-aware ``distribution='auto'`` selection (issue #301).
+
+    The per-GPU memory read is replaced by an injected budget so the selection
+    logic -- which normally only fires on a real multi-GPU node -- is exercised
+    on CPU/Gloo CI. Every case still runs the real process group and the real
+    exact-search paths, and compares against single-process Flat neighbors.
+    """
+
+    def test_auto_replicates_when_memory_is_ample(self, data, context, monkeypatch):
+        # A budget that fits a full index keeps the fast replicated path: no rank
+        # enters the sharded search, and every chunk still matches the reference.
+        monkeypatch.setattr(
+            distance_base,
+            "_available_gpu_memory_bytes",
+            lambda ctx: _budget_forcing("replicate", context.world_size),
+        )
+        calls = _spy_on_shard(monkeypatch)
+        ref_D, ref_I = _reference(data, K, "sqeuclidean")
+        au_D, au_I = _auto(data, context)
+        start, end = context.compute_chunk_bounds(N_SAMPLES)
+        assert torch.equal(au_I, ref_I[start:end])
+        assert torch.allclose(au_D, ref_D[start:end])
+        assert (
+            _all_gather_int(calls["n"], context.world_size) == [0] * context.world_size
+        )
+
+    def test_auto_shards_when_replication_exceeds_memory(
+        self, data, context, monkeypatch
+    ):
+        # A budget too small for a full index but large enough sharded routes every
+        # rank through the sharded search and still reproduces the exact neighbors.
+        monkeypatch.setattr(
+            distance_base,
+            "_available_gpu_memory_bytes",
+            lambda ctx: _budget_forcing("shard", context.world_size),
+        )
+        calls = _spy_on_shard(monkeypatch)
+        ref_D, ref_I = _reference(data, K, "sqeuclidean")
+        au_D, au_I = _auto(data, context)
+        start, end = context.compute_chunk_bounds(N_SAMPLES)
+        assert torch.equal(au_I, ref_I[start:end])
+        assert torch.allclose(au_D, ref_D[start:end])
+        assert (
+            _all_gather_int(calls["n"], context.world_size) == [1] * context.world_size
+        )
+
+    def test_auto_decision_is_consistent_across_divergent_budgets(
+        self, data, context, monkeypatch
+    ):
+        # Rank 0 alone would replicate (ample budget); the others would shard. The
+        # cross-rank MIN reduce forces one shared decision -- had the ranks decided
+        # locally, some would launch the sharded collectives while others would not
+        # and the run would deadlock. Reaching the assertions at all proves the
+        # decision was uniform; the spy confirms every rank took the sharded path.
+        def divergent(ctx):
+            target = "replicate" if ctx.rank == 0 else "shard"
+            return _budget_forcing(target, context.world_size)
+
+        monkeypatch.setattr(distance_base, "_available_gpu_memory_bytes", divergent)
+        calls = _spy_on_shard(monkeypatch)
+        ref_D, ref_I = _reference(data, K, "sqeuclidean")
+        au_D, au_I = _auto(data, context)
+        start, end = context.compute_chunk_bounds(N_SAMPLES)
+        assert torch.equal(au_I, ref_I[start:end])
+        assert torch.allclose(au_D, ref_D[start:end])
+        assert (
+            _all_gather_int(calls["n"], context.world_size) == [1] * context.world_size
+        )
+
+    def test_auto_refuses_consistently_when_nothing_fits(
+        self, data, context, monkeypatch
+    ):
+        # When even a sharded index is over budget, every rank must raise -- not
+        # hang -- so the failure surfaces in lockstep after the shared reduce.
+        monkeypatch.setattr(
+            distance_base,
+            "_available_gpu_memory_bytes",
+            lambda ctx: _budget_forcing("refuse", context.world_size),
+        )
+        with pytest.raises(RuntimeError, match="run out of memory"):
+            _auto(data, context)
+        dist.barrier()

--- a/torchdr/tests/test_faiss_plan.py
+++ b/torchdr/tests/test_faiss_plan.py
@@ -13,7 +13,12 @@ from torch.utils.data import DataLoader, TensorDataset
 
 from torchdr import EntropicAffinity, TSNE
 from torchdr.distance import FaissConfig, FaissPlanConfig, pairwise_distances
-from torchdr.distance.faiss_plan import _resolve_faiss_plan
+from torchdr.distance.faiss_plan import (
+    _AUTO_MEMORY_SAFETY,
+    _estimate_search_peak_bytes,
+    _resolve_faiss_plan,
+    _select_auto_distribution,
+)
 from torchdr.utils import faiss
 
 
@@ -35,6 +40,38 @@ class _FakeContext:
         self.world_size = world_size
         self.rank = 0
         self.local_rank = 0
+
+
+def _budget_forcing(target, *, n_samples, n_features, world_size):
+    """Per-GPU 'available' bytes that drives ``auto`` into ``target``.
+
+    Derived from the same peak-memory model the selector uses, so the tests stay
+    correct if the model constants change. The ``assert`` re-checks the crafted
+    budget against the pure selector, failing at setup rather than misattributing
+    a wrong branch.
+    """
+    replicate_peak = _estimate_search_peak_bytes(n_samples, n_features, n_samples)
+    shard_rows = (n_samples + world_size - 1) // world_size
+    shard_peak = _estimate_search_peak_bytes(n_samples, n_features, shard_rows)
+    if target == "replicate":
+        available = int(replicate_peak / _AUTO_MEMORY_SAFETY) + 10**9
+    elif target == "shard":
+        available = int((shard_peak + replicate_peak) / 2 / _AUTO_MEMORY_SAFETY)
+    elif target == "refuse":
+        available = int(shard_peak / _AUTO_MEMORY_SAFETY) - 10**6
+    else:  # pragma: no cover - test wiring error
+        raise ValueError(target)
+    if target != "refuse":
+        assert (
+            _select_auto_distribution(
+                n_samples=n_samples,
+                n_features=n_features,
+                world_size=world_size,
+                available_memory_bytes=available,
+            )
+            == target
+        )
+    return available
 
 
 @pytest.fixture(scope="module")
@@ -116,7 +153,10 @@ def test_shard_without_a_group_resolves_to_single():
     assert plan.distribution == "single"
 
 
-def test_auto_preserves_replication_until_memory_selection_is_implemented():
+def test_auto_without_a_budget_preserves_replication():
+    # The diagnostic ``faiss_plan_`` pass cannot measure memory, so it passes no
+    # budget; auto must then keep the established replicated fast path rather than
+    # guess. The distributed dispatcher supplies a measured budget separately.
     ctx = _FakeContext(world_size=2)
     plan, _ = _resolve_faiss_plan(
         FaissPlanConfig(distribution="auto"),
@@ -125,6 +165,81 @@ def test_auto_preserves_replication_until_memory_selection_is_implemented():
         distributed_ctx=ctx,
     )
     assert plan.distribution == "replicate"
+
+
+@pytest.mark.parametrize("world_size", [2, 4])
+def test_select_auto_topology_follows_the_memory_budget(world_size):
+    kw = dict(n_samples=100_000, n_features=128, world_size=world_size)
+    assert _select_auto_distribution(available_memory_bytes=None, **kw) == "replicate"
+    ample = _budget_forcing("replicate", **kw)
+    assert _select_auto_distribution(available_memory_bytes=ample, **kw) == "replicate"
+    tight = _budget_forcing("shard", **kw)
+    assert _select_auto_distribution(available_memory_bytes=tight, **kw) == "shard"
+
+
+def test_select_auto_refuses_when_neither_topology_fits():
+    kw = dict(n_samples=100_000, n_features=128, world_size=2)
+    starved = _budget_forcing("refuse", **kw)
+    with pytest.raises(RuntimeError, match="run out of memory"):
+        _select_auto_distribution(available_memory_bytes=starved, **kw)
+
+
+def test_select_auto_keeps_replication_for_a_single_rank():
+    # One rank cannot shard, so even a starving budget stays replicated; the
+    # single-process path never launches the sharded collectives.
+    assert (
+        _select_auto_distribution(
+            n_samples=100_000,
+            n_features=128,
+            world_size=1,
+            available_memory_bytes=1,
+        )
+        == "replicate"
+    )
+
+
+def test_resolve_auto_shards_under_a_measured_budget():
+    ctx = _FakeContext(world_size=4)
+    budget = _budget_forcing("shard", n_samples=100_000, n_features=128, world_size=4)
+    plan, resolved = _resolve_faiss_plan(
+        FaissPlanConfig(distribution="auto"),
+        n_samples=100_000,
+        n_features=128,
+        distributed_ctx=ctx,
+        available_memory_bytes=budget,
+    )
+    assert plan.distribution == "shard"
+    assert resolved.index_type == "Flat"
+    # The reported index footprint follows the sharded, not the replicated, size.
+    assert plan.index_memory_bytes == (100_000 // 4) * 128 * 4
+
+
+def test_resolve_auto_refuses_an_over_budget_run():
+    ctx = _FakeContext(world_size=2)
+    budget = _budget_forcing("refuse", n_samples=100_000, n_features=128, world_size=2)
+    with pytest.raises(RuntimeError, match="run out of memory"):
+        _resolve_faiss_plan(
+            FaissPlanConfig(distribution="auto"),
+            n_samples=100_000,
+            n_features=128,
+            distributed_ctx=ctx,
+            available_memory_bytes=budget,
+        )
+
+
+def test_resolve_auto_expert_index_stays_replicated_instead_of_refusing():
+    # An expert (non-Flat) index cannot be sharded, so auto keeps it replicated
+    # even under a budget that would otherwise shard or refuse an exact index.
+    ctx = _FakeContext(world_size=2)
+    plan, resolved = _resolve_faiss_plan(
+        FaissPlanConfig(expert=FaissConfig(index_type="IVF")),
+        n_samples=100_000,
+        n_features=128,
+        distributed_ctx=ctx,
+        available_memory_bytes=1,
+    )
+    assert plan.distribution == "replicate"
+    assert resolved.index_type == "IVF"
 
 
 def test_explicit_shard_rejects_unsupported_expert_index():


### PR DESCRIPTION
## Summary

Implements memory-aware `distribution="auto"` for distributed FAISS k-NN (issue #301) — the last unimplemented routing item on the roadmap. Until now `auto` was a stub that always resolved to `replicate`.

- On tensor input across a real process group, `auto` measures per-GPU memory, reduces it with `MIN` to a single cross-rank budget, and picks the topology that fits: the replicated fast path when a full exact `Flat` index fits, a sharded exact `Flat` index when it does not, and a hard refusal (raise) rather than launching a run estimated to run out of memory.
- The decision is a pure function of the reduced budget, so every rank decides identically and never deadlocks on mismatched collectives. `MIN` also makes the choice safe on heterogeneous GPUs (the tightest GPU sets the budget).
- Only `auto` triggers the guard. Explicit `replicate`/`shard` are unchanged. Expert (non-`Flat`) indexes stay replicated because sharding them is unimplemented.
- The diagnostic `faiss_plan_` pass measures nothing and keeps the established replicated default, so affinity/estimator behavior is unchanged.
- When `auto` overrides to `shard`, rank 0 logs the decision and the per-GPU estimate; over-budget refusal raises with the same numbers.
- Peak-memory model: fixed FAISS overhead + replicated input + `Flat` index storage, calibrated on the issue #301 memory-scaling sweep; `auto` commits to at most 90% of per-GPU memory.

## Verdict: APPROVE

The selector closes issue #301's automatic-selection criterion. It is exact-search-preserving (only ever chooses between two exact `Flat` topologies), opt-in in spirit (explicit choices are respected), deterministic across ranks, and fails loud rather than silently OOM.

## Decision table (model-predicted, calibrated on #301 sweep)

Self k-NN, d=768, 2× B200 (measured 191.5 GB/GPU; 90% budget ≈ 172 GB):

| n | replicate peak | shard peak (2 GPUs) | `auto` decision |
|---|---|---|---|
| 10M | 62 GB | — | replicate (fits) |
| 30M | 185 GB | 139 GB | shard (replicate over budget) |
| 60M | 369 GB | 277 GB | refuse (replicated input alone 184 GB > budget) |

## Test plan

- Pure unit tests (`test_faiss_plan.py`): selector replicate/shard/refuse, single-rank and no-budget defaults, resolver budget path, and expert-index fallback — 24 passed.
- Real-process Gloo tests (`test_distributed_faiss_shard.py::TestAutoDistribution`) at 2 and 4 processes: ample→replicate, tight→shard, divergent per-rank budgets→consistent shard (no deadlock), starved→consistent raise — 11 passed each.
- Non-vacuity break demos: flipping the cross-rank reduce `MIN`→`MAX` fails only the consistency test; making the selector ignore the budget fails shard/refuse/consistency while the ample-budget replicate case still passes.
- 2× B200 / NCCL probe: real `mem_get_info` read = 191.5 GB, cross-rank `MIN` over NCCL, and both `auto`→replicate and forced `auto`→shard return exact neighbors.
- Regression: `pre-commit` clean; distance/utils/dataloader/faiss-runtime suites 232 passed, 0 failed.
