### PR TITLE
[Fix] Propagate local FAISS errors across sharded search

### DIFF
--- a/torchdr/distance/faiss.py
+++ b/torchdr/distance/faiss.py
@@ -543,9 +543,12 @@ def sharded_pairwise_distances_faiss(
     global top-k. The result matches replicated Flat search for that rank's
     query chunk.
 
-    Only ``broadcast`` and ``all_gather`` collectives are used, so the same code
-    path runs on the Gloo (CPU) and NCCL (GPU) backends. Peak memory for the
-    merge is bounded by one query sub-batch, not by the dataset.
+    Only ``broadcast``, ``all_reduce``, and ``all_gather`` collectives are used,
+    so the same code path runs on the Gloo (CPU) and NCCL (GPU) backends. The
+    ``all_reduce`` votes on a per-batch success flag so that a local search
+    failing on one rank stops every rank together instead of leaving the
+    survivors to hang on the ``all_gather``. Peak memory for the merge is bounded
+    by one query sub-batch, not by the dataset.
 
     Only exact ``Flat`` search is supported here; approximate sharded indexes,
     which need a shared trained quantizer, are a separate follow-up.
@@ -681,16 +684,44 @@ def sharded_pairwise_distances_faiss(
 
             queries = buf.to(device=index_device, dtype=torch.float32).contiguous()
             queries_faiss = queries if faiss_torch_interop else queries.cpu().numpy()
-            with faiss_device_scope(faiss_device):
-                local_D, local_I = index.search(queries_faiss, k_search)
-            if not isinstance(local_D, torch.Tensor):
-                local_D = torch.from_numpy(local_D)
-                local_I = torch.from_numpy(local_I)
-            local_D = local_D.to(device=comm_device, dtype=torch.float32)
-            local_I = local_I.to(device=comm_device, dtype=torch.long)
-            # Map local FAISS ids to global database ids; -1 marks a missing
-            # neighbor (k_search larger than this shard) and stays -1.
-            global_I = torch.where(local_I >= 0, local_I + db_offset, local_I)
+            # A local search (or the copy of its result to the comm device) that
+            # raises on one rank would otherwise drop that rank out of the
+            # all_gather below while the others block on it forever. Guard the
+            # local work and vote on a shared success flag first, mirroring the
+            # trained-index broadcast in ``_train_index``: a rank that fails still
+            # reaches the collective carrying the failure, so every rank raises
+            # together instead of the survivors hanging.
+            searched = True
+            reason = ""
+            try:
+                with faiss_device_scope(faiss_device):
+                    local_D, local_I = index.search(queries_faiss, k_search)
+                if not isinstance(local_D, torch.Tensor):
+                    local_D = torch.from_numpy(local_D)
+                    local_I = torch.from_numpy(local_I)
+                local_D = local_D.to(device=comm_device, dtype=torch.float32)
+                local_I = local_I.to(device=comm_device, dtype=torch.long)
+                # Map local FAISS ids to global database ids; -1 marks a missing
+                # neighbor (k_search larger than this shard) and stays -1.
+                global_I = torch.where(local_I >= 0, local_I + db_offset, local_I)
+            except Exception as error:  # reported on every rank, not just this one
+                searched = False
+                reason = f"{type(error).__name__}: {error}"
+
+            # MIN drops to 0 as soon as any rank failed; every rank runs this
+            # reduce regardless, so the failure is seen everywhere before the
+            # all_gather that a failed rank could not join.
+            ok = torch.tensor(
+                [1 if searched else 0], dtype=torch.int64, device=comm_device
+            )
+            dist.all_reduce(ok, op=dist.ReduceOp.MIN)
+            if int(ok.item()) == 0:
+                raise RuntimeError(
+                    "[TorchDR] ERROR : a rank failed its local FAISS search over "
+                    "its database shard; every rank stops together so the "
+                    "survivors do not hang on the following all_gather."
+                    + (f" This rank's error was {reason}." if reason else "")
+                )
 
             D_parts = [torch.empty_like(local_D) for _ in range(world_size)]
             I_parts = [torch.empty_like(global_I) for _ in range(world_size)]

--- a/torchdr/distance/faiss.py
+++ b/torchdr/distance/faiss.py
@@ -667,6 +667,7 @@ def sharded_pairwise_distances_faiss(
     largest = metric == "angular"
     result_D: List[torch.Tensor] = []
     result_I: List[torch.Tensor] = []
+    search_ok = torch.ones(1, dtype=torch.int64, device=comm_device)
 
     # Fixed source order 0..world_size-1 and a shared batch size make every rank
     # issue the same broadcast/all_gather sequence, so the collectives never
@@ -682,8 +683,6 @@ def sharded_pairwise_distances_faiss(
                 buf.copy_(rows.detach().to(device=comm_device, dtype=torch.float32))
             dist.broadcast(buf, src=source)
 
-            queries = buf.to(device=index_device, dtype=torch.float32).contiguous()
-            queries_faiss = queries if faiss_torch_interop else queries.cpu().numpy()
             # A local search (or the copy of its result to the comm device) that
             # raises on one rank would otherwise drop that rank out of the
             # all_gather below while the others block on it forever. Guard the
@@ -694,6 +693,10 @@ def sharded_pairwise_distances_faiss(
             searched = True
             reason = ""
             try:
+                queries = buf.to(device=index_device, dtype=torch.float32).contiguous()
+                queries_faiss = (
+                    queries if faiss_torch_interop else queries.cpu().numpy()
+                )
                 with faiss_device_scope(faiss_device):
                     local_D, local_I = index.search(queries_faiss, k_search)
                 if not isinstance(local_D, torch.Tensor):
@@ -711,15 +714,12 @@ def sharded_pairwise_distances_faiss(
             # MIN drops to 0 as soon as any rank failed; every rank runs this
             # reduce regardless, so the failure is seen everywhere before the
             # all_gather that a failed rank could not join.
-            ok = torch.tensor(
-                [1 if searched else 0], dtype=torch.int64, device=comm_device
-            )
-            dist.all_reduce(ok, op=dist.ReduceOp.MIN)
-            if int(ok.item()) == 0:
+            search_ok.fill_(searched)
+            dist.all_reduce(search_ok, op=dist.ReduceOp.MIN)
+            if not search_ok.item():
                 raise RuntimeError(
-                    "[TorchDR] ERROR : a rank failed its local FAISS search over "
-                    "its database shard; every rank stops together so the "
-                    "survivors do not hang on the following all_gather."
+                    "[TorchDR] ERROR : a rank failed its local FAISS search; "
+                    "all ranks stopped before gathering incomplete results."
                     + (f" This rank's error was {reason}." if reason else "")
                 )
 

--- a/torchdr/tests/test_distributed_faiss_shard.py
+++ b/torchdr/tests/test_distributed_faiss_shard.py
@@ -154,3 +154,57 @@ class TestShardedSearch:
         start, end = context.compute_chunk_bounds(N_SAMPLES)
         assert torch.equal(sh_I, ref_I[start:end])
         assert torch.allclose(sh_D, ref_D[start:end], rtol=1e-4, atol=1e-4)
+
+
+class TestShardedSearchFailurePropagation:
+    """A local search that fails on one rank must stop every rank, not hang.
+
+    This exercises real TorchDR-level failure propagation. One rank's FAISS
+    index is wrapped so ``search`` raises a genuine exception inside the guarded
+    region, exactly as a GPU out-of-memory or an internal FAISS error would.
+    Every collective still runs for real: no collective is mocked and no process
+    group is torn down. Without the shared success flag the surviving ranks would
+    block forever on the following ``all_gather``; with it, all ranks raise
+    together. The workflow's wall-clock timeout fails the run if any rank hangs
+    instead.
+    """
+
+    def test_local_search_failure_raises_everywhere(self, data, context, monkeypatch):
+        import torchdr.distance.faiss as faiss_mod
+
+        failing_rank = context.world_size - 1
+        real_create_index = faiss_mod._create_index
+
+        class _FailingSearchIndex:
+            """Delegates to a real FAISS index but raises inside ``search``."""
+
+            def __init__(self, inner):
+                self._inner = inner
+
+            def add(self, x):
+                return self._inner.add(x)
+
+            def search(self, *args, **kwargs):
+                raise RuntimeError("injected local FAISS search failure")
+
+            def __getattr__(self, name):
+                return getattr(self._inner, name)
+
+        def faulty_create_index(*args, **kwargs):
+            index = real_create_index(*args, **kwargs)
+            if context.rank == failing_rank:
+                return _FailingSearchIndex(index)
+            return index
+
+        monkeypatch.setattr(faiss_mod, "_create_index", faulty_create_index)
+
+        # Every rank -- the one whose search raises and the ones whose search
+        # succeeds -- must surface the failure rather than block on all_gather.
+        with pytest.raises(RuntimeError):
+            sharded_pairwise_distances_faiss(
+                data, k=K, metric="sqeuclidean", distributed_ctx=context
+            )
+
+        # Reaching the barrier on every rank proves the group is still lockstep:
+        # no rank was left waiting on a collective the failed rank never issued.
+        dist.barrier()

--- a/torchdr/tests/test_distributed_faiss_shard.py
+++ b/torchdr/tests/test_distributed_faiss_shard.py
@@ -157,17 +157,7 @@ class TestShardedSearch:
 
 
 class TestShardedSearchFailurePropagation:
-    """A local search that fails on one rank must stop every rank, not hang.
-
-    This exercises real TorchDR-level failure propagation. One rank's FAISS
-    index is wrapped so ``search`` raises a genuine exception inside the guarded
-    region, exactly as a GPU out-of-memory or an internal FAISS error would.
-    Every collective still runs for real: no collective is mocked and no process
-    group is torn down. Without the shared success flag the surviving ranks would
-    block forever on the following ``all_gather``; with it, all ranks raise
-    together. The workflow's wall-clock timeout fails the run if any rank hangs
-    instead.
-    """
+    """A local search failure stops every rank before result gathering."""
 
     def test_local_search_failure_raises_everywhere(self, data, context, monkeypatch):
         import torchdr.distance.faiss as faiss_mod
@@ -176,8 +166,6 @@ class TestShardedSearchFailurePropagation:
         real_create_index = faiss_mod._create_index
 
         class _FailingSearchIndex:
-            """Delegates to a real FAISS index but raises inside ``search``."""
-
             def __init__(self, inner):
                 self._inner = inner
 
@@ -198,13 +186,10 @@ class TestShardedSearchFailurePropagation:
 
         monkeypatch.setattr(faiss_mod, "_create_index", faulty_create_index)
 
-        # Every rank -- the one whose search raises and the ones whose search
-        # succeeds -- must surface the failure rather than block on all_gather.
-        with pytest.raises(RuntimeError):
+        with pytest.raises(RuntimeError, match="a rank failed its local FAISS search"):
             sharded_pairwise_distances_faiss(
                 data, k=K, metric="sqeuclidean", distributed_ctx=context
             )
 
-        # Reaching the barrier on every rank proves the group is still lockstep:
-        # no rank was left waiting on a collective the failed rank never issued.
+        # The process group remains usable after the symmetric failure.
         dist.barrier()


### PR DESCRIPTION
### Summary

The sharded exact-search loop previously let a recoverable local FAISS error
remove one rank before the following result gather, leaving its peers blocked.
This change catches query conversion, local search, and result conversion,
then performs a one-scalar success vote before gathering candidates. Every rank
therefore raises together instead of consuming incomplete neighbors or hanging.

The status tensor is allocated before the loop and reused, which avoids a fresh
allocation while handling a possible memory error. Explicit replicated search
and successful sharded-search results are unchanged.

This addresses the recoverable local-search-failure part of #301. It does not
claim to recover from a hard process death or a failure inside the collective
itself; those remain process-group/runtime concerns.

### Review verdict

Approve. Unlike the closed test-only attempt, this adds an actual production
protocol and tests it without mocking collectives or destroying the process
group.

### Evidence

- Gloo/CPU: full sharded-search module passed with two and four processes.
- NCCL/2×B200 with GPU FAISS: all 8 sharded-search tests passed, including the
  injected one-rank failure and a subsequent barrier.
- No-fix fault injection hangs at the result gather under both Gloo and NCCL.
- NCCL communication-only microbenchmark: the vote adds about 0.05 ms per
  query batch (0.165–0.170 ms versus 0.119–0.122 ms for the existing broadcast
  and two gathers). This is a roughly 39–42% increase in communication-only
  latency; exact FAISS search cost was intentionally excluded from that number.
- Pre-commit passed on both changed files.

