### PR TITLE
[Fix] Match UMAP neighbor-count semantics

### DIFF
--- a/torchdr/affinity/knn_normalized.py
+++ b/torchdr/affinity/knn_normalized.py
@@ -5,7 +5,7 @@
 #
 # License: BSD 3-Clause License
 
-from typing import Optional, Tuple, Union
+from typing import Tuple, Union
 
 import torch
 
@@ -86,11 +86,6 @@ class SelfTuningAffinity(LogAffinity):
     _pre_processed : bool, optional
         If True, assumes inputs are already torch tensors on the correct device
         and skips the `to_torch` conversion. Default is False.
-    _n_neighbors_search : int, optional
-        Number of non-self neighbors to retrieve in sparse mode. This internal
-        override is used by :class:`~torchdr.UMAP` because its public
-        ``n_neighbors`` follows umap-learn's convention and includes self,
-        while TorchDR's distance backends remove self before returning results.
     """
 
     def __init__(
@@ -350,8 +345,11 @@ class UMAPAffinity(SparseAffinity):
 
     Parameters
     ----------
-    n_neighbors : float, optional
-        Number of effective nearest neighbors to consider. Similar to the perplexity.
+    n_neighbors : int, optional
+        UMAP neighbor count, including the sample itself during fit. TorchDR's
+        distance backends remove self-neighbors, so sparse mode retrieves
+        ``n_neighbors - 1`` other samples while retaining ``log2(n_neighbors)``
+        as the bandwidth target, matching umap-learn.
     max_iter : int, optional
         Maximum number of iterations for the root search.
     sparsity : bool, optional
@@ -390,7 +388,7 @@ class UMAPAffinity(SparseAffinity):
 
     def __init__(
         self,
-        n_neighbors: float = 30,
+        n_neighbors: int = 30,
         max_iter: int = 1000,
         sparsity: bool = True,
         metric: str = "sqeuclidean",
@@ -402,10 +400,8 @@ class UMAPAffinity(SparseAffinity):
         symmetrize: bool = True,
         distributed: Union[bool, str] = "auto",
         _pre_processed: bool = False,
-        _n_neighbors_search: Optional[int] = None,
     ):
         self.n_neighbors = n_neighbors
-        self._n_neighbors_search = _n_neighbors_search
         self.max_iter = max_iter
         self.symmetrize = symmetrize
 
@@ -439,14 +435,12 @@ class UMAPAffinity(SparseAffinity):
         """
         n_samples_in = self._get_n_samples(X)
         n_neighbors = check_neighbor_param(self.n_neighbors, n_samples_in)
-        n_neighbors_search = check_neighbor_param(
-            self._n_neighbors_search
-            if self._n_neighbors_search is not None
-            else n_neighbors,
-            n_samples_in,
-        )
 
         if self.sparsity:
+            # umap-learn's fit-time k-NN array contains self in its first column
+            # and skips that column when constructing memberships. TorchDR's
+            # distance backends already remove self, so request one fewer row.
+            n_neighbors_search = n_neighbors - 1
             if self.verbose:
                 self.logger.info(
                     f"Sparsity mode enabled, computing {n_neighbors_search} nearest "

--- a/torchdr/affinity/knn_normalized.py
+++ b/torchdr/affinity/knn_normalized.py
@@ -5,7 +5,7 @@
 #
 # License: BSD 3-Clause License
 
-from typing import Tuple, Union
+from typing import Optional, Tuple, Union
 
 import torch
 
@@ -86,6 +86,11 @@ class SelfTuningAffinity(LogAffinity):
     _pre_processed : bool, optional
         If True, assumes inputs are already torch tensors on the correct device
         and skips the `to_torch` conversion. Default is False.
+    _n_neighbors_search : int, optional
+        Number of non-self neighbors to retrieve in sparse mode. This internal
+        override is used by :class:`~torchdr.UMAP` because its public
+        ``n_neighbors`` follows umap-learn's convention and includes self,
+        while TorchDR's distance backends remove self before returning results.
     """
 
     def __init__(
@@ -397,8 +402,10 @@ class UMAPAffinity(SparseAffinity):
         symmetrize: bool = True,
         distributed: Union[bool, str] = "auto",
         _pre_processed: bool = False,
+        _n_neighbors_search: Optional[int] = None,
     ):
         self.n_neighbors = n_neighbors
+        self._n_neighbors_search = _n_neighbors_search
         self.max_iter = max_iter
         self.symmetrize = symmetrize
 
@@ -432,13 +439,22 @@ class UMAPAffinity(SparseAffinity):
         """
         n_samples_in = self._get_n_samples(X)
         n_neighbors = check_neighbor_param(self.n_neighbors, n_samples_in)
+        n_neighbors_search = check_neighbor_param(
+            self._n_neighbors_search
+            if self._n_neighbors_search is not None
+            else n_neighbors,
+            n_samples_in,
+        )
 
         if self.sparsity:
             if self.verbose:
                 self.logger.info(
-                    f"Sparsity mode enabled, computing {n_neighbors} nearest neighbors..."
+                    f"Sparsity mode enabled, computing {n_neighbors_search} nearest "
+                    "neighbors..."
                 )
-            C_, indices = self._distance_matrix(X, k=n_neighbors, return_indices=True)
+            C_, indices = self._distance_matrix(
+                X, k=n_neighbors_search, return_indices=True
+            )
         else:
             C_, indices = self._distance_matrix(X, return_indices=True)
 

--- a/torchdr/neighbor_embedding/umap.py
+++ b/torchdr/neighbor_embedding/umap.py
@@ -61,8 +61,11 @@ class UMAP(NegativeSamplingNeighborEmbedding):
 
     Parameters
     ----------
-    n_neighbors : float, optional
-        Number of nearest neighbors.
+    n_neighbors : int, optional
+        UMAP neighbor count. During fit this includes the sample itself, so the
+        fuzzy graph uses ``n_neighbors - 1`` other samples, matching umap-learn.
+        Transform is bipartite and therefore uses ``n_neighbors`` training
+        samples because a new query has no self-neighbor in the training set.
     n_components : int, optional
         Dimension of the embedding space.
     min_dist : float, optional
@@ -142,7 +145,7 @@ class UMAP(NegativeSamplingNeighborEmbedding):
 
     def __init__(
         self,
-        n_neighbors: float = 30,
+        n_neighbors: int = 30,
         n_components: int = 2,
         min_dist: float = 0.1,
         spread: float = 1.0,
@@ -201,7 +204,6 @@ class UMAP(NegativeSamplingNeighborEmbedding):
             sparsity=self.sparsity,
             compile=compile,
             distributed=distributed,
-            _n_neighbors_search=int(n_neighbors) - 1,
         )
 
         super().__init__(

--- a/torchdr/neighbor_embedding/umap.py
+++ b/torchdr/neighbor_embedding/umap.py
@@ -201,6 +201,7 @@ class UMAP(NegativeSamplingNeighborEmbedding):
             sparsity=self.sparsity,
             compile=compile,
             distributed=distributed,
+            _n_neighbors_search=int(n_neighbors) - 1,
         )
 
         super().__init__(

--- a/torchdr/tests/test_affinity.py
+++ b/torchdr/tests/test_affinity.py
@@ -356,6 +356,25 @@ def test_umap_data_affinity(dtype, metric, sparsity, backend, compile=False):
     check_nonnegativity(P)
 
 
+def test_umap_affinity_can_separate_target_and_search_neighbor_counts():
+    """UMAP can include self in its public count while searching non-self rows."""
+    X, _ = toy_dataset(32, "float32")
+    affinity = UMAPAffinity(
+        n_neighbors=15,
+        _n_neighbors_search=14,
+        symmetrize=False,
+        device="cpu",
+        backend=None,
+        sparsity=True,
+    )
+
+    _, indices = affinity(X, return_indices=True)
+
+    assert affinity.n_neighbors == 15
+    assert indices.shape == (32, 14)
+    assert torch.all(indices != torch.arange(32).unsqueeze(1))
+
+
 @pytest.mark.parametrize("dtype", lst_types)
 @pytest.mark.parametrize("metric", LIST_METRICS_TEST)
 @pytest.mark.parametrize("backend", lst_backend)

--- a/torchdr/tests/test_affinity.py
+++ b/torchdr/tests/test_affinity.py
@@ -356,23 +356,24 @@ def test_umap_data_affinity(dtype, metric, sparsity, backend, compile=False):
     check_nonnegativity(P)
 
 
-def test_umap_affinity_can_separate_target_and_search_neighbor_counts():
-    """UMAP can include self in its public count while searching non-self rows."""
+@pytest.mark.parametrize("n_neighbors", [2, 15])
+def test_umap_affinity_uses_self_inclusive_neighbor_count(n_neighbors):
+    """Fit searches k - 1 non-self rows but keeps log2(k) as its target."""
     X, _ = toy_dataset(32, "float32")
     affinity = UMAPAffinity(
-        n_neighbors=15,
-        _n_neighbors_search=14,
+        n_neighbors=n_neighbors,
         symmetrize=False,
         device="cpu",
         backend=None,
         sparsity=True,
     )
 
-    _, indices = affinity(X, return_indices=True)
+    P, indices = affinity(X, return_indices=True)
 
-    assert affinity.n_neighbors == 15
-    assert indices.shape == (32, 14)
+    assert indices.shape == (32, n_neighbors - 1)
     assert torch.all(indices != torch.arange(32).unsqueeze(1))
+    expected_mass = torch.full((32,), torch.log2(torch.tensor(float(n_neighbors))))
+    torch.testing.assert_close(P.sum(dim=1), expected_mass, rtol=1e-3, atol=1e-3)
 
 
 @pytest.mark.parametrize("dtype", lst_types)

--- a/torchdr/tests/test_umap_csr.py
+++ b/torchdr/tests/test_umap_csr.py
@@ -21,6 +21,14 @@ from torchdr.tests.utils import toy_dataset
 DEVICES = ["cpu"] + (["cuda"] if torch.cuda.is_available() else [])
 
 
+def test_umap_uses_umap_learn_neighbor_count_convention():
+    """UMAP's public count includes self while its search excludes self."""
+    model = UMAP(n_neighbors=15, backend=None, device="cpu")
+
+    assert model.n_neighbors == 15
+    assert model.affinity_in._n_neighbors_search == 14
+
+
 def test_flatten_padded_edges_row_major():
     """Padded grid flattens to row-major real edges with a sorted source."""
     # max_degree 4; rows with 2, 4, 0 and 1 real edges (-1 is padding).

--- a/torchdr/tests/test_umap_csr.py
+++ b/torchdr/tests/test_umap_csr.py
@@ -21,14 +21,6 @@ from torchdr.tests.utils import toy_dataset
 DEVICES = ["cpu"] + (["cuda"] if torch.cuda.is_available() else [])
 
 
-def test_umap_uses_umap_learn_neighbor_count_convention():
-    """UMAP's public count includes self while its search excludes self."""
-    model = UMAP(n_neighbors=15, backend=None, device="cpu")
-
-    assert model.n_neighbors == 15
-    assert model.affinity_in._n_neighbors_search == 14
-
-
 def test_flatten_padded_edges_row_major():
     """Padded grid flattens to row-major real edges with a sorted source."""
     # max_degree 4; rows with 2, 4, 0 and 1 real edges (-1 is padding).


### PR DESCRIPTION
## Verdict: APPROVE — fit semantics aligned, broader benchmark issue remains open

TorchDR distance backends already remove the self-neighbor. umap-learn's
fit-time k-NN array instead contains self in column zero, skips that column when
constructing memberships, and retains `log2(n_neighbors)` as the bandwidth
target. Consequently, TorchDR must retrieve `n_neighbors - 1` non-self rows at
fit time to implement the same public parameter.

## Changes

- `UMAPAffinity` now owns this convention directly: sparse fit retrieves
  `n_neighbors - 1` non-self neighbors and still targets
  `log2(n_neighbors)`.
- The public UMAP and UMAPAffinity documentation defines `n_neighbors` as an
  integer count that includes self during fit.
- Transform is documented separately: it remains bipartite and retrieves the
  full `n_neighbors` training rows because a new query has no self-row in the
  training set.
- The regression test checks public behavior rather than private constructor
  wiring: output support is `k - 1`, contains no self IDs, and each directed row
  has the `log2(k)` target mass. It includes `k=2`, where one non-self fit
  neighbor is valid.

## Review corrections

- Removed the private `_n_neighbors_search` option and its constructor-wiring
  test.
- Fixed the original implementation's `n_neighbors=2` regression: the derived
  one-neighbor search must not be revalidated against a generic minimum of two.
- Removed documentation that had accidentally been added to the unrelated
  `SelfTuningAffinity` class.
- Merged current `main` before final validation.

## Validation

- Focused UMAP affinity tests: 6 passed.
- Broader UMAP CSR, transform, and NeighborEmbedding tests: 56 passed, 1 skipped.
- Real two-process distributed NeighborEmbedding test: 5 passed on each rank.
- Touched-file pre-commit hooks: all passed.
- External graph-level comparison with umap-learn 0.5.11 on 128 seeded points,
  exact precomputed Euclidean distances, and an exact zero diagonal: both graphs
  had 2,566 nonzero edges, support Jaccard was 1.0, mean common-edge weight
  difference was `3.33e-7`, and maximum weight difference was `1.37e-6`.
- The matched 70,000-point MNIST benchmark from #352 improved mean paired-distance
  Spearman by 0.1268 and mean Procrustes disparity by 0.0745 (lower is better),
  with a 4.4% mean fit-time increase. Local k-NN overlap changed by -0.0056 on
  average, so this is a semantic-fidelity fix, not a universal quality claim.

This advances #352, but does not close it: Fashion-MNIST, PBMC68k, and QM9
benchmark coverage requested by that issue remains outstanding.

Refs #352
