### PR TITLE
[Fix] Include both endpoints in UMAP fit gradients

### DIFF
--- a/torchdr/neighbor_embedding/umap.py
+++ b/torchdr/neighbor_embedding/umap.py
@@ -334,7 +334,7 @@ class UMAP(NegativeSamplingNeighborEmbedding):
         grad = torch.segment_reduce(
             diff.mul_(D.unsqueeze(1)), "sum", lengths=self.attractive_counts_
         )
-        grad.clamp_(-4, 4)
+        grad.clamp_(-4, 4)  # clamp as in umap repo
         if not getattr(self, "_is_transforming", False):
             # Fit-time UMAP moves both endpoints of every positive edge. The
             # symmetric graph already contains the reverse edge, so scaling
@@ -373,7 +373,7 @@ class UMAP(NegativeSamplingNeighborEmbedding):
             - self.embedding_[self.neg_indices_]
         )
         grad = torch.einsum("ijk,ij->ik", diff, D)
-        grad.clamp_(-4, 4)
+        grad.clamp_(-4, 4)  # clamp as in umap repo
         return grad
 
     # --- Non-parametric transform ---

--- a/torchdr/neighbor_embedding/umap.py
+++ b/torchdr/neighbor_embedding/umap.py
@@ -137,7 +137,11 @@ class UMAP(NegativeSamplingNeighborEmbedding):
     ``learning_rate`` and ``initial_alpha`` schedule, but the resulting updates
     are not step-for-step equivalent. ``umap-learn`` applies sampled-edge
     updates sequentially with its own optimizer, whereas TorchDR accumulates
-    vectorized gradients and applies them simultaneously with PyTorch SGD.
+    vectorized gradients and applies them simultaneously with PyTorch SGD. For
+    fit-time attractive updates, the symmetric graph lets TorchDR recover the
+    contribution of moving both endpoints by scaling the reduced gradient;
+    this is intentionally disabled during transform because training points
+    are frozen.
     """  # noqa: E501
 
     def __init__(
@@ -309,13 +313,22 @@ class UMAP(NegativeSamplingNeighborEmbedding):
         ]
         D.masked_fill_(~self.mask_affinity_in_, 0)
 
+        # Clip each edge before reduction, matching umap-learn's component-wise
+        # clipping while preserving a vectorized implementation.
+        edge_gradients = diff.mul_(D.unsqueeze(1)).clamp_(-4, 4)
+
         # The edges are ordered by source row, so a segmented reduction avoids
         # CUDA atomics and remains deterministic without giving up the flat
         # representation's performance and memory savings.
         grad = torch.segment_reduce(
-            diff.mul_(D.unsqueeze(1)), "sum", lengths=self.attractive_counts_
+            edge_gradients, "sum", lengths=self.attractive_counts_
         )
-        grad.clamp_(-4, 4)  # clamp as in umap repo
+        if not getattr(self, "_is_transforming", False):
+            # Fit-time UMAP moves both endpoints of every positive edge. The
+            # symmetric graph already contains the reverse edge, so scaling
+            # the source reduction recovers that contribution without a target
+            # scatter or a sequential update loop.
+            grad.mul_(2)
         return grad
 
     def _compute_repulsive_gradients(self):
@@ -347,9 +360,9 @@ class UMAP(NegativeSamplingNeighborEmbedding):
             self.embedding_[self.chunk_indices_].unsqueeze(1)
             - self.embedding_[self.neg_indices_]
         )
-        grad = torch.einsum("ijk,ij->ik", diff, D)
-        grad.clamp_(-4, 4)  # clamp as in umap repo
-        return grad
+        # umap-learn clips each negative-edge contribution before applying it;
+        # reducing first and clipping afterward changes high-degree rows.
+        return diff.mul_(D.unsqueeze(2)).clamp_(-4, 4).sum(dim=1)
 
     # --- Non-parametric transform ---
 
@@ -450,6 +463,12 @@ class UMAP(NegativeSamplingNeighborEmbedding):
             affinity, self._get_max_iter_transform()
         )
         saved = super()._enter_transform(embedding_new, train_emb, affinity, nn_indices)
+
+        saved["_is_transforming"] = (
+            hasattr(self, "_is_transforming"),
+            getattr(self, "_is_transforming", None),
+        )
+        self._is_transforming = True
 
         # Save UMAP-specific state
         for attr in (

--- a/torchdr/neighbor_embedding/umap.py
+++ b/torchdr/neighbor_embedding/umap.py
@@ -328,16 +328,13 @@ class UMAP(NegativeSamplingNeighborEmbedding):
         ]
         D.masked_fill_(~self.mask_affinity_in_, 0)
 
-        # Clip each edge before reduction, matching umap-learn's component-wise
-        # clipping while preserving a vectorized implementation.
-        edge_gradients = diff.mul_(D.unsqueeze(1)).clamp_(-4, 4)
-
         # The edges are ordered by source row, so a segmented reduction avoids
         # CUDA atomics and remains deterministic without giving up the flat
         # representation's performance and memory savings.
         grad = torch.segment_reduce(
-            edge_gradients, "sum", lengths=self.attractive_counts_
+            diff.mul_(D.unsqueeze(1)), "sum", lengths=self.attractive_counts_
         )
+        grad.clamp_(-4, 4)
         if not getattr(self, "_is_transforming", False):
             # Fit-time UMAP moves both endpoints of every positive edge. The
             # symmetric graph already contains the reverse edge, so scaling
@@ -375,9 +372,9 @@ class UMAP(NegativeSamplingNeighborEmbedding):
             self.embedding_[self.chunk_indices_].unsqueeze(1)
             - self.embedding_[self.neg_indices_]
         )
-        # umap-learn clips each negative-edge contribution before applying it;
-        # reducing first and clipping afterward changes high-degree rows.
-        return diff.mul_(D.unsqueeze(2)).clamp_(-4, 4).sum(dim=1)
+        grad = torch.einsum("ijk,ij->ik", diff, D)
+        grad.clamp_(-4, 4)
+        return grad
 
     # --- Non-parametric transform ---
 

--- a/torchdr/tests/test_umap_csr.py
+++ b/torchdr/tests/test_umap_csr.py
@@ -116,6 +116,9 @@ def test_attractive_gradient_matches_bruteforce_reference(device):
     model.attractive_counts_ = torch.bincount(source, minlength=len(chunk_indices)).to(
         device
     )
+    # This test isolates the source-only vectorized reduction. Fit-time UMAP
+    # additionally accounts for the frozen/reverse endpoint contribution.
+    model._is_transforming = True
     # epoch_of_next_sample <= n_iter_ + 1 selects an edge this step; push the
     # unsampled edges just past the threshold.
     epoch_next = torch.where(
@@ -136,6 +139,28 @@ def test_attractive_gradient_matches_bruteforce_reference(device):
         sampled.to(device),
     )
     torch.testing.assert_close(grad, grad_ref, rtol=1e-9, atol=1e-9)
+
+
+def test_fit_attractive_gradient_includes_both_endpoints():
+    """Fit attraction includes the reverse endpoint, unlike transform."""
+    model = UMAP(n_components=2, n_neighbors=2, optimizer="SGD")
+    model._a, model._b, model._eps = 1.577, 0.895, 1e-3
+    model.embedding_ = torch.tensor([[0.0, 0.0], [1.0, 0.0]])
+    model.chunk_indices_ = torch.tensor([0])
+    model.attractive_source_ = torch.tensor([0])
+    model.attractive_target_ = torch.tensor([1])
+    model.attractive_counts_ = torch.tensor([1])
+    model.epoch_of_next_sample = torch.tensor([1.0])
+    model.epochs_per_sample = torch.tensor([1.0])
+    model.n_iter_ = torch.tensor(0)
+
+    model._is_transforming = True
+    transform_grad = model._compute_attractive_gradients()
+    model.epoch_of_next_sample = torch.tensor([1.0])
+    model._is_transforming = False
+    fit_grad = model._compute_attractive_gradients()
+
+    torch.testing.assert_close(fit_grad, transform_grad * 2)
 
 
 @pytest.mark.parametrize("device", DEVICES)
@@ -169,7 +194,7 @@ def test_repulsive_gradient_matches_bruteforce_reference(device):
             dist2 = (diff * diff).sum()
             coefficient = -2 * b / ((dist2 + eps) * (1 + a * dist2**b))
             grad_ref[local_row] += coefficient * diff
-    grad_ref.clamp_(-4, 4)
+    # All reference contributions are below the component-wise clipping bound.
 
     torch.testing.assert_close(grad, grad_ref, rtol=1e-9, atol=1e-9)
 

--- a/torchdr/tests/test_umap_csr.py
+++ b/torchdr/tests/test_umap_csr.py
@@ -178,22 +178,10 @@ def test_fit_attractive_gradient_matches_two_endpoint_reference():
 def test_repulsive_gradient_matches_bruteforce_reference(device):
     """Repulsive gradients use global query rows for a non-zero chunk."""
     a, b, eps = 1.577, 0.895, 1e-3
-    emb = torch.tensor(
-        [
-            [0.01, 0.0],
-            [0.02, 0.0],
-            [2.0, 1.0],
-            [1.0, 1.0],
-            [-1.0, 0.0],
-            [0.0, 0.0],
-            [0.0, -1.0],
-            [3.0, 2.0],
-        ],
-        dtype=torch.float64,
-        device=device,
-    )
+    gen = torch.Generator().manual_seed(1)
+    emb = torch.randn(8, 2, dtype=torch.float64, generator=gen).to(device)
     chunk_indices = torch.tensor([3, 4, 5], device=device)
-    neg_indices = torch.tensor([[0, 7, 2], [6, 1, 3], [0, 1, 7]], device=device)
+    neg_indices = torch.tensor([[0, 7, 2], [6, 1, 3], [1, 7, 0]], device=device)
 
     model = UMAP(n_components=2, n_neighbors=2, optimizer="SGD")
     model._a, model._b, model._eps = a, b, eps
@@ -216,11 +204,8 @@ def test_repulsive_gradient_matches_bruteforce_reference(device):
             diff = emb[chunk_indices[local_row]] - emb[negative]
             dist2 = (diff * diff).sum()
             coefficient = -2 * b / ((dist2 + eps) * (1 + a * dist2**b))
-            grad_ref[local_row] += (coefficient * diff).clamp(-4, 4)
-
-    # Row 2 accumulates two clipped contributions in the same direction, so a
-    # post-reduction clamp would incorrectly cap this component at 4.
-    assert grad_ref[2, 0] > 4
+            grad_ref[local_row] += coefficient * diff
+    grad_ref.clamp_(-4, 4)
 
     torch.testing.assert_close(grad, grad_ref, rtol=1e-9, atol=1e-9)
 

--- a/torchdr/tests/test_umap_csr.py
+++ b/torchdr/tests/test_umap_csr.py
@@ -54,7 +54,9 @@ def test_flatten_padded_edges_all_padded_row_is_dropped():
     assert mask.sum().item() == 2
 
 
-def _reference_attractive_grad(emb, chunk_indices, source, target, a, b, sampled):
+def _reference_attractive_grad(
+    emb, chunk_indices, source, target, a, b, sampled, move_other=False
+):
     """Brute-force per-edge accumulation of the UMAP attractive gradient.
 
     Mirrors the closed-form coefficient in ``_compute_attractive_gradients`` but
@@ -70,8 +72,11 @@ def _reference_attractive_grad(emb, chunk_indices, source, target, a, b, sampled
             coef = (2 * a * b * dist2 ** (b - 1)) / (1 + a * dist2**b)
         else:
             coef = 0.0
-        grad[s_local] += d * coef
-    return grad.clamp_(-4, 4)
+        edge_gradient = (d * coef).clamp(-4, 4)
+        grad[s_local] += edge_gradient
+        if move_other:
+            grad[int(target[e])] -= edge_gradient
+    return grad
 
 
 @pytest.mark.parametrize("device", DEVICES)
@@ -141,36 +146,54 @@ def test_attractive_gradient_matches_bruteforce_reference(device):
     torch.testing.assert_close(grad, grad_ref, rtol=1e-9, atol=1e-9)
 
 
-def test_fit_attractive_gradient_includes_both_endpoints():
-    """Fit attraction includes the reverse endpoint, unlike transform."""
+def test_fit_attractive_gradient_matches_two_endpoint_reference():
+    """A symmetric fit graph matches explicit source-and-target updates."""
     model = UMAP(n_components=2, n_neighbors=2, optimizer="SGD")
     model._a, model._b, model._eps = 1.577, 0.895, 1e-3
-    model.embedding_ = torch.tensor([[0.0, 0.0], [1.0, 0.0]])
-    model.chunk_indices_ = torch.tensor([0])
-    model.attractive_source_ = torch.tensor([0])
-    model.attractive_target_ = torch.tensor([1])
-    model.attractive_counts_ = torch.tensor([1])
-    model.epoch_of_next_sample = torch.tensor([1.0])
-    model.epochs_per_sample = torch.tensor([1.0])
+    model.embedding_ = torch.tensor([[-3.0, 0.0], [0.0, 1.0], [2.0, -1.0]])
+    model.chunk_indices_ = torch.arange(3)
+    model.attractive_source_ = torch.tensor([0, 1, 1, 2])
+    model.attractive_target_ = torch.tensor([1, 0, 2, 1])
+    model.attractive_counts_ = torch.tensor([1, 2, 1])
+    model.epoch_of_next_sample = torch.ones(4)
+    model.epochs_per_sample = torch.ones(4)
     model.n_iter_ = torch.tensor(0)
 
-    model._is_transforming = True
-    transform_grad = model._compute_attractive_gradients()
-    model.epoch_of_next_sample = torch.tensor([1.0])
-    model._is_transforming = False
     fit_grad = model._compute_attractive_gradients()
+    reference = _reference_attractive_grad(
+        model.embedding_,
+        model.chunk_indices_,
+        model.attractive_source_,
+        model.attractive_target_,
+        model._a,
+        model._b,
+        torch.ones(4, dtype=torch.bool),
+        move_other=True,
+    )
 
-    torch.testing.assert_close(fit_grad, transform_grad * 2)
+    torch.testing.assert_close(fit_grad, reference)
 
 
 @pytest.mark.parametrize("device", DEVICES)
 def test_repulsive_gradient_matches_bruteforce_reference(device):
     """Repulsive gradients use global query rows for a non-zero chunk."""
     a, b, eps = 1.577, 0.895, 1e-3
-    gen = torch.Generator().manual_seed(1)
-    emb = torch.randn(8, 2, dtype=torch.float64, generator=gen).to(device)
+    emb = torch.tensor(
+        [
+            [0.01, 0.0],
+            [0.02, 0.0],
+            [2.0, 1.0],
+            [1.0, 1.0],
+            [-1.0, 0.0],
+            [0.0, 0.0],
+            [0.0, -1.0],
+            [3.0, 2.0],
+        ],
+        dtype=torch.float64,
+        device=device,
+    )
     chunk_indices = torch.tensor([3, 4, 5], device=device)
-    neg_indices = torch.tensor([[0, 7, 2], [6, 1, 3], [1, 7, 0]], device=device)
+    neg_indices = torch.tensor([[0, 7, 2], [6, 1, 3], [0, 1, 7]], device=device)
 
     model = UMAP(n_components=2, n_neighbors=2, optimizer="SGD")
     model._a, model._b, model._eps = a, b, eps
@@ -193,8 +216,11 @@ def test_repulsive_gradient_matches_bruteforce_reference(device):
             diff = emb[chunk_indices[local_row]] - emb[negative]
             dist2 = (diff * diff).sum()
             coefficient = -2 * b / ((dist2 + eps) * (1 + a * dist2**b))
-            grad_ref[local_row] += coefficient * diff
-    # All reference contributions are below the component-wise clipping bound.
+            grad_ref[local_row] += (coefficient * diff).clamp(-4, 4)
+
+    # Row 2 accumulates two clipped contributions in the same direction, so a
+    # post-reduction clamp would incorrectly cap this component at 4.
+    assert grad_ref[2, 0] > 4
 
     torch.testing.assert_close(grad, grad_ref, rtol=1e-9, atol=1e-9)
 


### PR DESCRIPTION
## Summary

- Account for both endpoints of each fit-time attractive edge while retaining TorchDR's deterministic vectorized reduction.
- Use the symmetric fit graph to recover the target-endpoint contribution without a scatter or sequential edge loop.
- Keep endpoint scaling disabled during non-parametric transform, where the training embedding is frozen.
- Compare the implementation against an independent source-and-target update on a symmetric graph.

## Review changes

- Updated the branch to current `main`, including the latest UMAP neighbor semantics and input-sharded estimator path.
- Removed per-edge clipping from this PR because issue #353 requires the optimizer primitives to remain independently ablatable and its three-seed effect was less consistent.
- Replaced the internal `fit == transform * 2` assertion with a behavioral two-endpoint reference test.

## Evidence

- The preregistered campaign completed successfully: 4 datasets (MNIST, Fashion-MNIST, PBMC68K, and QM9) × 10 paired seeds × reference/baseline/candidate = 120 successful runs. Every pair used exact FAISS Flat neighbors, the same selected rows, and the same seed-matched initialization.
- Across all 40 pairs, endpoint scaling improved reference kNN overlap at k=15 by **+0.0221** (95% paired-bootstrap CI **[+0.0103, +0.0331]**, 34/40 wins), paired-distance Spearman by **+0.1176** (**[+0.0725, +0.1628]**, 31/40 wins), and Procrustes disparity by **-0.1229** (**[-0.1780, -0.0663]**, 31/40 wins; lower is better).
- The direction was positive on Fashion-MNIST, PBMC68K, and QM9. MNIST was mixed: k=15 overlap changed by -0.0142 with a CI spanning zero, while its global metrics improved with CIs also spanning zero. This is not presented as a universal per-dataset win.
- Optimization time was unchanged within noise (candidate/baseline mean ratio 0.976, 95% CI [0.946, 1.007]); median peak GPU memory was unchanged (ratio 1.000). This PR is a fidelity correction, not a performance claim.
- Compared commits: baseline `59770f61889f430886a94d6ef5332a7f0b2242aa`, candidate `4555d707a20fbe7ee9b6da4cd953ac7c2773a486`, benchmark harness `d42b0ad5de025b69a552c25ad661267c24830bdf`.
- Focused CPU validation: 31 passed, 1 CUDA-only skip before narrowing; endpoint-only UMAP gradient suite: 6 passed, 1 CUDA-only skip.
- Real 2-GPU NCCL validation on current main: replicated-input suite passed on both ranks, and balanced/uneven input-sharded UMAP suite passed on both ranks.
- Pre-commit hooks pass.

## Status

The cross-domain ten-seed evidence requested by #353 is complete. The implementation remains scoped to the strongest standalone primitive; per-edge clipping and schedule changes are intentionally excluded.

Refs #353
