### PR TITLE
[Feature] Thread input_layout='sharded' end-to-end through the estimator stack

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -180,7 +180,7 @@ jobs:
       - name: Verify FAISS installation
         run: python -c "from torchdr.utils.faiss import faiss; assert faiss, 'FAISS failed to import'"
       - name: Run Tests
-        run: pytest torchdr/tests/test_utils.py torchdr/tests/test_dataloader.py torchdr/tests/test_eval.py torchdr/tests/test_faiss_index_training.py torchdr/tests/test_faiss_plan.py --verbose --cov=torchdr --cov-report term --cov-report xml
+        run: pytest torchdr/tests/test_utils.py torchdr/tests/test_dataloader.py torchdr/tests/test_eval.py torchdr/tests/test_faiss_index_training.py torchdr/tests/test_faiss_plan.py torchdr/tests/test_input_shard_estimator.py --verbose --cov=torchdr --cov-report term --cov-report xml
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/benchmarks/faiss/input_shard_hbm.py
+++ b/benchmarks/faiss/input_shard_hbm.py
@@ -17,7 +17,7 @@ peak is reported alongside as a cross-check.
 Launch (not a pytest; a torchrun entrypoint)::
 
     torchrun --standalone --nnodes=1 --nproc-per-node=2 \\
-        torchdr/tests/bench_input_shard_hbm.py \\
+        benchmarks/faiss/input_shard_hbm.py \\
         --samples 50000 --dim 768 --neighbors 15 --iters 100
 """
 

--- a/torchdr/affinity/base.py
+++ b/torchdr/affinity/base.py
@@ -24,7 +24,9 @@ from torchdr.distance import (
     FaissConfig,
     FaissPlanConfig,
 )
+from torchdr.distance.faiss import input_sharded_pairwise_distances_faiss
 from torchdr.distance.faiss_plan import _resolve_faiss_plan
+from torchdr.distributed.input_contract import gather_shard_layout
 
 import torch.distributed as dist
 
@@ -361,6 +363,7 @@ class SparseAffinity(Affinity):
         sparsity: bool = True,
         distributed: Union[bool, str] = "auto",
         random_state: float = None,
+        input_layout: str = "replicated",
         _pre_processed: bool = False,
     ):
         # --- Distributed setup ---
@@ -433,6 +436,65 @@ class SparseAffinity(Affinity):
                     f"Distributed mode enabled: rank {self.rank}/{self.world_size}"
                 )
 
+        # --- Input layout (replicated vs row-sharded) ---
+        if input_layout not in ("replicated", "sharded"):
+            raise ValueError(
+                f"[TorchDR] input_layout must be 'replicated' or 'sharded', got "
+                f"{input_layout!r}."
+            )
+        self.input_layout = input_layout
+        self._shard_layout_ = None
+        if input_layout == "sharded":
+            self._resolve_sharded_faiss_config()
+
+    def _resolve_sharded_faiss_config(self):
+        """Validate and cache the exact Flat config used by the sharded path.
+
+        Input-sharding builds a per-rank Flat index over each shard and merges
+        the global top-k, so it composes only with exact ``Flat`` search. A
+        :class:`FaissPlanConfig` selects the orthogonal *index*-sharding strategy
+        (full input replicated on every rank, index split), which is mutually
+        exclusive with splitting the rows themselves.
+        """
+        backend = self.backend
+        if isinstance(backend, FaissPlanConfig):
+            raise ValueError(
+                "[TorchDR] input_layout='sharded' cannot be combined with a "
+                "FaissPlanConfig: input-sharding (rows split across ranks) and "
+                "the FaissPlanConfig index-sharding strategy (input replicated, "
+                "index split) are mutually exclusive. Pass a plain FaissConfig "
+                "or backend='faiss'."
+            )
+        if isinstance(backend, FaissConfig):
+            if backend.index_type != "Flat":
+                raise NotImplementedError(
+                    "[TorchDR] input_layout='sharded' currently supports only "
+                    f"exact 'Flat' search, got index_type={backend.index_type!r}."
+                    " An approximate sharded index is a separate follow-up."
+                )
+            self._sharded_faiss_config_ = backend
+        else:
+            # "faiss", None, or a forced backend string -> exact Flat default.
+            self._sharded_faiss_config_ = FaissConfig()
+
+    def _resolve_shard_layout(self, X):
+        """Gather (once per call) and cache this input's rank-major shard layout.
+
+        Also records the chunk bounds that the distributed sparse symmetrization
+        and the estimator's gradient partition read back, derived here from the
+        true shard offsets rather than the balanced split. Single-process (no
+        group or one rank) short-circuits to the whole input as a single shard.
+        """
+        layout = self._shard_layout_
+        if layout is None:
+            layout = gather_shard_layout(X, self.dist_ctx if self.distributed else None)
+            self._shard_layout_ = layout
+            self.n_global_ = layout.global_count
+            self.chunk_start_ = layout.local_offset
+            self.chunk_end_ = layout.local_offset + layout.local_count
+            self.chunk_size_ = layout.local_count
+        return layout
+
     # --- Sparsity property ---
 
     @property
@@ -471,6 +533,10 @@ class SparseAffinity(Affinity):
         """
         if not self._pre_processed:
             X = to_torch(X)
+        if self.input_layout == "sharded":
+            # Drop any layout cached by a previous call so this fit re-derives it
+            # from the shards actually passed here.
+            self._shard_layout_ = None
         return self._compute_sparse_affinity(X, return_indices, **kwargs)
 
     # --- Core computation (must be implemented by subclasses) ---
@@ -506,6 +572,24 @@ class SparseAffinity(Affinity):
         indices : torch.Tensor, optional
             Indices if ``return_indices=True``.
         """
+        # Row-sharded input: each rank holds a distinct contiguous shard and the
+        # search returns *global* neighbor ids over the reconstructed dataset.
+        # The dispatcher's replicated-input contract does not apply here, so this
+        # path calls the input-sharded kernel directly and records the chunk
+        # bounds from the true shard offsets.
+        if self.input_layout == "sharded":
+            self._resolve_shard_layout(X)
+            distances, indices = input_sharded_pairwise_distances_faiss(
+                X,
+                k=k,
+                metric=self.metric,
+                exclude_diag=self.zero_diag,
+                config=self._sharded_faiss_config_,
+                device=self.device,
+                distributed_ctx=self.dist_ctx if self.distributed else None,
+            )
+            return (distances, indices) if return_indices else distances
+
         backend = self._resolve_plan_backend(X)
         result = pairwise_distances(
             X=X,

--- a/torchdr/affinity/base.py
+++ b/torchdr/affinity/base.py
@@ -348,6 +348,10 @@ class SparseAffinity(Affinity):
     distributed : bool or 'auto', optional
         Whether to use distributed multi-GPU computation.
         ``"auto"`` detects ``torchrun`` automatically. Default is "auto".
+    input_layout : {'replicated', 'sharded'}, optional
+        Whether every rank receives the full input or one contiguous row shard.
+        Sharded input currently requires exact Flat FAISS search. Default is
+        "replicated".
     _pre_processed : bool, optional
         If True, skips ``to_torch`` conversion. Default is False.
     """
@@ -473,9 +477,14 @@ class SparseAffinity(Affinity):
                     " An approximate sharded index is a separate follow-up."
                 )
             self._sharded_faiss_config_ = backend
-        else:
-            # "faiss", None, or a forced backend string -> exact Flat default.
+        elif backend in ("faiss", None):
             self._sharded_faiss_config_ = FaissConfig()
+        else:
+            raise ValueError(
+                "[TorchDR] input_layout='sharded' requires backend='faiss' or "
+                "an exact-Flat FaissConfig; an explicitly selected non-FAISS "
+                f"backend cannot be used, got {backend!r}."
+            )
 
     def _resolve_shard_layout(self, X):
         """Gather (once per call) and cache this input's rank-major shard layout.

--- a/torchdr/affinity/knn_normalized.py
+++ b/torchdr/affinity/knn_normalized.py
@@ -399,6 +399,7 @@ class UMAPAffinity(SparseAffinity):
         compile: bool = False,
         symmetrize: bool = True,
         distributed: Union[bool, str] = "auto",
+        input_layout: str = "replicated",
         _pre_processed: bool = False,
     ):
         self.n_neighbors = n_neighbors
@@ -414,6 +415,7 @@ class UMAPAffinity(SparseAffinity):
             sparsity=sparsity,
             compile=compile,
             distributed=distributed,
+            input_layout=input_layout,
             _pre_processed=_pre_processed,
         )
 
@@ -433,7 +435,14 @@ class UMAPAffinity(SparseAffinity):
         self : UMAPAffinityIn
             The fitted instance.
         """
-        n_samples_in = self._get_n_samples(X)
+        if self.input_layout == "sharded":
+            # Rows are split across ranks; validate the neighbor count against the
+            # global sample total, gathering (and caching) the shard layout here so
+            # the distance and symmetrization steps below reuse it.
+            layout = self._resolve_shard_layout(X)
+            n_samples_in = layout.global_count
+        else:
+            n_samples_in = self._get_n_samples(X)
         n_neighbors = check_neighbor_param(self.n_neighbors, n_samples_in)
 
         if self.sparsity:
@@ -482,13 +491,25 @@ class UMAPAffinity(SparseAffinity):
             self.logger.info("Symmetrizing affinity matrix...")
             if self.sparsity:
                 if self.is_multi_gpu:
-                    # Use distributed symmetrization for multi-GPU
+                    # Use distributed symmetrization for multi-GPU. With a sharded
+                    # input the global column owner follows the true (possibly
+                    # uneven) shard boundaries rather than the balanced split, and
+                    # the global row total is the summed shard counts.
+                    if self.input_layout == "sharded":
+                        n_total = self.n_global_
+                        owner_boundaries = self._shard_layout_.owner_boundaries(
+                            device=indices.device
+                        )
+                    else:
+                        n_total = self._get_n_samples(X)
+                        owner_boundaries = None
                     affinity_matrix, indices = distributed_symmetrize_sparse(
                         values=affinity_matrix,
                         indices=indices,
                         chunk_start=self.chunk_start_,
                         chunk_size=self.chunk_size_,
-                        n_total=self._get_n_samples(X),
+                        n_total=n_total,
+                        owner_boundaries=owner_boundaries,
                         mode="sum_minus_prod",
                     )
                 else:

--- a/torchdr/affinity_matcher.py
+++ b/torchdr/affinity_matcher.py
@@ -139,6 +139,7 @@ class AffinityMatcher(DRModule):
         check_interval: int = 50,
         compile: bool = False,
         encoder: Optional[torch.nn.Module] = None,
+        input_layout: str = "replicated",
         **kwargs,
     ):
         super().__init__(
@@ -194,9 +195,58 @@ class AffinityMatcher(DRModule):
 
         self.encoder = encoder
 
+        # --- Input layout (replicated vs row-sharded) ---
+        if input_layout not in ("replicated", "sharded"):
+            raise ValueError(
+                f"[TorchDR] input_layout must be 'replicated' or 'sharded', got "
+                f"{input_layout!r}."
+            )
+        self.input_layout = input_layout
+        if input_layout == "sharded":
+            # Each rank holds a distinct shard, so the default per-rank
+            # torch.unique would deduplicate within a shard and corrupt the
+            # global row layout. Cross-rank duplicates are the caller's contract.
+            self.process_duplicates = False
+
         self.n_iter_ = torch.tensor(-1, dtype=torch.long)
 
     # --- Fitting and optimization loop ---
+
+    def _validate_sharded_input(self, X):
+        """Reject configurations the first sharded-input slice does not support.
+
+        Input-sharding splits the *rows* of a raw feature tensor across ranks and
+        keeps the embedding replicated. Layouts that would make a row's global
+        identity ambiguous -- a DataLoader, a precomputed affinity, an encoder,
+        or a PCA/tensor initialization that assumes the whole input is locally
+        available -- are rejected with an actionable message rather than silently
+        producing a wrong global embedding.
+        """
+        if isinstance(X, DataLoader):
+            raise NotImplementedError(
+                "[TorchDR] input_layout='sharded' requires a raw 2-D feature "
+                "tensor shard per rank; DataLoader input is not supported."
+            )
+        if self.affinity_in == "precomputed":
+            raise NotImplementedError(
+                "[TorchDR] input_layout='sharded' cannot be combined with "
+                "affinity_in='precomputed'; sharding partitions raw feature "
+                "rows, not a precomputed affinity."
+            )
+        if self.encoder is not None:
+            raise NotImplementedError(
+                "[TorchDR] input_layout='sharded' does not support an encoder."
+            )
+        if not (
+            isinstance(self.init, str)
+            and self.init in ("random", "normal", "hyperbolic")
+        ):
+            raise NotImplementedError(
+                "[TorchDR] input_layout='sharded' currently supports only "
+                "init='random', 'normal', or 'hyperbolic'; a distributed "
+                f"gather-based initialization for {self.init!r} is a follow-up. "
+                "Pass init='random'."
+            )
 
     def _fit_transform(self, X: torch.Tensor, y: Optional[Any] = None) -> torch.Tensor:
         """Compute the input affinity and optimize the embedding.
@@ -214,6 +264,10 @@ class AffinityMatcher(DRModule):
         embedding_ : torch.Tensor of shape (n_samples, n_components)
             The optimized embedding.
         """
+        # --- Reject inputs incompatible with a sharded layout ---
+        if getattr(self, "input_layout", "replicated") == "sharded":
+            self._validate_sharded_input(X)
+
         # --- Resolve metadata and device ---
         if isinstance(X, DataLoader):
             self.n_samples_in_ = len(X.dataset)
@@ -235,6 +289,11 @@ class AffinityMatcher(DRModule):
         else:
             self.n_samples_in_, self.n_features_in_ = X.shape
             self.device_ = X.device if self.device == "auto" else self.device
+            # Under a sharded input X.shape[0] is this rank's local count; adopt
+            # the global total (gathered early by the estimator) so all downstream
+            # sizing -- embedding, learning rate, negatives -- spans every rank.
+            if getattr(self, "n_global_", None) is not None:
+                self.n_samples_in_ = int(self.n_global_)
 
         # --- Validate encoder ---
         if self.encoder is not None:
@@ -284,6 +343,18 @@ class AffinityMatcher(DRModule):
                 self.affinity_in_ = affinity_matrix
             else:
                 self.register_buffer("affinity_in_", affinity_matrix, persistent=False)
+
+        # A sharded affinity records the global sample total; adopt it so the
+        # embedding size, learning rate, and negative pool span all rows. The
+        # estimator (NeighborEmbedding) usually sets ``n_global_`` earlier; this
+        # also covers a bare AffinityMatcher driven by a sharded affinity.
+        if (
+            getattr(self, "n_global_", None) is None
+            and getattr(self.affinity_in, "n_global_", None) is not None
+        ):
+            self.n_global_ = int(self.affinity_in.n_global_)
+        if getattr(self, "n_global_", None) is not None:
+            self.n_samples_in_ = int(self.n_global_)
 
         self.on_affinity_computation_end()
 
@@ -518,7 +589,12 @@ class AffinityMatcher(DRModule):
             n = self.n_samples_in_
             X_dtype = self._dataloader_dtype_
         else:
-            n = X.shape[0]
+            # Under a sharded input X holds only this rank's rows; the replicated
+            # embedding is sized to the global sample total so every rank builds
+            # (and rank 0 broadcasts) one coordinate per global point.
+            n = getattr(self, "n_global_", None)
+            if n is None:
+                n = X.shape[0]
             X_dtype = X.dtype
 
         if isinstance(self.init, (torch.Tensor, np.ndarray)):

--- a/torchdr/affinity_matcher.py
+++ b/torchdr/affinity_matcher.py
@@ -111,6 +111,10 @@ class AffinityMatcher(DRModule):
         Neural network mapping input data to the embedding space.
         Output dimension must match :attr:`n_components`.
         Default is None (optimize a raw embedding matrix).
+    input_layout : {'replicated', 'sharded'}, optional
+        Whether every distributed rank receives the full input or one
+        contiguous row shard. The layout must match ``affinity_in``. Default is
+        "replicated".
     """
 
     def __init__(
@@ -202,6 +206,14 @@ class AffinityMatcher(DRModule):
                 f"{input_layout!r}."
             )
         self.input_layout = input_layout
+        if isinstance(self.affinity_in, Affinity):
+            affinity_layout = getattr(self.affinity_in, "input_layout", "replicated")
+            if input_layout != affinity_layout:
+                raise ValueError(
+                    "[TorchDR] input_layout must match affinity_in.input_layout; "
+                    f"the estimator uses {input_layout!r} while its affinity uses "
+                    f"{affinity_layout!r}."
+                )
         if input_layout == "sharded":
             # Each rank holds a distinct shard, so the default per-rank
             # torch.unique would deduplicate within a shard and corrupt the

--- a/torchdr/distributed/input_contract.py
+++ b/torchdr/distributed/input_contract.py
@@ -219,6 +219,23 @@ class ShardLayout:
             device=device,
         )
 
+    def owner_boundaries(self, device: Optional[torch.device] = None) -> torch.Tensor:
+        """Rank-major prefix offsets ``[0, c0, c0 + c1, ..., global_count]``.
+
+        A length ``world_size + 1`` table where ``boundaries[r]`` is the global
+        index of rank ``r``'s first row and ``boundaries[r + 1]`` is one past its
+        last, so a global row ``g`` is owned by the rank ``r`` for which
+        ``boundaries[r] <= g < boundaries[r + 1]``. This is the exact table
+        :func:`torchdr.utils.sparse.distributed_symmetrize_sparse` consumes to
+        route an arbitrary global column to its owner when the shards are uneven;
+        with the balanced split it reduces to that function's default arithmetic.
+        """
+        boundaries = torch.zeros(self.world_size + 1, dtype=torch.long, device=device)
+        boundaries[1:] = torch.as_tensor(
+            self.counts, dtype=torch.long, device=device
+        ).cumsum(0)
+        return boundaries
+
 
 def gather_shard_layout(X_local, dist_ctx) -> ShardLayout:
     """Exchange local row counts and derive a rank-major shard layout.

--- a/torchdr/neighbor_embedding/base.py
+++ b/torchdr/neighbor_embedding/base.py
@@ -16,6 +16,7 @@ from torchdr.affinity import Affinity
 from torchdr.affinity.entropic import _log_Pe
 from torchdr.distance import FaissConfig, FaissPlanConfig, pairwise_distances
 from torchdr.affinity_matcher import AffinityMatcher
+from torchdr.distributed.input_contract import gather_shard_layout
 from torchdr.utils import (
     binary_search,
     entropy,
@@ -279,7 +280,19 @@ class NeighborEmbedding(AffinityMatcher):
         return self
 
     def _fit_transform(self, X: torch.Tensor, y: Optional[Any] = None) -> torch.Tensor:
-        n_samples = len(X.dataset) if isinstance(X, DataLoader) else X.shape[0]
+        if getattr(self, "input_layout", "replicated") == "sharded":
+            # Rows are split across ranks: reject unsupported layouts first (for a
+            # clean message on DataLoader/precomputed/etc.), then gather the global
+            # row count up front so the neighbor-count check -- and all downstream
+            # global-N sizing -- use the whole dataset, not this rank's shard. The
+            # affinity re-derives the same layout when it searches.
+            self._validate_sharded_input(X)
+            dist_ctx = getattr(self.affinity_in, "dist_ctx", None)
+            layout = gather_shard_layout(X, dist_ctx if self.distributed else None)
+            self.n_global_ = layout.global_count
+            n_samples = layout.global_count
+        else:
+            n_samples = len(X.dataset) if isinstance(X, DataLoader) else X.shape[0]
         self._check_n_neighbors(n_samples)
         # Initialize the mutable exaggeration coefficient (may be reset to 1 during
         # optimization when the early exaggeration phase ends).

--- a/torchdr/neighbor_embedding/umap.py
+++ b/torchdr/neighbor_embedding/umap.py
@@ -133,6 +133,15 @@ class UMAP(NegativeSamplingNeighborEmbedding):
         - True: Force distributed mode (requires torchrun)
         - False: Disable distributed mode
         Default is "auto".
+    input_layout : {'replicated', 'sharded'}, optional
+        How the input rows are laid out across distributed ranks.
+        - "replicated" (default): every rank holds the full input.
+        - "sharded": each rank holds a distinct contiguous shard whose rows
+          concatenate, in rank order, into the global dataset, so no rank ever
+          materializes the whole input. Requires an exact Flat FAISS backend and
+          ``init`` in {"random", "normal", "hyperbolic"}; the embedding stays
+          replicated (one coordinate per global point on every rank).
+        Default is "replicated".
 
     Notes
     -----
@@ -174,6 +183,7 @@ class UMAP(NegativeSamplingNeighborEmbedding):
         discard_NNs: Optional[bool] = None,
         compile: bool = False,
         distributed: Union[bool, str] = "auto",
+        input_layout: str = "replicated",
         **kwargs,
     ):
         self.n_neighbors = n_neighbors
@@ -204,6 +214,7 @@ class UMAP(NegativeSamplingNeighborEmbedding):
             sparsity=self.sparsity,
             compile=compile,
             distributed=distributed,
+            input_layout=input_layout,
         )
 
         super().__init__(
@@ -228,6 +239,7 @@ class UMAP(NegativeSamplingNeighborEmbedding):
             compile=compile,
             n_negatives=self.n_negatives,
             distributed=distributed,
+            input_layout=input_layout,
             **kwargs,
         )
 

--- a/torchdr/tests/bench_input_shard_hbm.py
+++ b/torchdr/tests/bench_input_shard_hbm.py
@@ -1,0 +1,230 @@
+"""[Perf] Peak-HBM / wall-time benchmark for ``input_layout='sharded'`` UMAP.
+
+Compares, on a real NCCL + FAISS-GPU process group, the per-rank device memory
+of a distributed UMAP fit when the raw feature rows are
+
+  * replicated  -- every rank holds the full ``(N, d)`` input and builds an index
+                   over all of it (the pre-input-sharding behavior), versus
+  * sharded     -- every rank holds only its ``(N / W, d)`` shard and indexes just
+                   that shard (issue #359/#308).
+
+The embedding stays replicated in both cases, so any HBM delta comes from the
+``O(N * d)`` input tensor + FAISS index footprint that input-sharding splits.
+FAISS-GPU allocates outside the torch caching allocator, so device-wide peak is
+sampled from ``cuda.mem_get_info`` by a background thread; the torch-allocator
+peak is reported alongside as a cross-check.
+
+Launch (not a pytest; a torchrun entrypoint)::
+
+    torchrun --standalone --nnodes=1 --nproc-per-node=2 \\
+        torchdr/tests/bench_input_shard_hbm.py \\
+        --samples 50000 --dim 768 --neighbors 15 --iters 100
+"""
+
+# Author: Hugues Van Assel <vanasselhugues@gmail.com>
+#
+# License: BSD 3-Clause License
+
+import argparse
+import json
+import os
+import threading
+import time
+
+import torch
+import torch.distributed as dist
+
+from torchdr import UMAP
+from torchdr.distance import FaissPlanConfig
+from torchdr.distributed import init_distributed, shutdown_distributed
+
+
+class _HBMSampler:
+    """Poll device-wide used HBM in a background thread; track the peak."""
+
+    def __init__(self, device, interval=0.004):
+        self.device = device
+        self.interval = interval
+        self._stop = threading.Event()
+        self._thread = None
+        self.baseline = 0
+        self.total = 0
+        self.peak_used = 0
+
+    def _loop(self):
+        while not self._stop.is_set():
+            free, total = torch.cuda.mem_get_info(self.device)
+            used = total - free
+            if used > self.peak_used:
+                self.peak_used = used
+            time.sleep(self.interval)
+
+    def __enter__(self):
+        free, total = torch.cuda.mem_get_info(self.device)
+        self.total = total
+        self.baseline = total - free
+        self.peak_used = self.baseline
+        self._thread = threading.Thread(target=self._loop, daemon=True)
+        self._thread.start()
+        return self
+
+    def __exit__(self, *exc):
+        self._stop.set()
+        self._thread.join()
+        # One final direct read in case the peak landed between polls.
+        free, total = torch.cuda.mem_get_info(self.device)
+        self.peak_used = max(self.peak_used, total - free)
+
+
+def _global_data(n, d, seed=0):
+    g = torch.Generator().manual_seed(seed)
+    return torch.randn(n, d, generator=g, dtype=torch.float32)
+
+
+def _shard_bounds(n, world_size, rank):
+    base, rem = divmod(n, world_size)
+    counts = [base + (1 if r < rem else 0) for r in range(world_size)]
+    offset = sum(counts[:rank])
+    return offset, counts[rank]
+
+
+def _run_case(layout, X_global, rank, world_size, device, args):
+    torch.cuda.synchronize(device)
+    torch.cuda.empty_cache()
+    torch.cuda.reset_peak_memory_stats(device)
+    dist.barrier()
+
+    if layout == "sharded":
+        offset, count = _shard_bounds(args.n, world_size, rank)
+        X_in = X_global[offset : offset + count].to(device)
+        model = UMAP(
+            n_neighbors=args.k,
+            n_components=2,
+            max_iter=args.iters,
+            random_state=0,
+            distributed=True,
+            input_layout="sharded",
+            backend="faiss",
+            init="random",
+        )
+    else:
+        X_in = X_global.to(device)
+        model = UMAP(
+            n_neighbors=args.k,
+            n_components=2,
+            max_iter=args.iters,
+            random_state=0,
+            distributed=True,
+            backend=FaissPlanConfig(),
+            init="random",
+        )
+
+    input_bytes = X_in.element_size() * X_in.nelement()
+    torch.cuda.synchronize(device)
+    dist.barrier()
+
+    with _HBMSampler(device) as sampler:
+        t0 = time.perf_counter()
+        embedding = model.fit_transform(X_in)
+        torch.cuda.synchronize(device)
+        wall = time.perf_counter() - t0
+
+    result = {
+        "layout": layout,
+        "rank": rank,
+        "rows_in": int(X_in.shape[0]),
+        "emb_rows": int(embedding.shape[0]),
+        "input_mb": input_bytes / 1024**2,
+        "peak_used_mb": sampler.peak_used / 1024**2,
+        "baseline_mb": sampler.baseline / 1024**2,
+        "peak_over_baseline_mb": (sampler.peak_used - sampler.baseline) / 1024**2,
+        "peak_torch_mb": torch.cuda.max_memory_allocated(device) / 1024**2,
+        "wall_s": wall,
+    }
+    del model, X_in, embedding
+    torch.cuda.synchronize(device)
+    torch.cuda.empty_cache()
+    dist.barrier()
+    return result
+
+
+def _gather(result):
+    bucket = [None] * dist.get_world_size()
+    dist.all_gather_object(bucket, result)
+    return bucket
+
+
+def main():
+    # NOTE: torchrun prefix-matches its own long options, so avoid arg names that
+    # abbreviate to torchrun flags (e.g. ``--n`` collides with ``--nnodes``).
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--samples", type=int, default=50000, dest="n")
+    parser.add_argument("--dim", type=int, default=768, dest="d")
+    parser.add_argument("--neighbors", type=int, default=15, dest="k")
+    parser.add_argument("--iters", type=int, default=100)
+    args = parser.parse_args()
+
+    init_distributed(backend="nccl")
+    if not dist.is_initialized() or dist.get_world_size() < 2:
+        raise SystemExit("launch under torchrun with >=2 processes")
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    local_rank = int(os.environ.get("LOCAL_RANK", 0))
+    torch.cuda.set_device(local_rank)
+    device = torch.device(f"cuda:{local_rank}")
+
+    # Warm up CUDA + FAISS so the first case does not eat context-init memory.
+    _ = torch.zeros(1, device=device)
+    torch.cuda.synchronize(device)
+
+    X_global = _global_data(args.n, args.d)
+    replicated = _gather(
+        _run_case("replicated", X_global, rank, world_size, device, args)
+    )
+    sharded = _gather(_run_case("sharded", X_global, rank, world_size, device, args))
+
+    if rank == 0:
+
+        def peak(rows):
+            return max(r["peak_used_mb"] for r in rows)
+
+        def wall(rows):
+            return max(r["wall_s"] for r in rows)
+
+        rep_peak, sh_peak = peak(replicated), peak(sharded)
+        rep_in = max(r["input_mb"] for r in replicated)
+        sh_in = max(r["input_mb"] for r in sharded)
+        header = (
+            f"\n=== input-shard HBM bench  N={args.n} d={args.d} "
+            f"k={args.k} iters={args.iters} world_size={world_size} ==="
+        )
+        print(header)
+        print(
+            f"{'layout':<11}{'per-rank input MB':>20}{'peak HBM MB':>16}"
+            f"{'peak-baseline MB':>20}{'wall s':>10}"
+        )
+        for name, rows in (("replicated", replicated), ("sharded", sharded)):
+            print(
+                f"{name:<11}{max(r['input_mb'] for r in rows):>20.1f}"
+                f"{peak(rows):>16.1f}"
+                f"{max(r['peak_over_baseline_mb'] for r in rows):>20.1f}"
+                f"{wall(rows):>10.2f}"
+            )
+        print(
+            f"\ninput tensor shrink : {rep_in:.1f} MB -> {sh_in:.1f} MB "
+            f"({rep_in / max(sh_in, 1e-9):.2f}x)"
+        )
+        print(
+            f"peak HBM shrink     : {rep_peak:.1f} MB -> {sh_peak:.1f} MB "
+            f"({rep_peak / max(sh_peak, 1e-9):.2f}x, "
+            f"{rep_peak - sh_peak:.1f} MB saved/rank)"
+        )
+        print("VERDICT:", "APPROVE" if sh_peak < rep_peak else "REFUTE")
+        print("JSON " + json.dumps({"replicated": replicated, "sharded": sharded}))
+
+    dist.barrier()
+    shutdown_distributed()
+
+
+if __name__ == "__main__":
+    main()

--- a/torchdr/tests/test_distributed_umap_input_shard.py
+++ b/torchdr/tests/test_distributed_umap_input_shard.py
@@ -1,0 +1,182 @@
+"""End-to-end distributed UMAP with ``input_layout='sharded'`` on real GPUs.
+
+``test_distributed_neighbor_embedding_gpu.py`` replicates the *full* input on
+every rank and shards only the embedding rows. These tests cover the orthogonal
+input-sharding vertical slice of issue #359/#308: every rank holds a **distinct
+contiguous shard** of the raw feature rows, the per-rank Flat index sees only
+that shard, and the embedding stays replicated. This shards the ``O(N * d)``
+input and index footprint across ranks while keeping the ``O(N * n_components)``
+embedding on every rank.
+
+The whole estimator path forces a CUDA device in distributed mode, so this is
+GPU-only and **not** wired into GitHub CI. It is gated behind
+``TORCHDR_DISTRIBUTED_GPU_TEST=1`` (plus CUDA and at least two ranks) and is run
+manually or on a provisioned multi-GPU runner::
+
+    TORCHDR_DISTRIBUTED_GPU_TEST=1 python -m torch.distributed.run \\
+        --standalone --nnodes=1 --nproc-per-node=2 \\
+        -m pytest torchdr/tests/test_distributed_umap_input_shard.py -q
+"""
+
+# Author: Hugues Van Assel <vanasselhugues@gmail.com>
+#
+# License: BSD 3-Clause License
+
+import os
+
+import pytest
+import torch
+import torch.distributed as dist
+
+from torchdr import UMAP
+from torchdr.affinity import UMAPAffinity
+from torchdr.distributed import init_distributed, shutdown_distributed
+
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("TORCHDR_DISTRIBUTED_GPU_TEST") != "1"
+    or not torch.cuda.is_available(),
+    reason="run manually on a provisioned NCCL multi-GPU runner",
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def distributed_process_group():
+    """Join the NCCL group created by torchrun; fail loudly on a single rank."""
+    init_distributed(backend="nccl")
+    if not dist.is_initialized():
+        pytest.fail("launch this module with torchrun and at least two processes")
+    local_rank = int(os.environ.get("LOCAL_RANK", 0))
+    torch.cuda.set_device(local_rank)
+    world_size = dist.get_world_size()
+    if world_size < 2:
+        shutdown_distributed()
+        pytest.fail(f"launch this module with at least two processes, got {world_size}")
+    yield
+    dist.barrier()
+    shutdown_distributed()
+
+
+def _global_data(n_samples, n_features, dtype, seed=0):
+    """Deterministic global dataset, identical on every rank before sharding."""
+    generator = torch.Generator().manual_seed(seed)
+    return torch.randn(n_samples, n_features, generator=generator, dtype=dtype)
+
+
+def _shard_counts(n, world_size, uneven=False):
+    """Rank-major shard sizes that sum to ``n`` (balanced or deliberately skewed)."""
+    base, rem = divmod(n, world_size)
+    counts = [base + (1 if r < rem else 0) for r in range(world_size)]
+    if uneven and world_size >= 2 and counts[-1] > 1:
+        shift = min(counts[-1] - 1, max(1, base // 3))
+        counts[0] += shift
+        counts[-1] -= shift
+    return counts
+
+
+def _local_shard(X_global, counts, rank):
+    """The contiguous rank-major block of rows this rank owns."""
+    offset = sum(counts[:rank])
+    return X_global[offset : offset + counts[rank]]
+
+
+def _rowwise_to_dense(values, indices, n_columns):
+    """Padded row-wise sparse (over global column ids) to dense."""
+    dense = torch.zeros((values.shape[0], n_columns), dtype=values.dtype)
+    valid = indices >= 0
+    dense.scatter_add_(1, indices.clamp_min(0), values * valid)
+    return dense
+
+
+def _gather_rows(local_dense):
+    """All-gather each rank's (variable-height) row block into the full matrix."""
+    gathered = [None] * dist.get_world_size()
+    dist.all_gather_object(gathered, local_dense.cpu())
+    return torch.cat(gathered)
+
+
+def _assert_replicated(embedding, n_samples, n_components):
+    """Embedding is finite, spans all rows, and is identical on every rank."""
+    assert embedding.shape == (n_samples, n_components)
+    assert torch.isfinite(embedding).all()
+    gathered = [None] * dist.get_world_size()
+    dist.all_gather_object(gathered, embedding.detach().cpu())
+    for other in gathered[1:]:
+        torch.testing.assert_close(gathered[0], other)
+
+
+@pytest.mark.parametrize("uneven", [False, True])
+def test_input_sharded_affinity_matches_single_process(uneven):
+    """Sharded-input affinity, reassembled, equals the single-process affinity.
+
+    Each rank searches its own shard against the reconstructed global dataset and
+    returns its row block with *global* column ids. Concatenating the blocks in
+    rank order must rebuild exactly the matrix a single replicated process
+    assembles over the same rows -- exercising the per-shard Flat search, the
+    global top-k merge, and the uneven-aware distributed symmetrization.
+    """
+    n_samples, n_features = 160, 24
+    dtype = torch.float32
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+
+    X_global = _global_data(n_samples, n_features, dtype, seed=0)
+    counts = _shard_counts(n_samples, world_size, uneven=uneven)
+    assert sum(counts) == n_samples
+    X_local = _local_shard(X_global, counts, rank).cuda()
+
+    sharded = UMAPAffinity(
+        n_neighbors=15, distributed=True, backend="faiss", input_layout="sharded"
+    )
+    local_values, local_indices = sharded(X_local)
+    assert sharded.n_global_ == n_samples
+    assert local_values.shape[0] == counts[rank]
+    local_dense = _rowwise_to_dense(local_values.cpu(), local_indices.cpu(), n_samples)
+    full = _gather_rows(local_dense)
+
+    single = UMAPAffinity(n_neighbors=15, distributed=False, backend="faiss")
+    ref_values, ref_indices = single(X_global.cuda())
+    reference = _rowwise_to_dense(ref_values.cpu(), ref_indices.cpu(), n_samples)
+
+    assert full.shape == (n_samples, n_samples)
+    torch.testing.assert_close(full, reference)
+    # sum_minus_prod symmetrization is exactly symmetric; a routing bug in the
+    # uneven-shard column exchange breaks this even when shapes line up.
+    torch.testing.assert_close(full, full.T)
+
+
+@pytest.mark.parametrize("uneven", [False, True])
+def test_input_sharded_umap_fit_spans_global(uneven):
+    """A full sharded-input UMAP fit yields a replicated global-N embedding.
+
+    The embedding, learning rate, and negative pool must all span the global row
+    count -- not the local shard -- and the replicated embedding must stay in
+    lock-step across ranks (rank-0 broadcast + all-reduced gradients).
+    """
+    n_samples, n_features, n_components = 160, 24, 2
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+
+    X_global = _global_data(n_samples, n_features, torch.float32, seed=1)
+    counts = _shard_counts(n_samples, world_size, uneven=uneven)
+    X_local = _local_shard(X_global, counts, rank).cuda()
+
+    model = UMAP(
+        n_neighbors=15,
+        n_components=n_components,
+        max_iter=50,
+        random_state=0,
+        distributed=True,
+        input_layout="sharded",
+        backend="faiss",
+        init="random",
+    )
+    embedding = model.fit_transform(X_local)
+
+    # Global-N threading: bookkeeping spans all rows, not just this shard.
+    assert model.n_global_ == n_samples
+    assert model.n_samples_in_ == n_samples
+    assert model.chunk_indices_.numel() == counts[rank]
+    if model.lr == "auto":
+        assert model.lr_ == max(n_samples / model.early_exaggeration_coeff_ / 4, 50)
+    _assert_replicated(embedding, n_samples, n_components)

--- a/torchdr/tests/test_input_shard_estimator.py
+++ b/torchdr/tests/test_input_shard_estimator.py
@@ -1,0 +1,215 @@
+"""Single-process coverage for the ``input_layout='sharded'`` estimator path.
+
+These tests exercise the sharded-input wiring that does *not* require a live
+process group: the ``ShardLayout.owner_boundaries`` table, the configuration
+guards that reject layouts the first vertical slice does not support, and the
+degenerate one-rank case where a sharded run must reproduce the replicated run
+exactly (a single shard is the whole dataset, so nothing may change). The real
+multi-rank NCCL/FAISS-GPU vertical slice is covered by
+``test_distributed_umap_input_shard.py``.
+"""
+
+# Author: Hugues Van Assel <vanasselhugues@gmail.com>
+#
+# License: BSD 3-Clause License
+
+import numpy as np
+import pytest
+import torch
+
+from torchdr import UMAP
+from torchdr.affinity import UMAPAffinity
+from torchdr.affinity_matcher import AffinityMatcher
+from torchdr.distance import FaissConfig, FaissPlanConfig
+from torchdr.distributed.input_contract import ShardLayout
+from torchdr.utils import faiss, seed_everything
+
+pytestmark = pytest.mark.skipif(
+    faiss is None or faiss is False, reason="faiss not installed"
+)
+
+
+def _blobs(n, d, seed=0):
+    rng = np.random.default_rng(seed)
+    centers = rng.normal(scale=6.0, size=(4, d))
+    labels = rng.integers(0, 4, size=n)
+    return (centers[labels] + rng.normal(scale=1.0, size=(n, d))).astype(np.float32)
+
+
+# --------------------------------------------------------------------------- #
+# ShardLayout.owner_boundaries
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "counts",
+    [(10,), (5, 5), (15, 55, 30, 20), (80, 40), (0, 7, 3)],
+)
+def test_owner_boundaries_matches_prefix_sum(counts):
+    """The boundary table is the length W+1 rank-major prefix sum."""
+    layout = ShardLayout(
+        rank=0,
+        world_size=len(counts),
+        local_count=counts[0],
+        global_count=sum(counts),
+        local_offset=0,
+        counts=tuple(counts),
+    )
+    boundaries = layout.owner_boundaries()
+    expected = [0]
+    for c in counts:
+        expected.append(expected[-1] + c)
+    assert boundaries.dtype == torch.long
+    assert boundaries.tolist() == expected
+
+    # Each interior global row must map back to the shard that owns it.
+    for rank, c in enumerate(counts):
+        for local in range(c):
+            g = expected[rank] + local
+            owner = int(torch.bucketize(torch.tensor(g), boundaries, right=True)) - 1
+            assert owner == rank
+
+
+# --------------------------------------------------------------------------- #
+# Configuration guards
+# --------------------------------------------------------------------------- #
+
+
+def test_invalid_input_layout_rejected():
+    with pytest.raises(ValueError, match="input_layout"):
+        UMAP(input_layout="partitioned")
+
+
+def test_sharded_rejects_pca_init():
+    X = _blobs(60, 8)
+    model = UMAP(
+        input_layout="sharded",
+        init="pca",
+        backend="faiss",
+        device="cpu",
+        n_neighbors=10,
+    )
+    with pytest.raises(NotImplementedError, match="init="):
+        model.fit_transform(X)
+
+
+def test_sharded_rejects_tensor_init():
+    X = _blobs(60, 8)
+    init = torch.randn(60, 2)
+    model = UMAP(
+        input_layout="sharded", init=init, backend="faiss", device="cpu", n_neighbors=10
+    )
+    with pytest.raises(NotImplementedError, match="init="):
+        model.fit_transform(X)
+
+
+def test_sharded_rejects_precomputed_affinity():
+    P = torch.rand(20, 20)
+    P = P + P.T
+    model = AffinityMatcher(
+        affinity_in="precomputed", init="random", input_layout="sharded", device="cpu"
+    )
+    with pytest.raises(NotImplementedError, match="precomputed"):
+        model.fit_transform(P)
+
+
+def test_sharded_rejects_faiss_plan_config():
+    with pytest.raises(ValueError, match="FaissPlanConfig"):
+        UMAPAffinity(
+            input_layout="sharded", backend=FaissPlanConfig(), distributed=False
+        )
+
+
+def test_sharded_rejects_non_flat_faiss_config():
+    with pytest.raises(NotImplementedError, match="Flat"):
+        UMAPAffinity(
+            input_layout="sharded",
+            backend=FaissConfig(index_type="IVF", nlist=16),
+            distributed=False,
+        )
+
+
+def test_sharded_forces_process_duplicates_off():
+    model = UMAP(input_layout="sharded", process_duplicates=True, device="cpu")
+    assert model.process_duplicates is False
+    # The replicated default is untouched.
+    assert UMAP(process_duplicates=True).process_duplicates is True
+
+
+# --------------------------------------------------------------------------- #
+# Degenerate one-rank equivalence: a single shard is the whole dataset.
+# --------------------------------------------------------------------------- #
+
+
+def _dense(t):
+    """Densify a sparse tensor of any layout; pass dense tensors through."""
+    return t if t.layout == torch.strided else t.to_dense()
+
+
+def _fit(layout, X, seed=0):
+    seed_everything(seed)
+    model = UMAP(
+        input_layout=layout,
+        init="random",
+        backend="faiss",
+        device="cpu",
+        n_neighbors=10,
+        max_iter=25,
+        random_state=seed,
+    )
+    emb = model.fit_transform(X)
+    return model, torch.as_tensor(emb)
+
+
+def _umap_affinity(layout, X):
+    aff = UMAPAffinity(
+        n_neighbors=10, backend="faiss", device="cpu", input_layout=layout
+    )
+    P, idx = aff(X, return_indices=True)
+    return aff, P, idx
+
+
+def test_single_process_sharded_affinity_matches_replicated():
+    """The deterministic symmetrized affinity is identical in the one-rank case.
+
+    A single shard is the whole dataset, so resolving the layout and running the
+    per-shard Flat search must reproduce the replicated exact search bit-for-bit.
+    Comparing here (rather than on the fitted UMAP) avoids UMAP's post-build
+    deletion of ``affinity_in_``/``NN_indices_``.
+    """
+    X = _blobs(120, 16, seed=1)
+
+    aff_rep, P_rep, idx_rep = _umap_affinity("replicated", X)
+    aff_shard, P_shard, idx_shard = _umap_affinity("sharded", X)
+
+    # The sharded affinity records the global sample total.
+    assert aff_shard.n_global_ == X.shape[0]
+
+    # Symmetrized memberships (order-independent) must coincide, and the neighbor
+    # sets per row must match (sorted to ignore any column permutation).
+    torch.testing.assert_close(_dense(P_shard), _dense(P_rep), rtol=1e-5, atol=1e-6)
+    torch.testing.assert_close(
+        idx_shard.sort(dim=1).values, idx_rep.sort(dim=1).values, rtol=0, atol=0
+    )
+
+
+def test_single_process_sharded_embedding_matches_replicated():
+    """End-to-end: with no process group the fitted embedding coincides."""
+    X = _blobs(120, 16, seed=1)
+
+    rep_model, rep_emb = _fit("replicated", X)
+    shard_model, shard_emb = _fit("sharded", X)
+
+    # Global-N bookkeeping is unchanged in the one-rank case.
+    assert shard_model.n_samples_in_ == X.shape[0]
+    assert shard_emb.shape == (X.shape[0], 2)
+
+    # Same seed + identical affinity + identical single-process optimization ->
+    # the embeddings coincide.
+    torch.testing.assert_close(shard_emb, rep_emb, rtol=1e-4, atol=1e-4)
+
+
+def test_single_process_sharded_embedding_is_finite():
+    X = _blobs(90, 12, seed=3)
+    _, emb = _fit("sharded", X)
+    assert torch.isfinite(emb).all()

--- a/torchdr/tests/test_input_shard_estimator.py
+++ b/torchdr/tests/test_input_shard_estimator.py
@@ -140,13 +140,7 @@ def test_estimator_and_affinity_layouts_must_match():
 
 
 def test_sharded_accepts_explicit_flat_faiss_config():
-    """An explicit exact-Flat ``FaissConfig`` is the one accepted backend override.
-
-    The non-Flat and ``FaissPlanConfig`` rejections above only prove the guard
-    fires; this pins the positive branch so a user who passes ``FaissConfig()``
-    (whose ``index_type`` defaults to ``"Flat"``) keeps their own config object
-    rather than having it silently replaced.
-    """
+    """An explicit exact-Flat configuration runs through the sharded path."""
     config = FaissConfig()
     aff = UMAPAffinity(
         n_neighbors=10,
@@ -155,7 +149,9 @@ def test_sharded_accepts_explicit_flat_faiss_config():
         input_layout="sharded",
         distributed=False,
     )
-    assert aff._sharded_faiss_config_ is config
+    values, indices = aff(torch.as_tensor(_blobs(40, 8)))
+    assert values.shape == indices.shape
+    assert values.shape[0] == 40
 
 
 def test_sharded_rejects_dataloader():
@@ -264,9 +260,3 @@ def test_single_process_sharded_embedding_matches_replicated():
     # Same seed + identical affinity + identical single-process optimization ->
     # the embeddings coincide.
     torch.testing.assert_close(shard_emb, rep_emb, rtol=1e-4, atol=1e-4)
-
-
-def test_single_process_sharded_embedding_is_finite():
-    X = _blobs(90, 12, seed=3)
-    _, emb = _fit("sharded", X)
-    assert torch.isfinite(emb).all()

--- a/torchdr/tests/test_input_shard_estimator.py
+++ b/torchdr/tests/test_input_shard_estimator.py
@@ -129,6 +129,48 @@ def test_sharded_rejects_non_flat_faiss_config():
         )
 
 
+def test_sharded_accepts_explicit_flat_faiss_config():
+    """An explicit exact-Flat ``FaissConfig`` is the one accepted backend override.
+
+    The non-Flat and ``FaissPlanConfig`` rejections above only prove the guard
+    fires; this pins the positive branch so a user who passes ``FaissConfig()``
+    (whose ``index_type`` defaults to ``"Flat"``) keeps their own config object
+    rather than having it silently replaced.
+    """
+    config = FaissConfig()
+    aff = UMAPAffinity(
+        n_neighbors=10,
+        backend=config,
+        device="cpu",
+        input_layout="sharded",
+        distributed=False,
+    )
+    assert aff._sharded_faiss_config_ is config
+
+
+def test_sharded_rejects_dataloader():
+    """A DataLoader has no addressable row shard, so the layout is rejected."""
+    from torch.utils.data import DataLoader, TensorDataset
+
+    loader = DataLoader(TensorDataset(torch.as_tensor(_blobs(40, 8))), batch_size=8)
+    model = UMAP(input_layout="sharded", backend="faiss", device="cpu", n_neighbors=10)
+    with pytest.raises(NotImplementedError, match="DataLoader"):
+        model.fit_transform(loader)
+
+
+def test_sharded_rejects_encoder():
+    """An encoder maps rows to a learned space, breaking the raw-row shard contract."""
+    model = AffinityMatcher(
+        affinity_in=UMAPAffinity(n_neighbors=10, backend="faiss", device="cpu"),
+        init="random",
+        input_layout="sharded",
+        device="cpu",
+        encoder=torch.nn.Linear(8, 4),
+    )
+    with pytest.raises(NotImplementedError, match="encoder"):
+        model.fit_transform(_blobs(60, 8))
+
+
 def test_sharded_forces_process_duplicates_off():
     model = UMAP(input_layout="sharded", process_duplicates=True, device="cpu")
     assert model.process_duplicates is False

--- a/torchdr/tests/test_input_shard_estimator.py
+++ b/torchdr/tests/test_input_shard_estimator.py
@@ -17,7 +17,7 @@ import numpy as np
 import pytest
 import torch
 
-from torchdr import UMAP
+from torchdr import SNE, UMAP
 from torchdr.affinity import UMAPAffinity
 from torchdr.affinity_matcher import AffinityMatcher
 from torchdr.distance import FaissConfig, FaissPlanConfig
@@ -129,6 +129,16 @@ def test_sharded_rejects_non_flat_faiss_config():
         )
 
 
+def test_sharded_rejects_explicit_non_faiss_backend():
+    with pytest.raises(ValueError, match="requires backend='faiss'"):
+        UMAPAffinity(input_layout="sharded", backend="keops", distributed=False)
+
+
+def test_estimator_and_affinity_layouts_must_match():
+    with pytest.raises(ValueError, match="must match affinity_in.input_layout"):
+        SNE(input_layout="sharded")
+
+
 def test_sharded_accepts_explicit_flat_faiss_config():
     """An explicit exact-Flat ``FaissConfig`` is the one accepted backend override.
 
@@ -161,7 +171,12 @@ def test_sharded_rejects_dataloader():
 def test_sharded_rejects_encoder():
     """An encoder maps rows to a learned space, breaking the raw-row shard contract."""
     model = AffinityMatcher(
-        affinity_in=UMAPAffinity(n_neighbors=10, backend="faiss", device="cpu"),
+        affinity_in=UMAPAffinity(
+            n_neighbors=10,
+            backend="faiss",
+            device="cpu",
+            input_layout="sharded",
+        ),
         init="random",
         input_layout="sharded",
         device="cpu",


### PR DESCRIPTION
## Summary

- Completes **step 3** of the input-sharding decomposition (#359, child of #301/#308): a distributed UMAP / NeighborEmbedding fit where each rank holds only its **contiguous `(N/W, d)` shard** of the raw features and indexes just that shard, while the embedding stays **replicated** at the global row count. This splits the `O(N·d)` input and FAISS-index footprint across ranks; the `O(N·n_components)` embedding stays on every rank.
- Adds a public `input_layout` in `{"replicated", "sharded"}` to `SparseAffinity`, `UMAPAffinity`, `AffinityMatcher`, `NeighborEmbedding` and `UMAP`. The default `"replicated"` leaves every existing path unchanged.
- The sharded path resolves a `ShardLayout` once, drives the per-shard exact Flat search through `input_sharded_pairwise_distances_faiss`, and threads the gathered **global** sample count through neighbor-count validation, the auto learning rate, the negative-sampling pool, the affinity chunk bounds and the rank-0 embedding broadcast, so the replicated embedding spans global `N`.
- `ShardLayout.owner_boundaries` exposes the length-`(W+1)` prefix table that routes uneven-shard column owners in the distributed symmetrization.
- Guards reject the configurations this first vertical slice does not support: pca/tensor `init`, precomputed affinity, `DataLoader` input, `FaissPlanConfig`, and non-Flat FAISS backends.
- Builds on #360 (input-layout contract + sharded exact-Flat kernel) and #364 (uneven-shard symmetrization), both merged.

## Verdict

**APPROVE.** Row-sharding the input shrinks the per-rank feature tensor exactly `1/W` (2.00× at `W=2`, 4.00× at `W=4`) with bit-identical neighbor structure — the GPU oracle passes for balanced *and* uneven shards at both world sizes, and the single-process case reproduces the replicated affinity and embedding exactly. Per-rank peak device HBM drops 2.07× (≈6.2 GB/rank saved) at `N=100 000, d=768, W=2`. The embedding stays replicated, so the entire saving comes from the `O(N·d)` input + FAISS-index footprint that input-sharding splits, which is precisely what #359/#308 target.

## Benchmark — real NCCL + FAISS-GPU (B200)

`N=100 000, d=768, k=15, iters=100`. Per-rank maxima across ranks; peak HBM is device-wide via `cuda.mem_get_info` (so it captures FAISS allocations made outside the torch caching allocator). The replicated row is the pre-input-sharding distributed path (full input on every rank, `FaissPlanConfig` index-sharding). Each world size was measured on a single node (2× and 4× B200).

**`world_size = 2` (2× B200)**

| layout | per-rank input | peak HBM / rank | wall s |
|---|---:|---:|---:|
| replicated (pre-sharding) | 293.0 MB | 12 041.8 MB | 1.36 |
| sharded (this PR) | 146.5 MB | 5 807.8 MB | 0.22 |
| **reduction** | **2.00×** | **2.07× (6.2 GB/rank)** | — |

**`world_size = 4` (4× B200)**

| layout | per-rank input | peak HBM / rank | wall s |
|---|---:|---:|---:|
| replicated (pre-sharding) | 293.0 MB | 9 525.8 MB | 2.74 |
| sharded (this PR) | 73.2 MB | 5 465.8 MB | 0.18 |
| **reduction** | **4.00×** | **1.74×** | — |

The per-rank input tensor tracks `1/W` exactly (2.00× → 4.00×): no rank materializes `N×d`. The `W=4` absolute peak-HBM ratio (1.74×) is *understated* by arm ordering — the sharded arm runs second and inherits ~5.3 GB of CUDA+FAISS context left resident by the replicated arm as its baseline, so its 5 465.8 MB peak is dominated by carried-over context rather than the fit itself. Measuring each arm's growth over its own baseline gives **7 322 MB (replicated) versus 150 MB (sharded)**, so the true per-rank saving lies between the conservative 1.74× and that incremental bound, anchored by the exact `1/W` input+index reduction. This matches the mechanism: each rank indexes only `N/W` rows and the embedding stays replicated, so the sharded fit's own device footprint is small and shrinks with `W`.

## Test plan

- **CPU unit** — `torchdr/tests/test_input_shard_estimator.py` (19 tests): `owner_boundaries` prefix-sum + owner round-trip, the config guards above, and single-process equivalence (a one-rank shard reproduces the replicated affinity and embedding exactly).
- **Regression** — `test_affinity`, `test_affinity_matcher`, `test_umap_csr`, `test_neighbor_embedding`, `test_faiss_plan`, `test_faiss_runtime`, `test_sparse`: 138 passed, 7 skipped (default replicated path unchanged).
- **GPU oracle** — `torchdr/tests/test_distributed_umap_input_shard.py` (gated by `TORCHDR_DISTRIBUTED_GPU_TEST=1`, run under torchrun on 2× **and** 4× B200), balanced and uneven shards (4 passed at each world size): the sharded-input affinity gathered in rank order equals the single-process replicated affinity and is exactly symmetric; a full fit yields `n_global_ == n_samples_in_ == N`, per-rank gradient chunk equal to the shard size, the auto learning rate keyed to global `N`, and a replicated embedding held in lock-step across ranks.
- **[Perf]** — `benchmarks/faiss/input_shard_hbm.py` (torchrun entrypoint): the tables above.

