### PR TITLE
[Test] Cover the GPU-only distributed auto-setup policy

### DIFF
--- a/torchdr/tests/test_distributed.py
+++ b/torchdr/tests/test_distributed.py
@@ -151,6 +151,28 @@ class TestShutdownDistributed:
         mock_destroy.assert_called_once()
 
 
+class TestAutoSetupDistributed:
+    """The import-time auto-setup is GPU-only by policy.
+
+    Unlike the explicit :func:`init_distributed`, which still builds a Gloo group
+    on a CPU launcher, the setup run automatically on import refuses to create a
+    process group when no GPU is present and tells the user why. That asymmetry
+    is deliberate, so lock it down.
+    """
+
+    def test_cpu_launcher_warns_and_skips_process_group(self, monkeypatch):
+        """LOCAL_RANK without a GPU must warn and create no process group."""
+        monkeypatch.setenv("LOCAL_RANK", "0")
+
+        with patch("torch.distributed.is_initialized", return_value=False):
+            with patch("torch.cuda.is_available", return_value=False):
+                with patch("torch.distributed.init_process_group") as mock_init:
+                    with pytest.warns(UserWarning, match="no GPU is available"):
+                        torchdr_distributed._auto_setup_distributed()
+
+        mock_init.assert_not_called()
+
+
 class TestDistributedContext:
     """Tests for DistributedContext class."""
 


### PR DESCRIPTION
Closes #366.

### Summary
- Add one focused regression test for the GPU-only policy of the import-time
  distributed auto-setup (`_auto_setup_distributed`).
- Assert that a CPU-only launcher (`LOCAL_RANK` set, no CUDA) warns the user and
  creates no process group — the deliberate asymmetry with the explicit
  `init_distributed`, whose Gloo-on-CPU path is already covered.
- Test-only; no production code changes.

### Test plan
- `pytest torchdr/tests/test_distributed.py` passes (32 tests) on a CPU node.
- Non-vacuity verified: the new test passes on `main` and fails when the CUDA
  guard in `_auto_setup_distributed` is removed (auto-setup then attempts an
  unconditional NCCL init on a CPU launch).
