### PR TITLE
[Test] Cover the distributed chunk-bounds affinity guard

### DIFF
--- a/torchdr/tests/test_distributed.py
+++ b/torchdr/tests/test_distributed.py
@@ -402,6 +402,20 @@ class TestChunkStartOffset:
 
         assert covered == n_samples
 
+    def test_distributed_model_requires_distributed_affinity(self):
+        """A distributed model paired with a non-distributed affinity fails fast."""
+        model = SNE(n_components=2)
+        model.rank = 0
+        model.world_size = 2
+        model.device_ = torch.device("cpu")
+        model.n_samples_in_ = 8
+        # affinity_in was not set up with distributed=True, so it carries no
+        # chunk bounds; the estimator must reject this instead of silently
+        # letting every rank process all rows.
+        assert not hasattr(model.affinity_in, "chunk_start_")
+        with pytest.raises(ValueError, match="chunk bounds"):
+            model.on_affinity_computation_end()
+
     def test_training_step_scatters_gradients_at_the_offset(self):
         """The gradient must land on this rank's rows and nowhere else."""
         n_samples, n_components = 7, 2


### PR DESCRIPTION
### Summary

- Adds a focused regression test for the distributed chunk-bounds guard in
  `NeighborEmbedding.on_affinity_computation_end`.
- When a model runs distributed (`world_size > 1`) but its `affinity_in` was not
  set up distributed, the affinity has no chunk bounds and the estimator raises
  `ValueError`; without the guard the run would silently fall through to the
  single-GPU path and give every rank the full sample range instead of its slice.
- The existing `TestChunkStartOffset` tests cover only the bounds-present paths;
  this adds the error-path counterpart. Test-only, no production code changed.

### Test plan

- New test placed beside the existing chunk tests in `TestChunkStartOffset`;
  CPU-only, no process group required (the guard fires in
  `on_affinity_computation_end`, before any collective).
- Verified on a CPU allocation with the project environment: the new test and the
  full `TestChunkStartOffset` class pass on current `main`; the new test fails
  when the guard is removed (the misconfiguration then falls through to the
  single-GPU chunk instead of raising).
- `ruff` and `ruff format --check` clean.

Closes #370
