### PR TITLE
[Test] Cover the distributed encoder guard in the training step

### DIFF
--- a/torchdr/tests/test_distributed.py
+++ b/torchdr/tests/test_distributed.py
@@ -452,3 +452,23 @@ class TestChunkStartOffset:
         model._exit_transform(saved)
         assert model.chunk_start_ == 2
         assert model.chunk_start_ == model.chunk_indices_[0].item()
+
+
+class TestEncoderDistributedGuard:
+    """A parametric encoder is unsupported alongside distributed closed-form gradients."""
+
+    def test_training_step_rejects_encoder_in_distributed(self):
+        """The closed-form encoder path must raise instead of misapplying gradients."""
+        n_samples, n_components = 5, 2
+
+        model = UMAP(n_components=n_components, optimizer="SGD", lr=0.0)
+        model.world_size = 2
+        model.scheduler_ = None
+        # The encoder produces the embedding, so its parameters carry the grads.
+        model.encoder = torch.nn.Linear(n_components, n_components)
+        model.X_train_ = torch.zeros(n_samples, n_components)
+        model.optimizer_ = torch.optim.SGD(model.encoder.parameters(), lr=0.0)
+        model._compute_gradients = lambda: torch.ones(n_samples, n_components)
+
+        with pytest.raises(NotImplementedError, match="encoder with distributed"):
+            model._training_step()


### PR DESCRIPTION
## Summary
- Adds a focused regression test for the previously-uncovered guard in `AffinityMatcher._training_step` that rejects a parametric encoder combined with distributed closed-form gradients (`encoder is not None` and `world_size > 1`), which raises `NotImplementedError`.
- Test-only; no production code is modified.

## Test plan
- Candidate (guard present): the new test passes.
- Baseline (guard removed): the new test fails with `DID NOT RAISE NotImplementedError`, confirming it exercises the guard rather than passing vacuously.
- Full `torchdr/tests/test_distributed.py` suite passes (32 tests) on CPU.

Closes #372