### PR TITLE
[Fix] Make FAISS distribution selection explicit

### DIFF
--- a/torchdr/distance/faiss_plan.py
+++ b/torchdr/distance/faiss_plan.py
@@ -10,7 +10,7 @@ from typing import Optional, Tuple, Union
 from .faiss import FaissConfig
 
 _VALID_MODES = ("exact", "balanced", "fast")
-_VALID_DISTRIBUTIONS = ("auto", "replicate", "shard")
+_VALID_DISTRIBUTIONS = ("replicate", "shard")
 
 
 @dataclass(frozen=True)
@@ -27,12 +27,17 @@ class FaissPlanConfig:
     mode : {"exact", "balanced", "fast"}, default="exact"
         Accuracy/speed intent. Only ``"exact"`` is currently implemented;
         ``"balanced"`` and ``"fast"`` raise :class:`NotImplementedError`.
-    distribution : {"auto", "replicate", "shard"}, default="auto"
+    distribution : {"replicate", "shard"}, default="replicate"
         Multi-GPU topology. ``"replicate"`` builds the full index on every rank.
         ``"shard"`` splits an exact ``Flat`` index across ranks. The input tensor
-        remains replicated under TorchDR's current distributed-input contract.
-        ``"auto"`` currently preserves the existing replicated-index strategy;
-        automatic memory-aware selection is not yet implemented.
+        remains replicated under this index-sharding contract. Select
+        ``input_layout="sharded"`` on a supported estimator or affinity instead
+        when the input rows themselves are already partitioned across ranks.
+
+        Topology selection is explicit because a portable pre-search memory
+        estimate cannot account reliably for FAISS's device- and version-specific
+        resource pool, search scratch, and other live allocations. Replication is
+        the default throughput path; sharding is the opt-in aggregate-memory path.
     expert : FaissConfig, optional
         Explicit low-level override for advanced users. It cannot be combined
         with a non-default mode. The object is copied during resolution.
@@ -46,7 +51,7 @@ class FaissPlanConfig:
     """
 
     mode: str = "exact"
-    distribution: str = "auto"
+    distribution: str = "replicate"
     expert: Optional[FaissConfig] = None
 
     def __post_init__(self):
@@ -148,8 +153,6 @@ def _resolve_faiss_plan(
             )
         distribution = "shard"
     else:
-        # Automatic memory-aware selection needs a trustworthy total peak-memory
-        # estimate. Until that exists, preserve the established fast path.
         distribution = "replicate"
 
     index_memory_bytes = None

--- a/torchdr/tests/test_faiss_plan.py
+++ b/torchdr/tests/test_faiss_plan.py
@@ -46,7 +46,7 @@ def test_config_defaults_are_exact_and_immutable():
     config = FaissPlanConfig()
     assert (config.mode, config.distribution, config.expert) == (
         "exact",
-        "auto",
+        "replicate",
         None,
     )
     with pytest.raises(FrozenInstanceError):
@@ -58,6 +58,7 @@ def test_config_defaults_are_exact_and_immutable():
     ("kwargs", "error"),
     [
         ({"mode": "turbo"}, ValueError),
+        ({"distribution": "auto"}, ValueError),
         ({"distribution": "single"}, ValueError),
         ({"expert": "not-a-config"}, TypeError),
         (
@@ -114,17 +115,6 @@ def test_shard_without_a_group_resolves_to_single():
         distributed_ctx=_FakeContext(world_size=1),
     )
     assert plan.distribution == "single"
-
-
-def test_auto_preserves_replication_until_memory_selection_is_implemented():
-    ctx = _FakeContext(world_size=2)
-    plan, _ = _resolve_faiss_plan(
-        FaissPlanConfig(distribution="auto"),
-        n_samples=1_000,
-        n_features=8,
-        distributed_ctx=ctx,
-    )
-    assert plan.distribution == "replicate"
 
 
 def test_explicit_shard_rejects_unsupported_expert_index():


### PR DESCRIPTION
## Summary

- make replicated FAISS indexes the explicit default
- keep exact index sharding as an explicit opt-in capacity strategy
- reject the previously accepted `auto` value, which always resolved to replication and implied a memory-aware choice that was not implemented
- document when to use true sharded inputs instead

## Design decision

A safe portable selector cannot reliably predict peak memory before search. On the provisioned B200/FAISS 1.11 environment, constructing an empty GPU Flat index materialized about 1.68 GB beyond the process baseline; creating standard GPU resources alone did not. Search scratch, configured temporary pools, dtype conversion, outputs, and unrelated live allocations add runtime-dependent memory. A fixed estimate would therefore risk choosing replication and failing with OOM.

Existing roadmap benchmarks also show that replication is the throughput path when it fits, while index sharding is primarily a capacity option. True input sharding is the larger memory-saving mechanism and is already exposed separately. Making the topology explicit is safer and simpler than retaining a non-functional automatic mode. The runtime behavior of the default is unchanged: it resolved to replication before and still does now.

## Validation

- 36 focused FAISS plan and sharded-input estimator tests
- real 2-process FAISS training tests: 7 passed per rank
- real 4-process exact sharded-search tests: 16 passed per rank
- two-B200 distributed UMAP/InfoTSNE integration suite: 4 passed per rank
- repository-wide pre-commit checks

Closes #301