### PR TITLE
[Feature] Support PCA init with sharded UMAP inputs

### DIFF
--- a/torchdr/affinity_matcher.py
+++ b/torchdr/affinity_matcher.py
@@ -230,7 +230,7 @@ class AffinityMatcher(DRModule):
         Input-sharding splits the *rows* of a raw feature tensor across ranks and
         keeps the embedding replicated. Layouts that would make a row's global
         identity ambiguous -- a DataLoader, a precomputed affinity, an encoder,
-        or a PCA/tensor initialization that assumes the whole input is locally
+        or a tensor initialization that assumes the whole input is locally
         available -- are rejected with an actionable message rather than silently
         producing a wrong global embedding.
         """
@@ -251,13 +251,12 @@ class AffinityMatcher(DRModule):
             )
         if not (
             isinstance(self.init, str)
-            and self.init in ("random", "normal", "hyperbolic")
+            and self.init in ("random", "normal", "hyperbolic", "pca")
         ):
             raise NotImplementedError(
                 "[TorchDR] input_layout='sharded' currently supports only "
-                "init='random', 'normal', or 'hyperbolic'; a distributed "
-                f"gather-based initialization for {self.init!r} is a follow-up. "
-                "Pass init='random'."
+                "init='random', 'normal', 'hyperbolic', or 'pca'; "
+                f"got {self.init!r}."
             )
 
     def _fit_transform(self, X: torch.Tensor, y: Optional[Any] = None) -> torch.Tensor:

--- a/torchdr/neighbor_embedding/base.py
+++ b/torchdr/neighbor_embedding/base.py
@@ -289,6 +289,7 @@ class NeighborEmbedding(AffinityMatcher):
             self._validate_sharded_input(X)
             dist_ctx = getattr(self.affinity_in, "dist_ctx", None)
             layout = gather_shard_layout(X, dist_ctx if self.distributed else None)
+            self._shard_layout_ = layout
             self.n_global_ = layout.global_count
             n_samples = layout.global_count
         else:
@@ -434,6 +435,38 @@ class NeighborEmbedding(AffinityMatcher):
 
     def _init_embedding(self, X: torch.Tensor):
         """Initialize embedding across ranks (broadcast from rank 0)."""
+        if (
+            getattr(self, "input_layout", "replicated") == "sharded"
+            and self.init == "pca"
+            and self.world_size > 1
+        ):
+            from torchdr.spectral_embedding.pca import PCA
+
+            # Distributed PCA aggregates only the feature covariance and returns
+            # this rank's projected rows. Gathering those small projections is
+            # enough to build the replicated embedding without ever gathering X.
+            local_embedding = PCA(
+                n_components=self.n_components,
+                device=self.device,
+                distributed=True,
+                process_duplicates=False,
+            ).fit_transform(X)
+            local_embedding = local_embedding.to(self.device_)
+
+            layout = self._shard_layout_
+            max_count = max(layout.counts)
+            padded = local_embedding.new_zeros((max_count, self.n_components))
+            padded[: layout.local_count] = local_embedding
+            gathered = [torch.empty_like(padded) for _ in layout.counts]
+            dist.all_gather(gathered, padded)
+            embedding = torch.cat(
+                [rows[:count] for rows, count in zip(gathered, layout.counts)]
+            )
+            self.embedding_ = (
+                self.init_scaling * embedding / embedding[:, 0].std()
+            ).requires_grad_()
+            return self.embedding_
+
         # All ranks must run _init_embedding to avoid NCCL deadlocks
         # (e.g., PCA init may trigger distributed ops internally).
         super()._init_embedding(X)

--- a/torchdr/neighbor_embedding/umap.py
+++ b/torchdr/neighbor_embedding/umap.py
@@ -139,8 +139,8 @@ class UMAP(NegativeSamplingNeighborEmbedding):
         - "sharded": each rank holds a distinct contiguous shard whose rows
           concatenate, in rank order, into the global dataset, so no rank ever
           materializes the whole input. Requires an exact Flat FAISS backend and
-          ``init`` in {"random", "normal", "hyperbolic"}; the embedding stays
-          replicated (one coordinate per global point on every rank).
+          ``init`` in {"random", "normal", "hyperbolic", "pca"}; the embedding
+          stays replicated (one coordinate per global point on every rank).
         Default is "replicated".
 
     Notes

--- a/torchdr/tests/test_distributed_umap_input_shard.py
+++ b/torchdr/tests/test_distributed_umap_input_shard.py
@@ -31,6 +31,7 @@ import torch.distributed as dist
 from torchdr import UMAP
 from torchdr.affinity import UMAPAffinity
 from torchdr.distributed import init_distributed, shutdown_distributed
+from torchdr.spectral_embedding import PCA
 
 
 pytestmark = pytest.mark.skipif(
@@ -179,4 +180,44 @@ def test_input_sharded_umap_fit_spans_global(uneven):
     assert model.chunk_indices_.numel() == counts[rank]
     if model.lr == "auto":
         assert model.lr_ == max(n_samples / model.early_exaggeration_coeff_ / 4, 50)
+    _assert_replicated(embedding, n_samples, n_components)
+
+
+def test_input_sharded_pca_init_matches_global_pca():
+    """The default initializer uses all shards without gathering raw features."""
+    n_samples, n_features, n_components = 161, 24, 2
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+
+    X_global = _global_data(n_samples, n_features, torch.float32, seed=2).cuda()
+    counts = _shard_counts(n_samples, world_size, uneven=True)
+    X_local = _local_shard(X_global, counts, rank)
+
+    model = UMAP(
+        n_neighbors=15,
+        n_components=n_components,
+        max_iter=0,
+        scheduler=None,
+        distributed=True,
+        input_layout="sharded",
+        backend="faiss",
+    )
+    embedding = model.fit_transform(X_local)
+
+    reference = PCA(
+        n_components=n_components,
+        distributed=False,
+        process_duplicates=False,
+    ).fit_transform(X_global)
+    reference = model.init_scaling * reference / reference[:, 0].std()
+
+    # PCA axes are defined up to sign. Align each coordinate before comparison.
+    signs = torch.sign((embedding * reference).sum(dim=0))
+    signs.masked_fill_(signs == 0, 1)
+    torch.testing.assert_close(
+        embedding * signs,
+        reference,
+        rtol=2e-4,
+        atol=2e-5,
+    )
     _assert_replicated(embedding, n_samples, n_components)

--- a/torchdr/tests/test_input_shard_estimator.py
+++ b/torchdr/tests/test_input_shard_estimator.py
@@ -80,7 +80,7 @@ def test_invalid_input_layout_rejected():
         UMAP(input_layout="partitioned")
 
 
-def test_sharded_rejects_pca_init():
+def test_sharded_accepts_pca_init():
     X = _blobs(60, 8)
     model = UMAP(
         input_layout="sharded",
@@ -88,9 +88,11 @@ def test_sharded_rejects_pca_init():
         backend="faiss",
         device="cpu",
         n_neighbors=10,
+        max_iter=5,
     )
-    with pytest.raises(NotImplementedError, match="init="):
-        model.fit_transform(X)
+    embedding = model.fit_transform(X)
+    assert embedding.shape == (60, 2)
+    assert np.isfinite(embedding).all()
 
 
 def test_sharded_rejects_tensor_init():


### PR DESCRIPTION
## Summary

- allow the default `init="pca"` with `input_layout="sharded"`
- compute PCA from per-rank feature statistics without gathering the raw input
- gather only the low-dimensional local projections needed by TorchDR's currently replicated embedding
- support uneven contiguous shards and CPU- or CUDA-resident input tensors

This removes an important usability trap: opting into true input sharding no longer requires users to override UMAP's default initializer. The implementation reuses TorchDR's distributed PCA and keeps the data contract explicit. Tensor initializers remain rejected because their global-versus-local layout is ambiguous.

## Four-GPU benchmark

Initializer-only benchmark on four B200 GPUs, float32 input with 4,000,000 rows and 128 features, six repetitions with alternating arm order. Reported memory is the maximum rank and timings are median synchronized wall time.

| Input layout | Init time | Peak PyTorch HBM/rank |
| --- | ---: | ---: |
| Replicated | 21.6 ms | 5,931 MiB |
| Sharded + projection gather | 7.2 ms | 1,351 MiB |

For this initializer workload, sharding reduced peak per-rank HBM by 77% and was 3.0x faster. This is not a claim about full UMAP wall time, where FAISS search and optimization also contribute. The benchmark script was intentionally not committed.

## Validation

- 19 single-process sharded-input estimator tests
- 42 neighbor-embedding, estimator, and PCA tests (6 expected failures)
- real two-process distributed PCA collectives
- full sharded-input UMAP suite on four B200 GPUs: 5 passed per rank, including uneven shards
- post-rebase numerical PCA-init regression on two B200 GPUs
- repository-wide pre-commit checks

Advances #359 and #308.