### PR TITLE
[Feature] Compose sharded inputs with FAISS plans

### DIFF
--- a/torchdr/affinity/base.py
+++ b/torchdr/affinity/base.py
@@ -455,36 +455,36 @@ class SparseAffinity(Affinity):
         """Validate and cache the exact Flat config used by the sharded path.
 
         Input-sharding builds a per-rank Flat index over each shard and merges
-        the global top-k, so it composes only with exact ``Flat`` search. A
-        :class:`FaissPlanConfig` selects the orthogonal *index*-sharding strategy
-        (full input replicated on every rank, index split), which is mutually
-        exclusive with splitting the rows themselves.
+        the global top-k, so it composes only with exact ``Flat`` search. A high-
+        level plan must explicitly request the matching sharded index topology;
+        replicated intent is contradictory when the caller supplies row shards.
         """
         backend = self.backend
         if isinstance(backend, FaissPlanConfig):
-            raise ValueError(
-                "[TorchDR] input_layout='sharded' cannot be combined with a "
-                "FaissPlanConfig: input-sharding (rows split across ranks) and "
-                "the FaissPlanConfig index-sharding strategy (input replicated, "
-                "index split) are mutually exclusive. Pass a plain FaissConfig "
-                "or backend='faiss'."
-            )
-        if isinstance(backend, FaissConfig):
-            if backend.index_type != "Flat":
-                raise NotImplementedError(
-                    "[TorchDR] input_layout='sharded' currently supports only "
-                    f"exact 'Flat' search, got index_type={backend.index_type!r}."
-                    " An approximate sharded index is a separate follow-up."
+            if backend.distribution != "shard":
+                raise ValueError(
+                    "[TorchDR] input_layout='sharded' requires "
+                    "FaissPlanConfig(distribution='shard'); replicated index "
+                    "intent contradicts a row-sharded input."
                 )
-            self._sharded_faiss_config_ = backend
+            _, resolved = _resolve_faiss_plan(backend)
+        elif isinstance(backend, FaissConfig):
+            resolved = backend
         elif backend in ("faiss", None):
-            self._sharded_faiss_config_ = FaissConfig()
+            resolved = FaissConfig()
         else:
             raise ValueError(
                 "[TorchDR] input_layout='sharded' requires backend='faiss' or "
                 "an exact-Flat FaissConfig; an explicitly selected non-FAISS "
                 f"backend cannot be used, got {backend!r}."
             )
+        if resolved.index_type != "Flat":
+            raise NotImplementedError(
+                "[TorchDR] input_layout='sharded' currently supports only "
+                f"exact 'Flat' search, got index_type={resolved.index_type!r}."
+                " An approximate sharded index is a separate follow-up."
+            )
+        self._sharded_faiss_config_ = resolved
 
     def _resolve_shard_layout(self, X):
         """Gather (once per call) and cache this input's rank-major shard layout.
@@ -587,7 +587,19 @@ class SparseAffinity(Affinity):
         # path calls the input-sharded kernel directly and records the chunk
         # bounds from the true shard offsets.
         if self.input_layout == "sharded":
-            self._resolve_shard_layout(X)
+            layout = self._resolve_shard_layout(X)
+            if isinstance(self.backend, FaissPlanConfig):
+                self.faiss_plan_, _ = _resolve_faiss_plan(
+                    self.backend,
+                    n_samples=layout.global_count,
+                    n_features=X.shape[1],
+                    distributed_ctx=self.dist_ctx if self.distributed else None,
+                    max_indexed_rows=max(layout.counts),
+                )
+                if self.verbose and self.rank == 0:
+                    self.logger.info(
+                        f"Resolved FAISS execution plan: {self.faiss_plan_}"
+                    )
             distances, indices = input_sharded_pairwise_distances_faiss(
                 X,
                 k=k,

--- a/torchdr/distance/faiss_plan.py
+++ b/torchdr/distance/faiss_plan.py
@@ -29,10 +29,10 @@ class FaissPlanConfig:
         ``"balanced"`` and ``"fast"`` raise :class:`NotImplementedError`.
     distribution : {"replicate", "shard"}, default="replicate"
         Multi-GPU topology. ``"replicate"`` builds the full index on every rank.
-        ``"shard"`` splits an exact ``Flat`` index across ranks. The input tensor
-        remains replicated under this index-sharding contract. Select
-        ``input_layout="sharded"`` on a supported estimator or affinity instead
-        when the input rows themselves are already partitioned across ranks.
+        ``"shard"`` splits an exact ``Flat`` index across ranks. With the default
+        input layout, the input tensor remains replicated. When the caller has
+        already partitioned the input rows, combine ``distribution="shard"`` with
+        ``input_layout="sharded"`` on a supported estimator or affinity.
 
         Topology selection is explicit because a portable pre-search memory
         estimate cannot account reliably for FAISS's device- and version-specific
@@ -81,8 +81,8 @@ class _FaissPlan:
     """Resolved, immutable diagnostics exposed as ``faiss_plan_``.
 
     ``index_memory_bytes`` estimates only FAISS's stored database vectors on
-    each rank. It deliberately excludes inputs, outputs, and temporary scratch
-    rather than presenting a partial estimate as total peak memory.
+    the busiest rank. It deliberately excludes inputs, outputs, and temporary
+    scratch rather than presenting a partial estimate as total peak memory.
     """
 
     mode: str
@@ -124,6 +124,7 @@ def _resolve_faiss_plan(
     n_samples: Optional[int] = None,
     n_features: Optional[int] = None,
     distributed_ctx=None,
+    max_indexed_rows: Optional[int] = None,
 ) -> Tuple[_FaissPlan, FaissConfig]:
     """Resolve user intent into diagnostics and a fresh low-level config."""
     if config.expert is not None:
@@ -156,10 +157,17 @@ def _resolve_faiss_plan(
         distribution = "replicate"
 
     index_memory_bytes = None
-    if training_size == 0 and n_samples is not None and n_features is not None:
-        indexed_rows = int(n_samples)
-        if distribution == "shard":
-            indexed_rows = (indexed_rows + world_size - 1) // world_size
+    if (
+        training_size == 0
+        and n_features is not None
+        and (n_samples is not None or max_indexed_rows is not None)
+    ):
+        if max_indexed_rows is not None:
+            indexed_rows = int(max_indexed_rows)
+        else:
+            indexed_rows = int(n_samples)
+            if distribution == "shard":
+                indexed_rows = (indexed_rows + world_size - 1) // world_size
         index_memory_bytes = indexed_rows * int(n_features) * 4
 
     return (

--- a/torchdr/neighbor_embedding/umap.py
+++ b/torchdr/neighbor_embedding/umap.py
@@ -140,7 +140,8 @@ class UMAP(NegativeSamplingNeighborEmbedding):
           concatenate, in rank order, into the global dataset, so no rank ever
           materializes the whole input. Requires an exact Flat FAISS backend and
           ``init`` in {"random", "normal", "hyperbolic", "pca"}; the embedding
-          stays replicated (one coordinate per global point on every rank).
+          stays replicated (one coordinate per global point on every rank). A
+          high-level FAISS plan must set ``distribution="shard"``.
         Default is "replicated".
 
     Notes

--- a/torchdr/tests/test_distributed_umap_input_shard.py
+++ b/torchdr/tests/test_distributed_umap_input_shard.py
@@ -30,6 +30,7 @@ import torch.distributed as dist
 
 from torchdr import UMAP
 from torchdr.affinity import UMAPAffinity
+from torchdr.distance import FaissPlanConfig
 from torchdr.distributed import init_distributed, shutdown_distributed
 from torchdr.spectral_embedding import PCA
 
@@ -126,12 +127,19 @@ def test_input_sharded_affinity_matches_single_process(uneven):
     assert sum(counts) == n_samples
     X_local = _local_shard(X_global, counts, rank).cuda()
 
+    backend = FaissPlanConfig(distribution="shard") if uneven else "faiss"
     sharded = UMAPAffinity(
-        n_neighbors=15, distributed=True, backend="faiss", input_layout="sharded"
+        n_neighbors=15,
+        distributed=True,
+        backend=backend,
+        input_layout="sharded",
     )
     local_values, local_indices = sharded(X_local)
     assert sharded.n_global_ == n_samples
     assert local_values.shape[0] == counts[rank]
+    if isinstance(backend, FaissPlanConfig):
+        assert sharded.faiss_plan_.distribution == "shard"
+        assert sharded.faiss_plan_.index_memory_bytes == max(counts) * n_features * 4
     local_dense = _rowwise_to_dense(local_values.cpu(), local_indices.cpu(), n_samples)
     full = _gather_rows(local_dense)
 

--- a/torchdr/tests/test_faiss_plan.py
+++ b/torchdr/tests/test_faiss_plan.py
@@ -141,6 +141,17 @@ def test_exact_plan_reports_resolved_execution():
     assert "index_memory_bytes=32000" in repr(restored)
 
 
+def test_sharded_plan_reports_busiest_observed_rank():
+    plan, _ = _resolve_faiss_plan(
+        FaissPlanConfig(distribution="shard"),
+        n_samples=120,
+        n_features=8,
+        distributed_ctx=_FakeContext(world_size=4),
+        max_indexed_rows=55,
+    )
+    assert plan.index_memory_bytes == 55 * 8 * 4
+
+
 def test_expert_resolution_is_non_mutating():
     expert = FaissConfig(
         index_type="IVFPQ", nlist=50, M=8, nbits=8, nprobe=4, custom_option=1

--- a/torchdr/tests/test_input_shard_estimator.py
+++ b/torchdr/tests/test_input_shard_estimator.py
@@ -115,18 +115,42 @@ def test_sharded_rejects_precomputed_affinity():
         model.fit_transform(P)
 
 
-def test_sharded_rejects_faiss_plan_config():
-    with pytest.raises(ValueError, match="FaissPlanConfig"):
+def test_sharded_rejects_replicated_faiss_plan():
+    with pytest.raises(ValueError, match="distribution='shard'"):
         UMAPAffinity(
             input_layout="sharded", backend=FaissPlanConfig(), distributed=False
         )
 
 
-def test_sharded_rejects_non_flat_faiss_config():
+def test_sharded_accepts_sharded_faiss_plan():
+    aff = UMAPAffinity(
+        n_neighbors=10,
+        input_layout="sharded",
+        backend=FaissPlanConfig(distribution="shard"),
+        device="cpu",
+        distributed=False,
+    )
+    values, indices = aff(torch.as_tensor(_blobs(40, 8)))
+    assert values.shape == indices.shape
+    assert aff.faiss_plan_.distribution == "single"
+    assert aff.faiss_plan_.index_type == "Flat"
+
+
+@pytest.mark.parametrize(
+    "backend",
+    [
+        FaissConfig(index_type="IVF", nlist=16),
+        FaissPlanConfig(
+            distribution="shard",
+            expert=FaissConfig(index_type="IVF", nlist=16),
+        ),
+    ],
+)
+def test_sharded_rejects_non_flat_faiss_config(backend):
     with pytest.raises(NotImplementedError, match="Flat"):
         UMAPAffinity(
             input_layout="sharded",
-            backend=FaissConfig(index_type="IVF", nlist=16),
+            backend=backend,
             distributed=False,
         )
 


### PR DESCRIPTION
## Summary

- compose row-sharded estimator inputs with an explicit `FaissPlanConfig(distribution="shard")` while continuing to reject contradictory replicated-index intent
- resolve and expose `faiss_plan_` for sharded inputs from the observed global layout, including an index-memory estimate based on the busiest rank for uneven shards
- preserve the exact-Flat-only boundary for input-sharded search and document the supported UMAP configuration

## Durable behavioral coverage

- verifies that replicated plans fail at the affinity boundary and that explicit sharded plans execute successfully
- verifies that approximate low-level and high-level plans remain rejected, preserving the exact-Flat contract
- exercises an uneven four-rank shard layout end to end, checks parity with single-process affinity results, and asserts that plan diagnostics use the largest observed shard
- unit-tests busiest-rank memory accounting independently of distributed execution

## Validation

- 38 focused CPU tests passed
- full four-B200 sharded UMAP suite passed
- 108 broader tests passed
- four-GPU uneven-shard diagnostic passed
- repository-wide pre-commit passed
- benchmark: plain FAISS 21.008 ms versus explicit sharded plan 21.105 ms; both used 94.6 MiB per rank

References #359 and #301; advances the FAISS roadmap in #308.
